### PR TITLE
fix(db): renumber sending-protection migrations to 112–118 (main is red)

### DIFF
--- a/internal/identity/migrate_test.go
+++ b/internal/identity/migrate_test.go
@@ -129,7 +129,7 @@ func TestMigrationsRewriteLegacySendingJobsWithImmutableAttribution(t *testing.T
 		t.Fatalf("schedule legacy job: %v", err)
 	}
 
-	migration, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	migration, err := migrations.FS.ReadFile("113_sending_budget_ledger.sql")
 	if err != nil {
 		t.Fatalf("read sending budget migration: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestSendingBudgetMigrationDoesNotDeadlockSourceFirstJobCancellation(t *test
 	if err != nil {
 		t.Fatalf("build real River cancellation client: %v", err)
 	}
-	migration, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	migration, err := migrations.FS.ReadFile("113_sending_budget_ledger.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,7 +452,7 @@ func TestSendingBudgetMigrationLeavesPostSnapshotLegacyJobForResolver(t *testing
 	if err := migrationConn.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&migrationPID); err != nil {
 		t.Fatalf("read migration backend pid: %v", err)
 	}
-	migration, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	migration, err := migrations.FS.ReadFile("113_sending_budget_ledger.sql")
 	if err != nil {
 		t.Fatalf("read sending budget migration: %v", err)
 	}

--- a/internal/sendingpolicy/schema_integration_test.go
+++ b/internal/sendingpolicy/schema_integration_test.go
@@ -22,13 +22,13 @@ func TestSendingProtectionMigrationsAreIdempotent(t *testing.T) {
 	ctx := context.Background()
 	pool := testutil.TestDB(t)
 	for _, name := range []string{
-		"109_sending_protection_policy.sql",
-		"110_sending_budget_ledger.sql",
-		"111_sending_feedback_provenance.sql",
-		"112_sending_controls_foreign_key.sql",
-		"113_sending_message_holds.sql",
-		"114_sending_suppression_provenance.sql",
-		"115_sending_protection_validate_constraints.sql",
+		"112_sending_protection_policy.sql",
+		"113_sending_budget_ledger.sql",
+		"114_sending_feedback_provenance.sql",
+		"115_sending_controls_foreign_key.sql",
+		"116_sending_message_holds.sql",
+		"117_sending_suppression_provenance.sql",
+		"118_sending_protection_validate_constraints.sql",
 	} {
 		migration, err := migrations.FS.ReadFile(name)
 		if err != nil {
@@ -62,7 +62,7 @@ func TestOperatorRecipientRegistryRejectsTruncate(t *testing.T) {
 }
 
 func TestSendingProtectionHotTableDDLIsEndLoadedBoundedAndNotValid(t *testing.T) {
-	budgetBytes, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	budgetBytes, err := migrations.FS.ReadFile("113_sending_budget_ledger.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestSendingProtectionHotTableDDLIsEndLoadedBoundedAndNotValid(t *testing.T)
 		}
 	}
 
-	controlsBytes, err := migrations.FS.ReadFile("112_sending_controls_foreign_key.sql")
+	controlsBytes, err := migrations.FS.ReadFile("115_sending_controls_foreign_key.sql")
 	if err != nil {
 		t.Fatalf("read controls FK migration: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestSendingProtectionHotTableDDLIsEndLoadedBoundedAndNotValid(t *testing.T)
 		}
 	}
 
-	feedbackBytes, err := migrations.FS.ReadFile("111_sending_feedback_provenance.sql")
+	feedbackBytes, err := migrations.FS.ReadFile("114_sending_feedback_provenance.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestSendingProtectionHotTableDDLIsEndLoadedBoundedAndNotValid(t *testing.T)
 		t.Fatal("account outcomes FK must be named, NOT VALID, and installed in migration 111's bounded tail")
 	}
 
-	messagesBytes, err := migrations.FS.ReadFile("113_sending_message_holds.sql")
+	messagesBytes, err := migrations.FS.ReadFile("116_sending_message_holds.sql")
 	if err != nil {
 		t.Fatalf("read messages hot-DDL migration: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestSendingProtectionHotTableDDLIsEndLoadedBoundedAndNotValid(t *testing.T)
 		t.Fatal("messages hot-DDL migration must contain no other strong-table work")
 	}
 
-	suppressionsBytes, err := migrations.FS.ReadFile("114_sending_suppression_provenance.sql")
+	suppressionsBytes, err := migrations.FS.ReadFile("117_sending_suppression_provenance.sql")
 	if err != nil {
 		t.Fatalf("read suppressions hot-DDL migration: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestSendingProtectionHotTableDDLIsEndLoadedBoundedAndNotValid(t *testing.T)
 		t.Fatal("suppressions hot-DDL migration must contain no other strong-table work")
 	}
 
-	validationBytes, err := migrations.FS.ReadFile("115_sending_protection_validate_constraints.sql")
+	validationBytes, err := migrations.FS.ReadFile("118_sending_protection_validate_constraints.sql")
 	if err != nil {
 		t.Fatalf("read validation migration: %v", err)
 	}
@@ -210,11 +210,11 @@ func testSendingBudgetMigrationDoesNotDeadlockAccountDeletionOrder(t *testing.T,
 	if err := jobs.Migrate(ctx, pool); err != nil {
 		t.Fatalf("migrate River schema: %v", err)
 	}
-	migration, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	migration, err := migrations.FS.ReadFile("113_sending_budget_ledger.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
-	controlsMigration, err := migrations.FS.ReadFile("112_sending_controls_foreign_key.sql")
+	controlsMigration, err := migrations.FS.ReadFile("115_sending_controls_foreign_key.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +427,7 @@ func TestSendingProtectionAccountFKFirstApplyLockWaitIsBounded(t *testing.T) {
 		hotRead    string
 	}{
 		{
-			"controls", "112_sending_controls_foreign_key.sql",
+			"controls", "115_sending_controls_foreign_key.sql",
 			`ALTER TABLE account_sending_controls DROP CONSTRAINT IF EXISTS account_sending_controls_user_id_fkey`,
 			`INSERT INTO users (id,email,name,google_subject)
 			 VALUES ('usr_first_apply_hot','owner@first-apply-hot.test','Owner','sub-first-apply-hot');
@@ -442,7 +442,7 @@ func TestSendingProtectionAccountFKFirstApplyLockWaitIsBounded(t *testing.T) {
 			`SELECT count(*) FROM messages WHERE id='msg_first_apply_hot'`,
 		},
 		{
-			"outcomes", "111_sending_feedback_provenance.sql",
+			"outcomes", "114_sending_feedback_provenance.sql",
 			`DROP TABLE account_sending_outcomes_daily`,
 			`INSERT INTO users (id,email,name,google_subject)
 			 VALUES ('usr_first_apply_hot','owner@first-apply-hot.test','Owner','sub-first-apply-hot');
@@ -459,7 +459,7 @@ func TestSendingProtectionAccountFKFirstApplyLockWaitIsBounded(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			validation, err := migrations.FS.ReadFile("115_sending_protection_validate_constraints.sql")
+			validation, err := migrations.FS.ReadFile("118_sending_protection_validate_constraints.sql")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -585,11 +585,11 @@ func TestSendingProtectionAccountFKFirstApplyLockWaitIsBounded(t *testing.T) {
 func TestSendingControlsFKTailRemovesOnlyOrphans(t *testing.T) {
 	ctx := context.Background()
 	pool := testutil.TestDB(t)
-	migration, err := migrations.FS.ReadFile("112_sending_controls_foreign_key.sql")
+	migration, err := migrations.FS.ReadFile("115_sending_controls_foreign_key.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
-	validation, err := migrations.FS.ReadFile("115_sending_protection_validate_constraints.sql")
+	validation, err := migrations.FS.ReadFile("118_sending_protection_validate_constraints.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -649,8 +649,8 @@ func TestSendingProtectionHotTableAlterLockWaitIsBounded(t *testing.T) {
 		table     string
 		migration string
 	}{
-		{"messages", "messages", "113_sending_message_holds.sql"},
-		{"suppressions", "suppressions", "114_sending_suppression_provenance.sql"},
+		{"messages", "messages", "116_sending_message_holds.sql"},
+		{"suppressions", "suppressions", "117_sending_suppression_provenance.sql"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pool := testutil.TestDB(t)
@@ -690,7 +690,7 @@ func TestSendingProtectionHotTableAlterLockWaitIsBounded(t *testing.T) {
 }
 
 func TestSendingProtectionConstraintValidationAllowsNormalDML(t *testing.T) {
-	validation, err := migrations.FS.ReadFile("115_sending_protection_validate_constraints.sql")
+	validation, err := migrations.FS.ReadFile("118_sending_protection_validate_constraints.sql")
 	if err != nil {
 		t.Fatalf("read validation migration: %v", err)
 	}

--- a/migrations/112_sending_protection_policy.sql
+++ b/migrations/112_sending_protection_policy.sql
@@ -1,4 +1,4 @@
--- 109_sending_protection_policy.sql
+-- 112_sending_protection_policy.sql
 -- Expand-only sending-protection policy authority. Runtime behavior remains disabled.
 
 CREATE TABLE IF NOT EXISTS sending_protection_runtime_policy (

--- a/migrations/113_sending_budget_ledger.sql
+++ b/migrations/113_sending_budget_ledger.sql
@@ -1,4 +1,4 @@
--- 110_sending_budget_ledger.sql
+-- 113_sending_budget_ledger.sql
 -- Expand-only account controls, provider-operation/budget ledger, and notice outbox.
 
 -- Freeze the exact pre-migration legacy River inventory before any per-kind

--- a/migrations/114_sending_feedback_provenance.sql
+++ b/migrations/114_sending_feedback_provenance.sql
@@ -1,4 +1,4 @@
--- 111_sending_feedback_provenance.sql
+-- 114_sending_feedback_provenance.sql
 -- Deletion-resistant provider-feedback attribution and detector aggregates.
 
 CREATE TABLE IF NOT EXISTS sending_feedback_correlations (

--- a/migrations/115_sending_controls_foreign_key.sql
+++ b/migrations/115_sending_controls_foreign_key.sql
@@ -1,4 +1,4 @@
--- 112_sending_controls_foreign_key.sql
+-- 115_sending_controls_foreign_key.sql
 --
 -- Install the controls ownership FK in a source-free transaction. Migration
 -- 110 may retain legacy agent/message/webhook rows while it rewrites River

--- a/migrations/116_sending_message_holds.sql
+++ b/migrations/116_sending_message_holds.sql
@@ -1,4 +1,4 @@
--- 113_sending_message_holds.sql
+-- 116_sending_message_holds.sql
 --
 -- Keep this bounded transaction limited to the unavoidable messages metadata
 -- lock. It follows the account FK transactions so it cannot invert the

--- a/migrations/117_sending_suppression_provenance.sql
+++ b/migrations/117_sending_suppression_provenance.sql
@@ -1,4 +1,4 @@
--- 114_sending_suppression_provenance.sql
+-- 117_sending_suppression_provenance.sql
 --
 -- Keep this bounded transaction limited to the unavoidable suppressions
 -- metadata lock. Safe defaults preserve the pre-sync local DELETE path; this

--- a/migrations/118_sending_protection_validate_constraints.sql
+++ b/migrations/118_sending_protection_validate_constraints.sql
@@ -1,4 +1,4 @@
--- 115_sending_protection_validate_constraints.sql
+-- 118_sending_protection_validate_constraints.sql
 --
 -- Validate the hot-table CHECKs and account FKs only after the migrations that
 -- install them have committed. VALIDATE CONSTRAINT uses the weaker SHARE UPDATE


### PR DESCRIPTION
**Main's CI is red** since #950 merged: `TestEmbeddedMigrationNumbersAreUniqueFrom108` fails because #950 (branched before today's merges) shipped migrations **109–115**, and 109/110/111 collide with `109_usage_events_units` / `110_account_limits_max_messages_day` (#949, in released **v1.8.1**, applied on staging under those filenames) and `111_wsd_failed_probe_index` (#955).

**Why the sending-protection set renumbers (not the pricing set):** the tracker records filenames; the pricing/index files are in a published tag and already applied on staging — renaming them would orphan applied-tracker rows. #950's files are in no tag and applied on no tracked environment, so they can renumber freely.

All seven shift +3 preserving internal order: `112_sending_protection_policy`, `113_sending_budget_ledger`, `114_sending_feedback_provenance`, `115_sending_controls_foreign_key`, `116_sending_message_holds`, `117_sending_suppression_provenance`, `118_sending_protection_validate_constraints` — with every filename reference updated (SQL headers, `internal/identity/migrate_test.go`, `internal/sendingpolicy/schema_integration_test.go`).

Verified: uniqueness test green; full `internal/sendingpolicy` suite green (idempotency, deadlock-order, FK tests); `internal/identity` green apart from the known pre-existing timezone flake. Anyone tracking `:main` in the last hour would re-apply the renamed files — they're idempotent per repo convention, so that's a no-op.

**Blocks the v1.8.2 cut** — main must be green and migration order unambiguous before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32