### PR TITLE
fix(auth): cascade configured OIDC logout

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -644,6 +644,9 @@ func main() {
 	}
 	if oidcAuth != nil {
 		log.Printf("[auth] OIDC login enabled (issuer=%s); discovering issuer in the background", cfg.OIDC.IssuerURL)
+		if cfg.OIDC.LogoutURL != "" {
+			userAuth.SetOIDCLogoutURL(cfg.OIDC.LogoutURL)
+		}
 	}
 
 	// HTTP API

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -627,6 +627,10 @@ func main() {
 
 	// User auth (Google OAuth for agent developers)
 	userAuth := auth.NewUserAuth(&cfg.OAuth, store, cfg.IsProduction())
+	// Logout provenance belongs to the canonical web app, not the optional
+	// legacy Google callback. OIDC-only deployments use the OIDC callback as a
+	// safe fallback when public_url is intentionally empty.
+	userAuth.SetLogoutOrigin(cfg.HTTP.PublicURL)
 	// Generic OIDC Authorization Code login. Disabled configurations perform
 	// no discovery and leave both OIDC routes unregistered. Enabled
 	// configurations construct synchronously (no network call) and discover
@@ -644,6 +648,9 @@ func main() {
 	}
 	if oidcAuth != nil {
 		log.Printf("[auth] OIDC login enabled (issuer=%s); discovering issuer in the background", cfg.OIDC.IssuerURL)
+		if cfg.HTTP.PublicURL == "" {
+			userAuth.SetLogoutOrigin(cfg.OIDC.RedirectURL)
+		}
 		if cfg.OIDC.LogoutURL != "" {
 			userAuth.SetOIDCLogoutURL(cfg.OIDC.LogoutURL)
 		}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,6 +86,10 @@ oidc:
   client_secret: ""       # keep secret; used only at token endpoint. Override: E2A_OIDC_CLIENT_SECRET
   redirect_url: ""        # e.g. "https://e2a.example.com/api/auth/oidc/callback". Override: E2A_OIDC_REDIRECT_URL
   user_id_claim: ""       # TokenCanopy uses "e2a_user_id". Override: E2A_OIDC_USER_ID_CLAIM
+  # Optional fixed upstream logout handoff. It must be an absolute http(s)
+  # URL with no query or fragment; do not derive it from browser input.
+  # Override: E2A_OIDC_LOGOUT_URL
+  logout_url: ""
   # Enable with: E2A_OIDC_ENABLED=true
 
 # — Delegated access tokens ——————————————————————————————————————————————————

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -49,6 +49,9 @@ type UserAuth struct {
 	secure      bool   // true in production (Secure cookie flag)
 	baseURL     string // frontend origin for post-login redirect
 	userInfoURL string // Google userinfo endpoint (overridable for testing)
+	// oidcLogoutURL is an operator-configured, fixed upstream logout endpoint.
+	// It is deliberately not derived from request input.
+	oidcLogoutURL string
 }
 
 type cliLoginHandoff struct {
@@ -153,6 +156,13 @@ func NewUserAuthWithOAuthConfig(cfg *config.OAuthConfig, oauthCfg *oauth2.Config
 		baseURL:     baseURL,
 		userInfoURL: userInfoURL,
 	}
+}
+
+// SetOIDCLogoutURL configures the fixed upstream logout endpoint used after
+// the local e2a session is revoked. The value must come from validated server
+// configuration; callers must never pass request-controlled URLs here.
+func (ua *UserAuth) SetOIDCLogoutURL(logoutURL string) {
+	ua.oidcLogoutURL = logoutURL
 }
 
 func generateNonce() string {
@@ -444,7 +454,10 @@ func (ua *UserAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, ua.baseURL+"/dashboard", http.StatusFound)
 }
 
-// HandleLogout deletes the session and clears the cookie.
+// HandleLogout deletes the session and clears the cookie. Browser callers then
+// follow a 303 to either the configured upstream OIDC logout endpoint or the
+// local application root. A native navigation is required for the upstream
+// endpoint so its cross-origin session cookies can be cleared.
 func (ua *UserAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(SessionCookieName)
 	if err == nil {
@@ -460,6 +473,15 @@ func (ua *UserAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   -1,
 	})
+
+	if ua.oidcLogoutURL != "" {
+		http.Redirect(w, r, ua.oidcLogoutURL, http.StatusSeeOther)
+		return
+	}
+	if ua.baseURL != "" {
+		http.Redirect(w, r, ua.baseURL+"/", http.StatusSeeOther)
+		return
+	}
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -460,8 +460,18 @@ func (ua *UserAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 // endpoint so its cross-origin session cookies can be cleared.
 func (ua *UserAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(SessionCookieName)
+	hasValidSession := false
 	if err == nil {
-		ua.store.DeleteUserSession(r.Context(), cookie.Value)
+		_, sessionErr := ua.store.GetUserSession(r.Context(), cookie.Value)
+		if sessionErr != nil && !errors.Is(sessionErr, pgx.ErrNoRows) {
+			http.Error(w, "logout temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		hasValidSession = sessionErr == nil
+		if err := ua.store.DeleteUserSession(r.Context(), cookie.Value); err != nil {
+			http.Error(w, "logout temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
 	}
 
 	http.SetCookie(w, &http.Cookie{
@@ -474,7 +484,11 @@ func (ua *UserAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   -1,
 	})
 
-	if ua.oidcLogoutURL != "" {
+	if ua.oidcLogoutURL != "" && hasValidSession {
+		if !ua.isSameOriginLogoutRequest(r) {
+			http.Error(w, "logout request origin is not allowed", http.StatusForbidden)
+			return
+		}
 		http.Redirect(w, r, ua.oidcLogoutURL, http.StatusSeeOther)
 		return
 	}
@@ -482,8 +496,31 @@ func (ua *UserAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, ua.baseURL+"/", http.StatusSeeOther)
 		return
 	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
 
-	w.WriteHeader(http.StatusOK)
+// isSameOriginLogoutRequest validates the browser provenance needed before a
+// configured upstream logout handoff. Origin is preferred; Referer is a
+// compatibility fallback for browsers that omit Origin on native form posts.
+// An absent or unparsable provenance header fails closed for the upstream
+// handoff, while local session revocation has already completed.
+func (ua *UserAuth) isSameOriginLogoutRequest(r *http.Request) bool {
+	expected := ua.baseURL
+	if expected == "" {
+		return false
+	}
+	if origin := r.Header.Get("Origin"); origin != "" {
+		return origin == expected
+	}
+	referer := r.Header.Get("Referer")
+	if referer == "" {
+		return false
+	}
+	u, err := url.Parse(referer)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil {
+		return false
+	}
+	return u.Scheme+"://"+u.Host == expected
 }
 
 // HandleMe returns the current authenticated user's info.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -49,6 +49,10 @@ type UserAuth struct {
 	secure      bool   // true in production (Secure cookie flag)
 	baseURL     string // frontend origin for post-login redirect
 	userInfoURL string // Google userinfo endpoint (overridable for testing)
+	// logoutOrigin is the canonical web-app origin used for logout provenance.
+	// It is separate from baseURL because generic OIDC deployments may not
+	// configure the legacy Google OAuth callback.
+	logoutOrigin string
 	// oidcLogoutURL is an operator-configured, fixed upstream logout endpoint.
 	// It is deliberately not derived from request input.
 	oidcLogoutURL string
@@ -163,6 +167,36 @@ func NewUserAuthWithOAuthConfig(cfg *config.OAuthConfig, oauthCfg *oauth2.Config
 // configuration; callers must never pass request-controlled URLs here.
 func (ua *UserAuth) SetOIDCLogoutURL(logoutURL string) {
 	ua.oidcLogoutURL = logoutURL
+}
+
+// SetLogoutOrigin configures the canonical web-app origin used to validate
+// browser logout requests. The value must come from trusted server
+// configuration, never from a request parameter.
+func (ua *UserAuth) SetLogoutOrigin(origin string) {
+	ua.logoutOrigin = normalizeHTTPOrigin(origin)
+}
+
+func normalizeHTTPOrigin(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" || u.User != nil ||
+		(u.Scheme != "http" && u.Scheme != "https") || u.RawQuery != "" || u.Fragment != "" {
+		return ""
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return ""
+	}
+	port := u.Port()
+	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+		port = ""
+	}
+	if strings.Contains(host, ":") { // IPv6 literal
+		host = "[" + host + "]"
+	}
+	if port != "" {
+		host += ":" + port
+	}
+	return strings.ToLower(u.Scheme) + "://" + host
 }
 
 func generateNonce() string {
@@ -492,8 +526,12 @@ func (ua *UserAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, ua.oidcLogoutURL, http.StatusSeeOther)
 		return
 	}
-	if ua.baseURL != "" {
-		http.Redirect(w, r, ua.baseURL+"/", http.StatusSeeOther)
+	logoutOrigin := ua.logoutOrigin
+	if logoutOrigin == "" {
+		logoutOrigin = normalizeHTTPOrigin(ua.baseURL)
+	}
+	if logoutOrigin != "" {
+		http.Redirect(w, r, logoutOrigin+"/", http.StatusSeeOther)
 		return
 	}
 	http.Redirect(w, r, "/", http.StatusSeeOther)
@@ -505,12 +543,15 @@ func (ua *UserAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 // An absent or unparsable provenance header fails closed for the upstream
 // handoff, while local session revocation has already completed.
 func (ua *UserAuth) isSameOriginLogoutRequest(r *http.Request) bool {
-	expected := ua.baseURL
+	expected := ua.logoutOrigin
+	if expected == "" {
+		expected = normalizeHTTPOrigin(ua.baseURL)
+	}
 	if expected == "" {
 		return false
 	}
 	if origin := r.Header.Get("Origin"); origin != "" {
-		return origin == expected
+		return normalizeHTTPOrigin(origin) == expected
 	}
 	referer := r.Header.Get("Referer")
 	if referer == "" {
@@ -520,7 +561,7 @@ func (ua *UserAuth) isSameOriginLogoutRequest(r *http.Request) bool {
 	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil {
 		return false
 	}
-	return u.Scheme+"://"+u.Host == expected
+	return normalizeHTTPOrigin(u.Scheme+"://"+u.Host) == expected
 }
 
 // HandleMe returns the current authenticated user's info.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -179,7 +179,7 @@ func (ua *UserAuth) SetLogoutOrigin(origin string) {
 func normalizeHTTPOrigin(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil || u.Host == "" || u.User != nil ||
-		(u.Scheme != "http" && u.Scheme != "https") || u.RawQuery != "" || u.Fragment != "" {
+		(u.Scheme != "http" && u.Scheme != "https") {
 		return ""
 	}
 	host := strings.ToLower(u.Hostname())

--- a/internal/auth/handlers_extra_test.go
+++ b/internal/auth/handlers_extra_test.go
@@ -27,8 +27,11 @@ func TestHandleLogout_DeletesSessionAndClearsCookie(t *testing.T) {
 	w := httptest.NewRecorder()
 	ua.HandleLogout(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", w.Code)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "http://localhost/" {
+		t.Fatalf("Location = %q, want http://localhost/", location)
 	}
 
 	// The response must expire the session cookie.
@@ -61,8 +64,31 @@ func TestHandleLogout_WithoutCookieStillSucceeds(t *testing.T) {
 	w := httptest.NewRecorder()
 	ua.HandleLogout(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 (logout is idempotent)", w.Code)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (logout is idempotent)", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "http://localhost/" {
+		t.Fatalf("Location = %q, want http://localhost/", location)
+	}
+}
+
+func TestHandleLogout_RedirectsToConfiguredOIDCLogoutURL(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	const logoutURL = "https://auth.example.com/auth/logout/upstream"
+	ua.SetOIDCLogoutURL(logoutURL)
+
+	req := authedRequest("POST", "/api/auth/logout", token)
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != logoutURL {
+		t.Fatalf("Location = %q, want %q", location, logoutURL)
+	}
+	if _, err := store.GetUserSession(context.Background(), token); err == nil {
+		t.Fatal("session still resolves after upstream logout redirect")
 	}
 }
 

--- a/internal/auth/handlers_extra_test.go
+++ b/internal/auth/handlers_extra_test.go
@@ -105,7 +105,7 @@ func TestHandleLogout_UsesCanonicalOIDCOriginWithoutGoogleOAuth(t *testing.T) {
 		t.Fatalf("CreateUserSession: %v", err)
 	}
 	ua := auth.NewUserAuth(&config.OAuthConfig{}, store, false)
-	ua.SetLogoutOrigin("https://APP.example.com:443")
+	ua.SetLogoutOrigin("https://APP.example.com/api/auth/oidc/callback?tenant=one")
 	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
 
 	req := authedRequest("POST", "/api/auth/logout", token)
@@ -142,6 +142,7 @@ func TestHandleLogout_ConfiguredRejectsCrossOriginHandoff(t *testing.T) {
 
 	req := authedRequest("POST", "/api/auth/logout", token)
 	req.Header.Set("Origin", "https://attacker.test")
+	req.Header.Set("Referer", "http://localhost/dashboard")
 	w := httptest.NewRecorder()
 	ua.HandleLogout(w, req)
 
@@ -153,6 +154,23 @@ func TestHandleLogout_ConfiguredRejectsCrossOriginHandoff(t *testing.T) {
 	}
 	if _, err := store.GetUserSession(context.Background(), token); err == nil {
 		t.Fatal("session still resolves after cross-origin logout")
+	}
+}
+
+func TestHandleLogout_ConfiguredAcceptsSameOriginReferer(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
+
+	req := authedRequest("POST", "/api/auth/logout", token)
+	req.Header.Set("Referer", "http://localhost/dashboard")
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "https://auth.example.com/auth/logout/upstream" {
+		t.Fatalf("Location = %q, want upstream logout URL", location)
 	}
 }
 

--- a/internal/auth/handlers_extra_test.go
+++ b/internal/auth/handlers_extra_test.go
@@ -93,6 +93,34 @@ func TestHandleLogout_RedirectsToConfiguredOIDCLogoutURL(t *testing.T) {
 	}
 }
 
+func TestHandleLogout_UsesCanonicalOIDCOriginWithoutGoogleOAuth(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	user, err := store.CreateOrGetUser(context.Background(), "oidc@example.test", "OIDC User", "oidc-subject")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	token, err := store.CreateUserSession(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("CreateUserSession: %v", err)
+	}
+	ua := auth.NewUserAuth(&config.OAuthConfig{}, store, false)
+	ua.SetLogoutOrigin("https://APP.example.com:443")
+	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
+
+	req := authedRequest("POST", "/api/auth/logout", token)
+	req.Header.Set("Origin", "https://app.example.com")
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "https://auth.example.com/auth/logout/upstream" {
+		t.Fatalf("Location = %q, want upstream logout URL", location)
+	}
+}
+
 func TestHandleLogout_ConfiguredWithoutCookieDoesNotCascade(t *testing.T) {
 	ua, _, _ := setupUserAuth(t)
 	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")

--- a/internal/auth/handlers_extra_test.go
+++ b/internal/auth/handlers_extra_test.go
@@ -105,7 +105,7 @@ func TestHandleLogout_UsesCanonicalOIDCOriginWithoutGoogleOAuth(t *testing.T) {
 		t.Fatalf("CreateUserSession: %v", err)
 	}
 	ua := auth.NewUserAuth(&config.OAuthConfig{}, store, false)
-	ua.SetLogoutOrigin("https://APP.example.com/api/auth/oidc/callback?tenant=one")
+	ua.SetLogoutOrigin("https://APP.example.com:443/api/auth/oidc/callback?tenant=one")
 	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
 
 	req := authedRequest("POST", "/api/auth/logout", token)
@@ -154,6 +154,56 @@ func TestHandleLogout_ConfiguredRejectsCrossOriginHandoff(t *testing.T) {
 	}
 	if _, err := store.GetUserSession(context.Background(), token); err == nil {
 		t.Fatal("session still resolves after cross-origin logout")
+	}
+}
+
+func TestHandleLogout_ConfiguredRejectsMissingProvenance(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
+
+	req := authedRequest("POST", "/api/auth/logout", token)
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "" {
+		t.Fatalf("Location = %q, want no upstream redirect", location)
+	}
+}
+
+func TestHandleLogout_ConfiguredRejectsMalformedReferer(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
+
+	req := authedRequest("POST", "/api/auth/logout", token)
+	req.Header.Set("Referer", "not a URL")
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "" {
+		t.Fatalf("Location = %q, want no upstream redirect", location)
+	}
+}
+
+func TestHandleLogout_ConfiguredStaleSessionDoesNotCascade(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
+
+	req := authedRequest("POST", "/api/auth/logout", "sess_stale")
+	req.Header.Set("Origin", "http://localhost")
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "http://localhost/" {
+		t.Fatalf("Location = %q, want local root", location)
 	}
 }
 

--- a/internal/auth/handlers_extra_test.go
+++ b/internal/auth/handlers_extra_test.go
@@ -78,6 +78,7 @@ func TestHandleLogout_RedirectsToConfiguredOIDCLogoutURL(t *testing.T) {
 	ua.SetOIDCLogoutURL(logoutURL)
 
 	req := authedRequest("POST", "/api/auth/logout", token)
+	req.Header.Set("Origin", "http://localhost")
 	w := httptest.NewRecorder()
 	ua.HandleLogout(w, req)
 
@@ -89,6 +90,74 @@ func TestHandleLogout_RedirectsToConfiguredOIDCLogoutURL(t *testing.T) {
 	}
 	if _, err := store.GetUserSession(context.Background(), token); err == nil {
 		t.Fatal("session still resolves after upstream logout redirect")
+	}
+}
+
+func TestHandleLogout_ConfiguredWithoutCookieDoesNotCascade(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
+
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, httptest.NewRequest("POST", "/api/auth/logout", nil))
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "http://localhost/" {
+		t.Fatalf("Location = %q, want local root", location)
+	}
+}
+
+func TestHandleLogout_ConfiguredRejectsCrossOriginHandoff(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
+
+	req := authedRequest("POST", "/api/auth/logout", token)
+	req.Header.Set("Origin", "https://attacker.test")
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "" {
+		t.Fatalf("Location = %q, want no upstream redirect", location)
+	}
+	if _, err := store.GetUserSession(context.Background(), token); err == nil {
+		t.Fatal("session still resolves after cross-origin logout")
+	}
+}
+
+func TestHandleLogout_ReturnsUnavailableWhenSessionLookupFails(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ua.SetOIDCLogoutURL("https://auth.example.com/auth/logout/upstream")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := authedRequest("POST", "/api/auth/logout", token).WithContext(ctx)
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+	if _, err := store.GetUserSession(context.Background(), token); err != nil {
+		t.Fatalf("session should remain when revocation cannot be confirmed: %v", err)
+	}
+}
+
+func TestHandleLogout_UsesRelativeRootWithoutOAuthBaseURL(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ua := auth.NewUserAuth(&config.OAuthConfig{}, identity.NewStore(pool), false)
+
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, httptest.NewRequest("POST", "/api/auth/logout", nil))
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", w.Code)
+	}
+	if location := w.Header().Get("Location"); location != "/" {
+		t.Fatalf("Location = %q, want /", location)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -227,6 +227,10 @@ type OIDCConfig struct {
 	RedirectURL string `yaml:"redirect_url"`
 	// UserIDClaim names the ID-token claim containing an existing users.id.
 	UserIDClaim string `yaml:"user_id_claim"`
+	// LogoutURL is an optional fixed URL to visit after local logout. Hosted
+	// deployments can use this to cascade logout through their OIDC control
+	// plane; it is never taken from a request parameter.
+	LogoutURL string `yaml:"logout_url"`
 }
 
 type SigningConfig struct {
@@ -759,6 +763,9 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("E2A_OIDC_USER_ID_CLAIM"); v != "" {
 		cfg.OIDC.UserIDClaim = v
 	}
+	if v := os.Getenv("E2A_OIDC_LOGOUT_URL"); v != "" {
+		cfg.OIDC.LogoutURL = v
+	}
 	if v := os.Getenv("E2A_DELEGATED_ENABLED"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
 			cfg.Delegated.Enabled = b
@@ -977,6 +984,12 @@ func (c *Config) Validate() error {
 		redirectURL, err := absoluteHTTPURL(c.OIDC.RedirectURL)
 		if err != nil || redirectURL.Fragment != "" {
 			return fmt.Errorf("config: oidc.redirect_url must be an absolute http(s) URL without a fragment")
+		}
+	}
+	if c.OIDC.LogoutURL != "" {
+		logoutURL, err := absoluteHTTPURL(c.OIDC.LogoutURL)
+		if err != nil || logoutURL.RawQuery != "" || logoutURL.Fragment != "" {
+			return fmt.Errorf("config: oidc.logout_url must be an absolute http(s) URL without query or fragment")
 		}
 	}
 	if c.Delegated.Enabled {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -991,6 +991,9 @@ func (c *Config) Validate() error {
 		if err != nil || logoutURL.RawQuery != "" || logoutURL.Fragment != "" {
 			return fmt.Errorf("config: oidc.logout_url must be an absolute http(s) URL without query or fragment")
 		}
+		if c.IsProduction() && logoutURL.Scheme != "https" {
+			return fmt.Errorf("config: oidc.logout_url must use https in production")
+		}
 	}
 	if c.Delegated.Enabled {
 		if err := c.validateDelegated(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -477,6 +477,32 @@ oidc:
 	}
 }
 
+func TestValidateOIDCLogoutURLRequiresHTTPSInProduction(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(cfgPath, []byte(`
+env: "production"
+signing:
+  hmac_secret: "0123456789abcdef0123456789abcdef"
+oidc:
+  enabled: true
+  issuer_url: "https://issuer.example.com"
+  client_id: "e2a"
+  client_secret: "secret"
+  redirect_url: "https://e2a.example.com/api/auth/oidc/callback"
+  user_id_claim: "e2a_user_id"
+  logout_url: "http://issuer.example.com/auth/logout"
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Load(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), "logout_url must use https") {
+		t.Fatalf("Load error = %v, want production HTTPS logout URL validation", err)
+	}
+}
+
 func TestIsProduction(t *testing.T) {
 	prod := &Config{Env: "production"}
 	dev := &Config{Env: "development"}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -344,6 +344,7 @@ func TestLoadConfigOIDCEnvOverrides(t *testing.T) {
 	t.Setenv("E2A_OIDC_CLIENT_SECRET", "secret")
 	t.Setenv("E2A_OIDC_REDIRECT_URL", "https://e2a.example.com/api/auth/oidc/callback")
 	t.Setenv("E2A_OIDC_USER_ID_CLAIM", "e2a_user_id")
+	t.Setenv("E2A_OIDC_LOGOUT_URL", "https://issuer.example.com/auth/logout")
 
 	cfg, err := Load(cfgPath)
 	if err != nil {
@@ -366,6 +367,9 @@ func TestLoadConfigOIDCEnvOverrides(t *testing.T) {
 	}
 	if cfg.OIDC.UserIDClaim != "e2a_user_id" {
 		t.Errorf("OIDC.UserIDClaim = %q", cfg.OIDC.UserIDClaim)
+	}
+	if cfg.OIDC.LogoutURL != "https://issuer.example.com/auth/logout" {
+		t.Errorf("OIDC.LogoutURL = %q", cfg.OIDC.LogoutURL)
 	}
 }
 
@@ -401,6 +405,7 @@ oidc:
   client_secret: "secret"
   redirect_url: "https://e2a.example.com/api/auth/oidc/callback"
   user_id_claim: "e2a_user_id"
+  logout_url: "https://issuer.example.com/auth/logout"
 `), 0644)
 
 	cfg, err := Load(cfgPath)
@@ -410,6 +415,9 @@ oidc:
 	if !cfg.OIDC.Enabled {
 		t.Error("expected OIDC.Enabled = true")
 	}
+	if cfg.OIDC.LogoutURL != "https://issuer.example.com/auth/logout" {
+		t.Errorf("OIDC.LogoutURL = %q", cfg.OIDC.LogoutURL)
+	}
 }
 
 func TestValidateOIDCEnabledRequiresAbsoluteHTTPURLs(t *testing.T) {
@@ -417,12 +425,17 @@ func TestValidateOIDCEnabledRequiresAbsoluteHTTPURLs(t *testing.T) {
 		name        string
 		issuerURL   string
 		redirectURL string
+		logoutURL   string
 		want        string
 	}{
 		{name: "relative issuer", issuerURL: "/issuer", redirectURL: "https://e2a.example.com/api/auth/oidc/callback", want: "issuer_url"},
 		{name: "issuer query", issuerURL: "https://issuer.example.com?tenant=one", redirectURL: "https://e2a.example.com/api/auth/oidc/callback", want: "issuer_url"},
 		{name: "relative redirect", issuerURL: "https://issuer.example.com", redirectURL: "/api/auth/oidc/callback", want: "redirect_url"},
 		{name: "non-http redirect", issuerURL: "https://issuer.example.com", redirectURL: "javascript:alert(1)", want: "redirect_url"},
+		{name: "relative logout", issuerURL: "https://issuer.example.com", redirectURL: "https://e2a.example.com/api/auth/oidc/callback", logoutURL: "/auth/logout", want: "logout_url"},
+		{name: "logout query", issuerURL: "https://issuer.example.com", redirectURL: "https://e2a.example.com/api/auth/oidc/callback", logoutURL: "https://issuer.example.com/auth/logout?return_to=/", want: "logout_url"},
+		{name: "logout fragment", issuerURL: "https://issuer.example.com", redirectURL: "https://e2a.example.com/api/auth/oidc/callback", logoutURL: "https://issuer.example.com/auth/logout#done", want: "logout_url"},
+		{name: "non-http logout", issuerURL: "https://issuer.example.com", redirectURL: "https://e2a.example.com/api/auth/oidc/callback", logoutURL: "javascript:alert(1)", want: "logout_url"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -437,7 +450,8 @@ oidc:
   client_secret: "secret"
   redirect_url: %q
   user_id_claim: "e2a_user_id"
-`, test.issuerURL, test.redirectURL)
+  logout_url: %q
+`, test.issuerURL, test.redirectURL, test.logoutURL)
 			if err := os.WriteFile(cfgPath, []byte(body), 0644); err != nil {
 				t.Fatal(err)
 			}

--- a/web/src/app/components/AuthProvider.test.tsx
+++ b/web/src/app/components/AuthProvider.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AuthProvider, useAuth } from "./AuthProvider";
+
+function SignOutButton() {
+  const { signOut } = useAuth();
+  return <button onClick={() => void signOut()}>Sign out</button>;
+}
+
+describe("AuthProvider sign out", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(async () => ({ ok: false })) as unknown as typeof fetch;
+    jest.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("submits a native POST so cross-origin logout redirects can clear upstream cookies", async () => {
+    render(
+      <AuthProvider>
+        <SignOutButton />
+      </AuthProvider>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    const form = document.querySelector('form[action="/api/auth/logout"]');
+    expect(form).toHaveAttribute("method", "POST");
+    expect(HTMLFormElement.prototype.submit).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith("/api/auth/me", {
+      credentials: "include",
+    });
+  });
+});

--- a/web/src/app/components/AuthProvider.tsx
+++ b/web/src/app/components/AuthProvider.tsx
@@ -37,12 +37,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const signOut = useCallback(async () => {
-    await fetch("/api/auth/logout", {
-      method: "POST",
-      credentials: "include",
-    });
     setUser(null);
-    window.location.href = "/";
+
+    // Use a top-level native navigation instead of fetch(). The server may
+    // redirect to an OIDC provider on another origin, and fetch follows that
+    // redirect without navigating the browser or reliably applying the
+    // provider's Set-Cookie headers.
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = "/api/auth/logout";
+    form.hidden = true;
+    document.body.appendChild(form);
+    form.submit();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary\n- add a validated, operator-configured OIDC logout handoff URL\n- revoke the local e2a session and expire its cookie before the 303 handoff\n- use a native POST navigation in the web client so cross-origin upstream cookies are cleared\n- preserve local-only logout when no handoff is configured\n\n## Validation\n- go test -short ./...\n- npm test -- --runInBand (107 suites, 907 tests)\n- npm run lint\n- npm run build\n\nThe staging ops configuration is prepared separately in the dependent ops PR. No production configuration is enabled here.