### PR TITLE
fix(auth): request Google's account chooser on legacy login

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -345,7 +345,13 @@ func (ua *UserAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 	ua.setCookie(w, StateCookieName, nonce, 600)
 
-	http.Redirect(w, r, ua.oauthConfig.AuthCodeURL(EncodeOAuthState(state)), http.StatusFound)
+	// prompt=select_account forces Google to show the account chooser instead
+	// of silently re-authenticating a single signed-in account, ensuring users
+	// can switch accounts after signing out.
+	http.Redirect(w, r, ua.oauthConfig.AuthCodeURL(
+		EncodeOAuthState(state),
+		oauth2.SetAuthURLParam("prompt", "select_account"),
+	), http.StatusFound)
 }
 
 // validateReturnToPath enforces the same-origin / known-route allow-list

--- a/internal/auth/cli_login_test.go
+++ b/internal/auth/cli_login_test.go
@@ -108,6 +108,40 @@ func TestHandleLogin_WebLoginOmitsCliParams(t *testing.T) {
 	}
 }
 
+func TestHandleLogin_RequestsGoogleAccountChooser(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/login", nil)
+	w := httptest.NewRecorder()
+	ua.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	location := w.Result().Header.Get("Location")
+	u, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse redirect URL: %v", err)
+	}
+
+	query := u.Query()
+	for key, want := range map[string]string{
+		"prompt":        "select_account",
+		"client_id":     "test",
+		"redirect_uri":  "http://localhost/api/auth/callback",
+		"response_type": "code",
+		"scope":         "openid email profile",
+	} {
+		if got := query.Get(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	if query.Get("state") == "" {
+		t.Error("state parameter missing from redirect URL")
+	}
+}
+
 // TestHandleLogin_EncodesReturnToInOAuthState: /api/auth/login?return_to=
 // /oauth2/authorize?... encodes that path into the Google OAuth state
 // so HandleCallback can bounce the user back into the MCP authorize flow.


### PR DESCRIPTION
## Summary
- **User-visible problem:** Because no `prompt` parameter was sent in the legacy Google OAuth login handler (`HandleLogin`), Google would silently re-authenticate a browser session that has a single signed-in Google account which had already consented. A user who signed out and clicked "Sign in with Google" was logged straight back in without being able to choose another account.
- **Fix:** Pass `oauth2.SetAuthURLParam("prompt", "select_account")` to `ua.oauthConfig.AuthCodeURL(...)` in `internal/auth/auth.go`.
- **Trade-off:** Single-account users see Google's account selection prompt on login, requiring one extra click to confirm their account.
- **Contract & scope:** Scopes, `access_type`, state encoding, and the OIDC (TokenCanopy) login path remain completely unchanged. This touches only the legacy `/api/auth/login` route; no `/v1` endpoints, OpenAPI spec, or SDK regeneration are involved.

## Validation Commands and Results

### `make fmt-check`
```
(clean, exit 0)
```

### `make build`
```
go build -o bin/e2a ./cmd/e2a
```

### `go vet ./internal/auth/...`
```
(clean, exit 0)
```

### `make test-unit`
```
go test -short ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/ ./internal/unsubscribe/ ./internal/limits/ ./internal/httpapi/ ./internal/ratelimit/
ok  	github.com/tokencanopy/e2a/internal/outbound	0.807s
...
--- FAIL: TestInboundActivityRecording_AuthenticatedMailUpdatesCounters (1.61s)
    inbound_activity_test.go:95: inbound_count = 0, want 1
...
FAIL	github.com/tokencanopy/e2a/internal/relay	12.698s
ok  	github.com/tokencanopy/e2a/internal/config	0.471s
ok  	github.com/tokencanopy/e2a/internal/webhook	8.102s
ok  	github.com/tokencanopy/e2a/internal/approvaltoken	0.118s
ok  	github.com/tokencanopy/e2a/internal/unsubscribe	0.442s
ok  	github.com/tokencanopy/e2a/internal/limits	0.344s
ok  	github.com/tokencanopy/e2a/internal/httpapi	7.252s
ok  	github.com/tokencanopy/e2a/internal/ratelimit	3.213s
FAIL
make: *** [test-unit] Error 1
```
*Note on pre-existing test failure:* `make test-unit` encounters a failure in `github.com/tokencanopy/e2a/internal/relay` (`TestInboundActivityRecording_AuthenticatedMailUpdatesCounters` in `inbound_activity_test.go:95: inbound_count = 0, want 1`). This failure is pre-existing and reproducible on clean `main`.

All tests in `github.com/tokencanopy/e2a/internal/auth` pass:
```
$ go test ./internal/auth/...
ok  	github.com/tokencanopy/e2a/internal/auth	31.711s
```

Prepared by a pi agent (gemini-3.8-flash), reviewed before merge.
