### PR TITLE
chore(release): bump ts-sdk 5.9.0, cli 2.5.1, python 5.8.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.5.1
+
+Bug fix only. No flag, output-field, or exit-code meaning changes from 2.5.0.
+
+**Fixed:** `e2a contacts import` no longer bakes a stray carriage return into
+imported contact metadata. The CSV parser dropped `\r` unconditionally outside
+a quoted field but appended it verbatim inside one, so a CRLF export from
+Excel, Sheets, or a CRM containing a multi-line cell stored the cell's internal
+line breaks as `\r\n`. Quoted fields now normalize the same way the unquoted
+branch already did, matching the parser's documented RFC 4180 conformance.
+
+**Documentation:** corrected the `--send-at` description in the README and in
+this changelog's 2.2.0 entry. Both claimed a review hold *drops* the schedule;
+in fact a scheduled send caught by a hold keeps its `send_at` — approving the
+message submits at that instant if it is still in the future, or immediately if
+it has already passed. No command behavior changed.
+
 ## 2.5.0
 
 Additive only for every input that already succeeded in 2.4.0 — no flag,

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "CLI for e2a — give any AI agent a real, authenticated email inbox",
   "bin": {
     "e2a": "./dist/bin/e2a.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
     },
     "cli": {
       "name": "@e2a/cli",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@e2a/sdk": "^5.7.0"
@@ -8111,7 +8111,7 @@
     },
     "sdks/typescript": {
       "name": "@e2a/sdk",
-      "version": "5.8.0",
+      "version": "5.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.21.3"

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 5.8.1
+
+Documentation only. No public name, signature, type, validation, or runtime
+behavior differs from 5.8.0 — every 5.8.0 call site keeps working identically
+on both ``AsyncE2AClient`` and the synchronous ``E2AClient``.
+
+### Documentation
+- Regenerated the model field descriptions from the current OpenAPI document so
+  the shipped ``pydantic`` ``Field(description=...)`` text matches the server.
+  ``LimitsCapsView.max_messages_month`` and ``LimitsUsageView.messages_month``
+  now state that the monthly allowance counts **outbound recipient-deliveries**
+  — a message to N distinct recipients consumes N units, and received mail is
+  free and never counted. ``LimitExceededDetails.resource`` documents the
+  additional ``messages_day`` stem (a per-UTC-day send cap carried by some
+  accounts; it has no ``AccountView`` field and resets at midnight UTC), so a
+  ``limit_exceeded`` on it clears when the UTC day rolls over rather than on an
+  upgrade. ``ErrorBody.code`` documents ``auth_unavailable`` (503 — an auth
+  backend such as a delegated-token verifier or the identity store could not
+  judge the credential; retry).
+
 ## 5.8.0
 
 ### Changed

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "5.8.0"
+version = "5.8.1"
 description = "Python SDK for e2a — build AI agents with authenticated email"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -760,7 +760,7 @@ wheels = [
 
 [[package]]
 name = "e2a"
-version = "5.8.0"
+version = "5.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 5.9.0
+
+### Changed
+- **Dot-segment path parameters are now rejected for *every* generated request,
+  not just the ten wrapper methods 5.8.0 covered.** The guard moved down to the
+  generated `RequestContext` chokepoint (both the constructor and `setUrl`), so
+  any `/v1` call whose templated path contains a literal `.` or `..` segment
+  throws `HttpException` ("request path contains an unsafe `..` segment")
+  *before* `new URL()` collapses the segment. Previously that collapse happened
+  before any middleware or retry layer could see it, so a caller-controlled
+  value of exactly `..` silently retargeted the request at a different,
+  larger-scoped resource. 5.8.0 closed this for the ten hand-written wrappers it
+  enumerated; every other path parameter — including any added by future codegen
+  — was still exposed. The guard is injected by a codegen post-processing step
+  rather than hand-edited, so `make generate` cannot drop it again. This is a
+  behavior change for any caller that was, deliberately or not, passing `.` or
+  `..` as a path parameter: it now throws instead of sending the (misdirected)
+  request.
+
+### Documentation
+- Regenerated model and operation docs for the outbound-metering semantics the
+  server now documents. `LimitsCapsView.maxMessagesMonth` and
+  `LimitsUsageView.messagesMonth` are described as **outbound
+  recipient-deliveries** — a message to N distinct recipients consumes N units,
+  and received mail is free and never counted. `LimitExceededDetails.resource`
+  documents the additional `messages_day` stem (a per-UTC-day send cap carried
+  by some accounts; it has no `AccountView` field and resets at midnight UTC),
+  and the `402` throw sites say to retry after the UTC day rolls over.
+  `ErrorBody.code` documents `auth_unavailable` (503 — an auth backend could not
+  judge the credential; retry). Field names, types, and runtime behavior are
+  unchanged from 5.8.0.
+
 ## 5.8.0
 
 ### Added

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "TypeScript SDK for e2a — build AI agents with authenticated email",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Cuts the three client packages ahead of the tag pushes that actually publish them. Every scope decision below comes from diffing each package directory against **its own last published tag**, not against the last server release — the baseline mistake #932 made and #935 documented.

| Package | Registry | Published today | This PR | Bump |
|---|---|---|---|---|
| `@e2a/sdk` (`sdks/typescript/`) | npm | 5.8.0 | **5.9.0** | minor |
| `@e2a/cli` (`cli/`) | npm | 2.5.0 | **2.5.1** | patch |
| `e2a` (`sdks/python/`) | PyPI | 5.8.0 | **5.8.1** | patch |

Nothing is published by merging this. The manifests still carry the published versions today, so a `ts-sdk-v*` / `python-v*` / `cli-v*` tag pushed before this lands would try to republish an existing version and fail at the registry. This PR is the prerequisite; the tags come after.

---

## `@e2a/sdk` 5.9.0 — minor

`git diff ts-sdk-v5.8.0..main -- sdks/typescript/`

**#936 — dot-segment path guard at the generated `http.ts` chokepoint** (fixes #915). 5.8.0 shipped this guard on ten hand-written wrapper methods, enumerated by name. #936 moves it down into the generated `RequestContext` (both the constructor and `setUrl`), so *every* generated request is covered, including any path parameter added by future codegen. Without it `new URL()` collapses a literal `.` / `..` segment before any middleware or retry layer can see the request, so a caller-controlled value of exactly `..` silently retargets the call at a different, larger-scoped resource. The guard is injected by a codegen post-processing step (`scripts/guard-dot-segment-path.py`, wired into `generate-oag.sh`) rather than hand-edited, so `make generate` cannot drop it again. Ships in `dist/`.

**Minor, not patch**, on the #935 precedent and matching Python 5.8.0: a path parameter that previously produced a real (misdirected) request now throws `HttpException`. That is a behavior change for any caller passing those values, deliberately or not.

**Generated doc refresh** (#949, #946) — descriptions only, no type or field changes: `LimitsCapsView.maxMessagesMonth` / `LimitsUsageView.messagesMonth` are documented as outbound recipient-deliveries (a message to N distinct recipients consumes N units; received mail is free), `LimitExceededDetails.resource` documents the `messages_day` per-UTC-day send-cap stem, and `ErrorBody.code` documents `auth_unavailable` (503).

Also in range but not user-visible: #957 (explicit timeouts on live e2e reads), #938 (contract harness raises on an unrecognized setup step), #964 (`@types/node` devDependency).

## `@e2a/cli` 2.5.1 — patch

`git diff cli-v2.5.0..main -- cli/`

**#947 — `parseCSV` strips CR inside quoted fields, not just outside them.** The parser dropped `\r` unconditionally outside a quoted field but appended it verbatim inside one, so a CRLF export from Excel/Sheets/a CRM containing a multi-line cell had the cell's internal line breaks stored as `\r\n` in contact metadata via `e2a contacts import`. One-character fix (`} else {` → `} else if (char !== "\r") {`) plus a regression test.

**#937 — `--send-at` / review-hold documentation correction** in `cli/README.md` and the changelog's 2.2.0 entry. Both claimed a hold *drops* the schedule; a held scheduled send actually keeps its `send_at` and re-arms on approval. No command behavior changed.

`cli/package.json` deliberately keeps `"@e2a/sdk": "^5.7.0"`. `check-sdk-version-sync.mjs` compares majors only, `^5.7.0` already resolves to 5.9.0 on a fresh install, and tightening it to `^5.9.0` would create a window where `cli-v2.5.1` is unsatisfiable on npm.

## `e2a` (Python) 5.8.1 — patch

`git diff python-v5.8.0..main -- sdks/python/`

**Documentation only.** The only shipped-source change is regenerated `pydantic` `Field(description=...)` text on four generated models — the same `messages_month` / `messages_day` / `auth_unavailable` refresh described above. Public names, signatures, types, and validation are identical to 5.8.0. Remaining diff is `tests/test_contract.py` (#938), which is not packaged.

---

## Validation (all run in this branch's worktree)

| Command | Result |
|---|---|
| `node scripts/check-sdk-version-sync.mjs` | pass — `mcp ^5.0.0` and `cli ^5.7.0` both match workspace SDK 5.9.0 |
| `node scripts/check-plugin-version-bump.mjs origin/main` | pass — no plugin package changes detected |
| `npm ci` | clean; lockfile unchanged by the install |
| `npm run build --workspace @e2a/sdk` | pass (`@e2a/sdk@5.9.0`) |
| `npm test --workspace @e2a/sdk` | pass — typecheck + 269 unit tests in 11 files + type tests |
| `npm test --workspace @e2a/cli` | pass — typecheck + 322 tests in 20 files |
| `npm run build --workspace @e2a/cli` | pass (`@e2a/cli@2.5.1`) |
| `pip install -e ".[dev]" && pytest tests/` | pass — 613 passed, 48 skipped, 94.12% coverage (floor 90%) |
| `mypy` | pass — no issues in 4 source files |

`package-lock.json` was updated by hand to the two workspace version lines only. Running `npm install --package-lock-only` on this machine's npm 11.6.4 additionally strips `libc` fields that the CI-generated lockfile carries, which would have been unrelated churn; the resulting 2-line diff matches the shape of the previous release commits.

## After merge — tag push order

Tags are pushed against the merged commit, one at a time, each verified before the next. `@e2a/cli` depends on `@e2a/sdk`, so the CLI tag goes last.

```
git push origin <merged-sha>:refs/tags/ts-sdk-v5.9.0
#   wait for the publish workflow, then: npm view @e2a/sdk version   -> 5.9.0

git push origin <merged-sha>:refs/tags/python-v5.8.1
#   wait for the publish workflow (PyPI sends no email; the run is the only
#   signal), then:
#   curl -s https://pypi.org/pypi/e2a/json | python3 -c 'import json,sys;print(json.load(sys.stdin)["info"]["version"])'  -> 5.8.1

git push origin <merged-sha>:refs/tags/cli-v2.5.1
#   only after 5.9.0 is visible on npm; then: npm view @e2a/cli version -> 2.5.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjfGxvXW6fNKWGFHuo68yX
