### PR TITLE
feat(sending): add durable provider authorization gate

### DIFF
--- a/internal/sendingpolicy/budget.go
+++ b/internal/sendingpolicy/budget.go
@@ -1,0 +1,460 @@
+package sendingpolicy
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// This file owns the budget ledger: which pools an operation draws on, what
+// today's limit for each pool is, and how capacity is taken, confirmed, and
+// given back. Nothing here decides whether to enforce — that is the caller's
+// reading of the runtime policy's budget mode. This layer answers only "is
+// there room", so shadow mode computes the exact same arithmetic without
+// blocking anything.
+
+// randomID mints an opaque identifier. crypto/rand failure means the OS RNG is
+// broken; panicking surfaces that as a 500 rather than writing a predictable
+// operation ID that an attacker could then reference.
+func randomID(prefix string) string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("sendingpolicy: crypto/rand failed: %v", err))
+	}
+	return prefix + hex.EncodeToString(b)
+}
+
+// randomNonce mints the single-use redemption secret stored on a confirmed
+// reservation. It is longer than an ID because guessing it would let a caller
+// redeem an authorization it was never handed.
+func randomNonce() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("sendingpolicy: crypto/rand failed: %v", err))
+	}
+	return hex.EncodeToString(b)
+}
+
+// accountClassExempt reports whether an account's class removes it from every
+// customer budget.
+//
+// The list is closed and positive on purpose. `demo`, an unknown class written
+// by a future binary, and the empty string all fall through to "budgeted",
+// because the failure mode of budgeting a trusted account is a held prober
+// message, while the failure mode of exempting an untrusted one is exactly the
+// abuse this system exists to prevent.
+func accountClassExempt(class string) bool {
+	return class == "system" || class == "internal"
+}
+
+// accountDailyLimit resolves the account-daily cap from the current policy and
+// the account's authoritative plan code.
+//
+// A paid plan is not "unlimited": it is limited at the all-customer ceiling, so
+// its usage is still recorded on a per-account counter and a single paid
+// account still cannot quietly consume the whole platform's day without that
+// being visible per account. An unknown or missing plan code deliberately falls
+// to the Free default — a plan the catalog does not name is not evidence of
+// payment.
+func accountDailyLimit(policy RuntimePolicy, planCode string) int {
+	for _, code := range policy.DailyUnlimitedPlanCodes {
+		if code == planCode {
+			return policy.AllCustomerGlobalDailyRecipients
+		}
+	}
+	return policy.DefaultAccountDailyRecipients
+}
+
+// scopeKeys returns which counters an operation of this shape charges, with no
+// reference to limits or the calendar.
+//
+// Keeping structure separate from magnitude is what lets the release path work:
+// releasing an old attempt's units needs to know exactly which rows it touched,
+// and it must be able to answer that without re-deriving the plan code and
+// policy generation that were in force when the units were taken.
+//
+// The mapping is the whole containment argument, so it is one switch rather
+// than logic spread across call sites:
+//
+//   - customer traffic charges the platform ceiling and its own account, plus
+//     the probation pool while it is unproven and the shared-domain pool while
+//     it borrows platform reputation;
+//   - public feedback has no account to charge but still burns platform and
+//     probation capacity, because it shares the same provider surface;
+//   - the two operational purposes draw only on their own pools, which is what
+//     lets a pause notice go out during the abuse wave that exhausted
+//     everything else;
+//   - trusted first-party traffic charges nothing.
+func scopeKeys(purpose Purpose, accountID string, shared, probation bool) []counterKey {
+	var keys []counterKey
+	switch purpose {
+	case PurposeCustomerMessage, PurposeCustomerNotification:
+		keys = append(keys,
+			counterKey{ScopeGlobalAll, scopeIDAllCustomers},
+			counterKey{ScopeAccountDaily, accountID},
+		)
+		if probation {
+			keys = append(keys, counterKey{ScopeGlobalProbation, scopeIDProbation})
+		}
+		if shared {
+			keys = append(keys, counterKey{ScopeAccountSharedDaily, accountID})
+		}
+	case PurposePublicFeedback:
+		keys = append(keys,
+			counterKey{ScopeGlobalAll, scopeIDAllCustomers},
+			counterKey{ScopeGlobalProbation, scopeIDProbation},
+		)
+	case PurposeCriticalOperational:
+		keys = append(keys, counterKey{ScopeGlobalCritical, scopeIDCritical})
+	case PurposeViolationOperational:
+		keys = append(keys, counterKey{ScopeGlobalViolation, scopeIDViolation})
+	case PurposeTrustedSystem:
+		return nil
+	}
+	sortCounterKeys(keys)
+	return keys
+}
+
+// limitFor resolves today's cap for one counter under the current policy and
+// the account's authoritative plan.
+func limitFor(key counterKey, policy RuntimePolicy, planCode string) int {
+	switch key.Scope {
+	case ScopeGlobalAll:
+		return policy.AllCustomerGlobalDailyRecipients
+	case ScopeGlobalProbation:
+		return policy.ProbationGlobalDailyRecipients
+	case ScopeAccountDaily:
+		return accountDailyLimit(policy, planCode)
+	case ScopeAccountSharedDaily:
+		return policy.SharedDomainAccountDailyRecip
+	case ScopeGlobalCritical:
+		return policy.CriticalOperationalDailyRecip
+	case ScopeGlobalViolation:
+		return policy.ViolationOperationalDailyRecip
+	}
+	return 0
+}
+
+// optimisticLimitFor is the cap Reserve checks against: the most permissive
+// value any plan could produce for this scope.
+//
+// Reserve does not take the account-control and plan locks that make a plan
+// read authoritative, so it cannot know whether this account is paid. That
+// leaves two ways to be wrong, and they are not symmetric. A false ALLOW here
+// costs nothing — ConsumeAttempt re-evaluates every scope under the real locks
+// and holds the message if it must. A false DENY is a customer-visible outage:
+// the worker treats an early hold as "snooze until midnight", so guessing the
+// Free cap for a paying customer would defer their mail for a day that
+// ConsumeAttempt would have allowed. So Reserve deliberately denies only when
+// no plan could have fit.
+func optimisticLimitFor(key counterKey, policy RuntimePolicy) int {
+	if key.Scope != ScopeAccountDaily {
+		return limitFor(key, policy, "")
+	}
+	if policy.AllCustomerGlobalDailyRecipients > policy.DefaultAccountDailyRecipients {
+		return policy.AllCustomerGlobalDailyRecipients
+	}
+	return policy.DefaultAccountDailyRecipients
+}
+
+// holdReasonForScope maps a denied counter to its machine-readable reason.
+func holdReasonForScope(scope Scope) string {
+	switch scope {
+	case ScopeAccountDaily:
+		return ReasonAccountDailyBudget
+	case ScopeAccountSharedDaily:
+		return ReasonAccountSharedBudget
+	case ScopeGlobalAll:
+		return ReasonGlobalAllBudget
+	case ScopeGlobalProbation:
+		return ReasonGlobalProbation
+	case ScopeGlobalCritical:
+		return ReasonGlobalCritical
+	case ScopeGlobalViolation:
+		return ReasonGlobalViolation
+	}
+	return "budget_exhausted"
+}
+
+// ledgerDay reads the UTC date this transaction's writes belong to.
+//
+// clock_timestamp(), not now(): now() is frozen at transaction start, so a
+// transaction that began at 23:59:59 and then waited two seconds on a row lock
+// would charge yesterday's counter while the rest of the fleet had already
+// rolled over. Reading the wall clock AFTER the serializing locks are held is
+// what makes the day boundary consistent with lock acquisition, and it is why
+// the adjacent-day physical exposure bound is 2*cap rather than unbounded.
+func ledgerDay(ctx context.Context, tx pgx.Tx) (time.Time, error) {
+	var day time.Time
+	if err := tx.QueryRow(ctx, `SELECT (clock_timestamp() AT TIME ZONE 'UTC')::date`).Scan(&day); err != nil {
+		return time.Time{}, fmt.Errorf("sendingpolicy: read ledger day: %w", err)
+	}
+	return day.UTC(), nil
+}
+
+// nextUTCMidnight is the retry time for a day-bounded hold: the moment the
+// denied counter resets. Derived from the ledger day the transaction actually
+// used, so a hold decided just after rollover does not advise a 24-hour wait.
+func nextUTCMidnight(day time.Time) time.Time {
+	return time.Date(day.Year(), day.Month(), day.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1)
+}
+
+// ledgerRef names one physical counter row: a scope key on a specific day.
+type ledgerRef struct {
+	counterKey
+	Day time.Time
+}
+
+// ledgerRow is one locked counter row plus the net change this transaction
+// intends to apply to it.
+type ledgerRow struct {
+	ref       ledgerRef
+	reserved  int
+	confirmed int
+	limit     int
+
+	// delta is the pending change to reserved_count. Accumulated in memory so
+	// a row that is both released and re-acquired in the same transaction is
+	// written once, and so an all-or-nothing decision can be made before any
+	// row is modified.
+	delta int
+	// acquired is the part of delta that came from taking capacity, tracked
+	// separately so a denial can drop every acquisition while keeping the
+	// releases that must survive it.
+	acquired int
+	// exists is false for a row that was absent and is not being created.
+	exists bool
+}
+
+// ledgerPlan is the locked working set for one budget transaction.
+type ledgerPlan struct {
+	rows  map[ledgerRef]*ledgerRow
+	order []ledgerRef
+}
+
+// lockLedger takes every counter row this transaction may touch, once, in the
+// normative order, before any of them is read for a decision.
+//
+// A single ordered locking pass is the deadlock argument. Two workers charging
+// the same account will contend on global_all and account_daily; if one took
+// them in the opposite order — or took a release row after an acquire row —
+// Postgres would resolve the cycle by killing a transaction, and on the final
+// authorization path a killed transaction is a message that errors instead of
+// being held. Every caller therefore hands the complete set here first and does
+// its arithmetic afterwards against rows it already holds.
+//
+// `create` names the rows that must exist because this transaction intends to
+// take capacity on them; they are upserted, which both creates and locks in one
+// statement so two concurrent creators cannot both believe the row was absent.
+// Rows outside `create` are release-only: if they do not exist there is nothing
+// to give back, so a plain locking read is correct and avoids resurrecting a
+// row a janitor legitimately removed.
+func lockLedger(ctx context.Context, tx pgx.Tx, create map[ledgerRef]int, releaseOnly []ledgerRef) (*ledgerPlan, error) {
+	plan := &ledgerPlan{rows: make(map[ledgerRef]*ledgerRow)}
+
+	refs := make([]ledgerRef, 0, len(create)+len(releaseOnly))
+	for ref := range create {
+		refs = append(refs, ref)
+	}
+	for _, ref := range releaseOnly {
+		if _, dup := create[ref]; dup {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	sortLedgerRefs(refs)
+
+	for _, ref := range refs {
+		limit, creating := create[ref]
+		row := &ledgerRow{ref: ref, limit: limit}
+		var err error
+		if creating {
+			if limit <= 0 {
+				// A non-positive limit cannot be stored (the CHECK forbids it)
+				// and would mean "hold everything forever", which no policy
+				// meant to express. Validation rejects it at activation, so
+				// reaching here is a bug; failing closed is the only safe read.
+				return nil, fmt.Errorf("sendingpolicy: scope %s has a non-positive limit %d", ref.Scope, limit)
+			}
+			// The DO UPDATE branch both takes the row lock and performs the
+			// limit synchronization. Synchronizing before any check is what
+			// makes a limit change effective on its first armed day in both
+			// directions: a reduction blocks immediately even when today's
+			// usage already exceeds the new value, and an increase releases
+			// exactly the new headroom rather than retroactively forgiving
+			// anything already spent.
+			err = tx.QueryRow(ctx, `
+				INSERT INTO sending_budget_counters
+				    (scope, scope_id, day, reserved_count, confirmed_count, daily_limit)
+				VALUES ($1, $2, $3, 0, 0, $4)
+				ON CONFLICT (scope, scope_id, day) DO UPDATE
+				    SET daily_limit = EXCLUDED.daily_limit
+				RETURNING reserved_count, confirmed_count, daily_limit`,
+				ref.Scope, ref.ScopeID, ref.Day, limit,
+			).Scan(&row.reserved, &row.confirmed, &row.limit)
+			if err != nil {
+				return nil, fmt.Errorf("sendingpolicy: lock counter %s/%s: %w", ref.Scope, ref.ScopeID, err)
+			}
+			row.exists = true
+		} else {
+			err = tx.QueryRow(ctx, `
+				SELECT reserved_count, confirmed_count, daily_limit
+				  FROM sending_budget_counters
+				 WHERE scope = $1 AND scope_id = $2 AND day = $3
+				   FOR UPDATE`,
+				ref.Scope, ref.ScopeID, ref.Day,
+			).Scan(&row.reserved, &row.confirmed, &row.limit)
+			switch {
+			case errors.Is(err, pgx.ErrNoRows):
+				row.exists = false
+			case err != nil:
+				return nil, fmt.Errorf("sendingpolicy: lock counter %s/%s: %w", ref.Scope, ref.ScopeID, err)
+			default:
+				row.exists = true
+			}
+		}
+		plan.rows[ref] = row
+		plan.order = append(plan.order, ref)
+	}
+	return plan, nil
+}
+
+// sortLedgerRefs orders physical counter rows: scope rank first (the normative
+// order), then scope ID, then day. Including the day makes the order total when
+// a transaction spans a midnight rollover and must touch yesterday's and
+// today's row for the same scope.
+func sortLedgerRefs(refs []ledgerRef) {
+	sort.Slice(refs, func(i, j int) bool {
+		ri, rj := scopeLockRank[refs[i].Scope], scopeLockRank[refs[j].Scope]
+		if ri != rj {
+			return ri < rj
+		}
+		if refs[i].ScopeID != refs[j].ScopeID {
+			return refs[i].ScopeID < refs[j].ScopeID
+		}
+		return refs[i].Day.Before(refs[j].Day)
+	})
+}
+
+// release records giving back `units` of reserved-but-unconfirmed capacity.
+//
+// Silently skipping an absent row is correct: a counter that no longer exists
+// holds no units of ours. Clamping at confirmed_count is belt-and-braces
+// against the one mistake that would corrupt the ledger — releasing units that
+// were already confirmed. The table's CHECK would catch it, but a constraint
+// violation aborts the whole transaction, and releases run on paths (rate
+// deferral, suppression cancel) where aborting strands a message.
+func (p *ledgerPlan) release(ref ledgerRef, units int) {
+	row, ok := p.rows[ref]
+	if !ok || !row.exists {
+		return
+	}
+	if row.reserved+row.delta-units < row.confirmed {
+		return
+	}
+	row.delta -= units
+}
+
+// acquire records taking `units`, reporting whether there was room.
+func (p *ledgerPlan) acquire(ref ledgerRef, units int) bool {
+	row, ok := p.rows[ref]
+	if !ok {
+		return false
+	}
+	if row.reserved+row.delta+units > row.limit {
+		return false
+	}
+	row.delta += units
+	row.acquired += units
+	return true
+}
+
+// overrun takes `units` past the limit. Only shadow mode uses it.
+//
+// Clamping the counter at the cap during a shadow window would make the window
+// prove only that the cap exists. What the activation gate actually has to
+// approve is whether the proposed number covers real aggregate demand plus
+// headroom, and that is measurable only if the counter is allowed to record
+// demand it would have refused.
+func (p *ledgerPlan) overrun(ref ledgerRef, units int) {
+	row, ok := p.rows[ref]
+	if !ok {
+		return
+	}
+	row.delta += units
+	row.acquired += units
+}
+
+// discardAcquisitions drops every take while keeping every give-back, so an
+// enforced denial leaves the attempt released rather than half-charged.
+func (p *ledgerPlan) discardAcquisitions() {
+	for _, row := range p.rows {
+		row.delta -= row.acquired
+		row.acquired = 0
+	}
+}
+
+// flush writes every accumulated delta, in the same order the rows were
+// locked. A zero delta writes nothing — the common steady-state case where an
+// attempt releases and immediately re-acquires the same units on the same row
+// costs one lock and no write.
+func (p *ledgerPlan) flush(ctx context.Context, tx pgx.Tx) error {
+	for _, ref := range p.order {
+		row := p.rows[ref]
+		if row.delta == 0 || !row.exists {
+			continue
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE sending_budget_counters
+			   SET reserved_count = reserved_count + $4
+			 WHERE scope = $1 AND scope_id = $2 AND day = $3`,
+			ref.Scope, ref.ScopeID, ref.Day, row.delta,
+		); err != nil {
+			return fmt.Errorf("sendingpolicy: write counter %s/%s: %w", ref.Scope, ref.ScopeID, err)
+		}
+	}
+	return nil
+}
+
+// confirm moves `units` from reserved to confirmed on every named row.
+//
+// Confirmed means the capacity is irrevocably spent for a possible provider
+// attempt — not that SES accepted anything. That distinction is why a crash
+// between authorization and the socket costs the account a recipient:
+// under-admitting is recoverable at the next midnight, while refunding an
+// attempt that might already have reached SES would let a delete-and-resend
+// loop mint free reputation exposure.
+func confirmCounters(ctx context.Context, tx pgx.Tx, refs []ledgerRef, units int) error {
+	sorted := append([]ledgerRef(nil), refs...)
+	sortLedgerRefs(sorted)
+	for _, ref := range sorted {
+		tag, err := tx.Exec(ctx, `
+			UPDATE sending_budget_counters
+			   SET confirmed_count = confirmed_count + $4
+			 WHERE scope = $1 AND scope_id = $2 AND day = $3`,
+			ref.Scope, ref.ScopeID, ref.Day, units,
+		)
+		if err != nil {
+			return fmt.Errorf("sendingpolicy: confirm counter %s/%s: %w", ref.Scope, ref.ScopeID, err)
+		}
+		if tag.RowsAffected() != 1 {
+			return fmt.Errorf("sendingpolicy: confirm counter %s/%s: row is missing", ref.Scope, ref.ScopeID)
+		}
+	}
+	return nil
+}
+
+// refsFor pairs a scope key set with a day.
+func refsFor(keys []counterKey, day time.Time) []ledgerRef {
+	refs := make([]ledgerRef, len(keys))
+	for i, key := range keys {
+		refs[i] = ledgerRef{counterKey: key, Day: day}
+	}
+	return refs
+}

--- a/internal/sendingpolicy/budget.go
+++ b/internal/sendingpolicy/budget.go
@@ -91,7 +91,7 @@ func accountDailyLimit(policy RuntimePolicy, planCode string) int {
 //     lets a pause notice go out during the abuse wave that exhausted
 //     everything else;
 //   - trusted first-party traffic charges nothing.
-func scopeKeys(purpose Purpose, accountID string, shared, probation bool) []counterKey {
+func scopeKeys(purpose Purpose, accountID string, shared, probation bool) ([]counterKey, error) {
 	var keys []counterKey
 	switch purpose {
 	case PurposeCustomerMessage, PurposeCustomerNotification:
@@ -115,10 +115,16 @@ func scopeKeys(purpose Purpose, accountID string, shared, probation bool) []coun
 	case PurposeViolationOperational:
 		keys = append(keys, counterKey{ScopeGlobalViolation, scopeIDViolation})
 	case PurposeTrustedSystem:
-		return nil
+		return nil, nil
+	default:
+		// Charging nothing is the most permissive answer this function can
+		// give, so it must never be the answer to a question it does not
+		// understand. A purpose added to the closed set but not to this switch
+		// would otherwise become an unbudgeted send path.
+		return nil, fmt.Errorf("sendingpolicy: no budget mapping for purpose %q", purpose)
 	}
 	sortCounterKeys(keys)
-	return keys
+	return keys, nil
 }
 
 // limitFor resolves today's cap for one counter under the current policy and
@@ -139,28 +145,6 @@ func limitFor(key counterKey, policy RuntimePolicy, planCode string) int {
 		return policy.ViolationOperationalDailyRecip
 	}
 	return 0
-}
-
-// optimisticLimitFor is the cap Reserve checks against: the most permissive
-// value any plan could produce for this scope.
-//
-// Reserve does not take the account-control and plan locks that make a plan
-// read authoritative, so it cannot know whether this account is paid. That
-// leaves two ways to be wrong, and they are not symmetric. A false ALLOW here
-// costs nothing — ConsumeAttempt re-evaluates every scope under the real locks
-// and holds the message if it must. A false DENY is a customer-visible outage:
-// the worker treats an early hold as "snooze until midnight", so guessing the
-// Free cap for a paying customer would defer their mail for a day that
-// ConsumeAttempt would have allowed. So Reserve deliberately denies only when
-// no plan could have fit.
-func optimisticLimitFor(key counterKey, policy RuntimePolicy) int {
-	if key.Scope != ScopeAccountDaily {
-		return limitFor(key, policy, "")
-	}
-	if policy.AllCustomerGlobalDailyRecipients > policy.DefaultAccountDailyRecipients {
-		return policy.AllCustomerGlobalDailyRecipients
-	}
-	return policy.DefaultAccountDailyRecipients
 }
 
 // holdReasonForScope maps a denied counter to its machine-readable reason.
@@ -185,11 +169,17 @@ func holdReasonForScope(scope Scope) string {
 // ledgerDay reads the UTC date this transaction's writes belong to.
 //
 // clock_timestamp(), not now(): now() is frozen at transaction start, so a
-// transaction that began at 23:59:59 and then waited two seconds on a row lock
-// would charge yesterday's counter while the rest of the fleet had already
-// rolled over. Reading the wall clock AFTER the serializing locks are held is
-// what makes the day boundary consistent with lock acquisition, and it is why
-// the adjacent-day physical exposure bound is 2*cap rather than unbounded.
+// transaction that began at 23:59:59 and then waited two seconds on the
+// operation lock would charge yesterday's counter while the rest of the fleet
+// had already rolled over.
+//
+// Precisely: this is read after the operation and attempt locks and BEFORE the
+// counter locks, so a transaction can still wait on a contended counter after
+// fixing its day. The adjacent-day exposure bound is therefore
+// 2*cap over a window as wide as that counter lock wait, not an instant —
+// deliberately inducing contention on a global pool at 23:59:5x widens it. The
+// bound itself holds either way, because each side of the boundary is still a
+// separate counter row with its own cap.
 func ledgerDay(ctx context.Context, tx pgx.Tx) (time.Time, error) {
 	var day time.Time
 	if err := tx.QueryRow(ctx, `SELECT (clock_timestamp() AT TIME ZONE 'UTC')::date`).Scan(&day); err != nil {

--- a/internal/sendingpolicy/gate.go
+++ b/internal/sendingpolicy/gate.go
@@ -685,7 +685,7 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 	// that commits first may already be entering its one SES call.
 	if op.Purpose.isCustomer() {
 		if !ownerExists {
-			return st, holdDecision(ReasonAccountDeleted, time.Time{}), nil
+			return st, terminalHold(ReasonAccountDeleted), nil
 		}
 		if controlState == "paused" {
 			return st, holdDecision(ReasonAccountPaused, time.Time{}), nil
@@ -707,7 +707,7 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 	// notice for a delivery already marked sent, which is the exact duplicate
 	// this module claims to make impossible.
 	if notice != nil && notice.state != "pending" {
-		return st, holdDecision(ReasonNoticeSettled, time.Time{}), nil
+		return st, terminalHold(ReasonNoticeSettled), nil
 	}
 
 	if notice != nil && notice.audience == AudienceOwner && !ownerExists {
@@ -716,39 +716,44 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 		if err := m.markNoticeSkipped(ctx, tx, notice); err != nil {
 			return st, Decision{}, err
 		}
-		return st, holdDecision(ReasonAccountDeleted, time.Time{}), nil
+		return st, terminalHold(ReasonAccountDeleted), nil
 	}
 
 	// The reputation class is immutable on the operation, but `sent_as` is not
 	// immutable on the message: the approval path rewrites it, and it depends
 	// on the domain's live verification state. If the operation was prepared
-	// while the customer's own domain was sending-verified and the message is
-	// now going out over the shared relay, sending it would put shared traffic
+	// while the customer's own domain was sending-verified and the message now
+	// goes out over the shared relay, sending it would put shared traffic
 	// through a dedicated budget — escaping both the 50/day shared cap and the
-	// probation pool. Refusing is the safe answer, and it makes a caller that
-	// prepared too early loud instead of silently cheap. (Tightening in the
-	// other direction needs no action: an operation already classed as shared
-	// stays shared.)
-	if op.Purpose == PurposeCustomerMessage {
-		_, nowShared, classErr := messageEnvelopeAndClass(ctx, tx, op.OperationID)
-		if classErr == nil && nowShared && !op.Shared {
-			return st, holdDecision(ReasonClassChanged, time.Time{}), nil
-		}
-	}
-
-	st.envelope, err = m.resolveEnvelope(ctx, tx, op, ref, notice, ownerEmail)
-	if err != nil {
+	// probation pool. (Tightening the other way needs no action: an operation
+	// already classed as shared stays shared.)
+	//
+	// TERMINAL, not a snooze. shared_reputation is frozen at operation creation
+	// and the operation is keyed by message id, so there is no future in which
+	// this operation describes that message again; a retryable hold would
+	// leave the message stuck until a human noticed. The caller fails it — the
+	// lifecycle catalog's submission.sending_setup_expired is the fitting code
+	// — and prepares a fresh operation if the send should still happen.
+	//
+	// One read of the message row serves both this check and the envelope,
+	// rather than resolving the same row twice per authorization.
+	envelope, envErr := m.resolveEnvelopeAndClass(ctx, tx, op, ref, notice, ownerEmail)
+	if envErr != nil {
 		// A source that has been deleted, or an envelope that no longer
 		// resolves, is a HOLD and not an error. Returning an error here rolls
 		// the transaction back with the attempt still marked reserved, and
 		// since every later execution fails at the same point, those units are
 		// stranded on the SHARED pools until midnight with nothing able to
 		// release them. A caller could farm that: reserve, delete, repeat.
-		if errors.Is(err, ErrSourceUnavailable) || errors.Is(err, ErrEnvelopeUnavailable) {
-			return st, holdDecision(ReasonSourceUnavailable, time.Time{}), nil
+		if errors.Is(envErr, ErrSourceUnavailable) || errors.Is(envErr, ErrEnvelopeUnavailable) {
+			return st, terminalHold(ReasonSourceUnavailable), nil
 		}
-		return st, Decision{}, err
+		if errors.Is(envErr, errReputationClassChanged) {
+			return st, terminalHold(ReasonClassChanged), nil
+		}
+		return st, Decision{}, envErr
 	}
+	st.envelope = envelope
 	st.units = len(st.envelope)
 	return st, allowDecision(), nil
 }
@@ -815,6 +820,30 @@ func (m *Module) markNoticeSkipped(ctx context.Context, tx pgx.Tx, notice *notic
 		return fmt.Errorf("sendingpolicy: close notice delivery: %w", err)
 	}
 	return nil
+}
+
+// errReputationClassChanged marks a customer message whose class no longer
+// matches the operation derived from it.
+var errReputationClassChanged = errors.New("sendingpolicy: reputation class changed after preparation")
+
+// resolveEnvelopeAndClass resolves the envelope and, for a customer message,
+// re-checks that the message still belongs to the reputation class its
+// operation was frozen with.
+//
+// The two are one function because they are one read. Splitting them is what
+// had this path querying the same message row twice per authorization.
+func (m *Module) resolveEnvelopeAndClass(ctx context.Context, tx pgx.Tx, op operationRow, ref AttemptRef, notice *noticeState, ownerEmail string) ([]string, error) {
+	if op.Purpose != PurposeCustomerMessage {
+		return m.resolveEnvelope(ctx, tx, op, ref, notice, ownerEmail)
+	}
+	envelope, nowShared, err := messageEnvelopeAndClass(ctx, tx, op.OperationID)
+	if err != nil {
+		return nil, err
+	}
+	if nowShared && !op.Shared {
+		return nil, errReputationClassChanged
+	}
+	return envelope, nil
 }
 
 // resolveEnvelope produces the exact final recipient set, under the locks that
@@ -1033,6 +1062,10 @@ func (m *Module) authorize(ctx context.Context, tx pgx.Tx, st authState) (*Provi
 	if st.notice != nil {
 		version, commitment, err := m.noticeCommitmentFor(st)
 		if err != nil {
+			// Reserve may already hold this attempt's units, and returning an
+			// error here rolls back with the row still reserved — every retry
+			// then fails identically and the capacity is stranded. Surface it
+			// as the terminal hold it is so the caller releases and stops.
 			return nil, err
 		}
 		noticeVersion, noticeCommitment = &version, commitment
@@ -1214,12 +1247,16 @@ func (m *Module) recordCorrelation(ctx context.Context, tx pgx.Tx, st authState,
 // because the notice pool is exhausted must not enqueue another notice.
 //
 // Lock order note: this runs while the caller holds budget-counter locks, which
-// is later in the normative order than the notice keys. That inversion is
-// deliberate and bounded — the plan requires the notice to be inserted
-// ATOMICALLY with the denial, and the only rows touched are ones this
-// transaction is creating, so the sole contention point is the partial unique
-// index when two callers hit the same scope and day. No path locks an existing
-// delivery row and then reaches for a counter, so there is no cycle to close.
+// is later in the normative order than the notice keys. The inversion is
+// deliberate — the plan requires the notice to be inserted ATOMICALLY with the
+// denial — and it is currently acyclic, but NOT for the obvious reason.
+//
+// readAuthState does lock an existing delivery row and then reach for counters,
+// so the two directions do exist. What closes the cycle is that the only
+// transactions holding a delivery row are notice operations, whose purpose is
+// operational, and this function returns nil for operational purposes before
+// touching a notice key. That is the load-bearing fact: if an operational
+// purpose ever becomes able to enqueue a notice, the cycle closes silently.
 func (m *Module) enqueueDenialNotice(ctx context.Context, tx pgx.Tx, policy RuntimePolicy, op operationRow, day time.Time, scope Scope) error {
 	if op.Purpose.isOperational() {
 		return nil

--- a/internal/sendingpolicy/gate.go
+++ b/internal/sendingpolicy/gate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -110,7 +111,7 @@ type reservationRow struct {
 // to target exactly those rows — otherwise a domain that graduated out of
 // probation, or a control that was disarmed, would leak reserved capacity until
 // midnight.
-func (r reservationRow) scopeKeys(shared bool) []counterKey {
+func (r reservationRow) scopeKeys(shared bool) ([]counterKey, error) {
 	account := ""
 	if r.SourceAccountRef != nil {
 		account = *r.SourceAccountRef
@@ -149,17 +150,26 @@ func lockReservation(ctx context.Context, tx pgx.Tx, operationID string, attempt
 // exactly how a naive accounting would undercount a fan-out by an order of
 // magnitude.
 func messageEnvelope(ctx context.Context, tx pgx.Tx, messageID string) ([]string, error) {
+	envelope, _, err := messageEnvelopeAndClass(ctx, tx, messageID)
+	return envelope, err
+}
+
+// messageEnvelopeAndClass also reports the message's CURRENT reputation class,
+// so final authorization can notice that it stopped matching the immutable one
+// the operation was derived from.
+func messageEnvelopeAndClass(ctx context.Context, tx pgx.Tx, messageID string) ([]string, bool, error) {
 	var to, cc, bcc []string
+	var sentAs *string
 	err := tx.QueryRow(ctx, `
-		SELECT COALESCE(to_recipients, '{}'), COALESCE(cc, '{}'), COALESCE(bcc, '{}')
+		SELECT COALESCE(to_recipients, '{}'), COALESCE(cc, '{}'), COALESCE(bcc, '{}'), sent_as
 		  FROM messages
 		 WHERE id = $1 AND direction = 'outbound'`, messageID,
-	).Scan(&to, &cc, &bcc)
+	).Scan(&to, &cc, &bcc, &sentAs)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, ErrSourceUnavailable
+		return nil, false, ErrSourceUnavailable
 	}
 	if err != nil {
-		return nil, fmt.Errorf("sendingpolicy: read message envelope: %w", err)
+		return nil, false, fmt.Errorf("sendingpolicy: read message envelope: %w", err)
 	}
 	all := make([]string, 0, len(to)+len(cc)+len(bcc))
 	all = append(all, to...)
@@ -167,9 +177,9 @@ func messageEnvelope(ctx context.Context, tx pgx.Tx, messageID string) ([]string
 	all = append(all, bcc...)
 	envelope, err := normalizeEnvelope(all)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrEnvelopeUnavailable, err)
+		return nil, false, fmt.Errorf("%w: %v", ErrEnvelopeUnavailable, err)
 	}
-	return envelope, nil
+	return envelope, sharedFromSentAs(sentAs), nil
 }
 
 // plannedUnits is how much capacity an attempt intends to take.
@@ -225,6 +235,46 @@ func (m *Module) Reserve(ctx context.Context, ref OperationRef) (Decision, Attem
 		return Decision{}, AttemptRef{}, err
 	}
 
+	// Reserve judges the same caps ConsumeAttempt will, using the same
+	// authoritative inputs, and that is not optional.
+	//
+	// An earlier version guessed instead: it skipped these reads and widened
+	// the account cap so it could never under-admit a paid account. That trade
+	// was wrong in both directions. Judging the ACCOUNT scope optimistically
+	// while still charging the SHARED global pools at their real limits let one
+	// Free account hold the entire platform pool in reservations it could never
+	// confirm — starving every other tenant and paging the operator with a
+	// guardrail incident. And judging it pessimistically deferred a paying
+	// customer's mail to the next midnight, because the worker treats an early
+	// hold as "snooze". The only correct answer is to read the class and the
+	// plan, which costs one FOR SHARE apiece.
+	var probeAccount string
+	var probePurpose Purpose
+	if err := tx.QueryRow(ctx, `
+		SELECT COALESCE(source_account_ref, ''), purpose
+		  FROM sending_provider_operations
+		 WHERE operation_id = $1`, ref.id,
+	).Scan(&probeAccount, &probePurpose); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Decision{}, AttemptRef{}, ErrSourceUnavailable
+		}
+		return Decision{}, AttemptRef{}, fmt.Errorf("sendingpolicy: read operation: %w", err)
+	}
+
+	var accountClass, planCode string
+	if probePurpose.isCustomer() && probeAccount != "" {
+		if err := tx.QueryRow(ctx,
+			`SELECT account_class FROM users WHERE id = $1 FOR SHARE`, probeAccount,
+		).Scan(&accountClass); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return Decision{}, AttemptRef{}, fmt.Errorf("sendingpolicy: lock user: %w", err)
+		}
+		if err := tx.QueryRow(ctx,
+			`SELECT COALESCE(plan_code, '') FROM account_limits WHERE user_id = $1 FOR SHARE`, probeAccount,
+		).Scan(&planCode); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return Decision{}, AttemptRef{}, fmt.Errorf("sendingpolicy: lock account limits: %w", err)
+		}
+	}
+
 	op, err := lockOperation(ctx, tx, ref.id)
 	if err != nil {
 		return Decision{}, AttemptRef{}, err
@@ -261,13 +311,23 @@ func (m *Module) Reserve(ctx context.Context, ref OperationRef) (Decision, Attem
 	// which is correct while the ramp itself is pass-through.
 	probation := op.Shared
 
-	state := "reserved"
+	// Trusted first-party accounts charge nothing, and that has to be true
+	// HERE and not only at final authorization. The exemption exists so
+	// probers keep working during the abuse wave that exhausted the customer
+	// pools — but an early hold makes the worker snooze without ever reaching
+	// ConsumeAttempt, so an exemption that lives only there is dead on the one
+	// path it was written for.
+	exempt := accountClassExempt(accountClass) && op.Purpose.isCustomer()
+	charged := false
 	deniedScope := Scope("")
-	if policy.BudgetMode == ModeEnforce {
-		keys := scopeKeys(op.Purpose, op.accountRef(), op.Shared, probation)
+	if policy.BudgetMode == ModeEnforce && !exempt {
+		keys, err := scopeKeys(op.Purpose, op.accountRef(), op.Shared, probation)
+		if err != nil {
+			return Decision{}, AttemptRef{}, err
+		}
 		create := make(map[ledgerRef]int, len(keys))
 		for _, key := range keys {
-			create[ledgerRef{counterKey: key, Day: day}] = optimisticLimitFor(key, policy)
+			create[ledgerRef{counterKey: key, Day: day}] = limitFor(key, policy, planCode)
 		}
 		plan, err := lockLedger(ctx, tx, create, nil)
 		if err != nil {
@@ -279,24 +339,45 @@ func (m *Module) Reserve(ctx context.Context, ref OperationRef) (Decision, Attem
 				break
 			}
 		}
-		if deniedScope != "" {
-			// Nothing is written: the plan's deltas are discarded, so this
-			// early denial leaves the ledger exactly as it found it. The row
-			// still records the intended size so a later ConsumeAttempt can
-			// re-arm it.
-			state = "released"
-		} else if err := plan.flush(ctx, tx); err != nil {
+		if deniedScope == "" {
+			if err := plan.flush(ctx, tx); err != nil {
+				return Decision{}, AttemptRef{}, err
+			}
+			charged = true
+		}
+		// On a denial the plan's deltas are simply never flushed, so the
+		// ledger is left exactly as it was found.
+	}
+
+	// The row records that capacity is HELD only when it actually is. Writing
+	// `reserved` for an attempt that charged nothing — because the budget was
+	// disabled, or the account is exempt, or the acquisition was denied — would
+	// make a later ConsumeAttempt release units this attempt never took, and
+	// on the day enforcement is first armed that phantom release is capacity
+	// silently handed back to whoever else is in flight.
+	state := "released"
+	if charged {
+		state = "reserved"
+	}
+	if err := upsertReservation(ctx, tx, op, attempt, day, units, probation, state); err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
+
+	if deniedScope != "" {
+		// The violation notice is owed HERE, not only at final authorization.
+		// Every scope except account_daily is judged identically by both
+		// calls, so a denial that stops at Reserve is a denial the customer and
+		// the operator would otherwise never hear about — the worker snoozes
+		// and ConsumeAttempt, where the notice used to be written, is never
+		// reached.
+		if err := m.enqueueDenialNotice(ctx, tx, policy, op, day, deniedScope); err != nil {
 			return Decision{}, AttemptRef{}, err
 		}
 	}
 
-	if err := upsertReservation(ctx, tx, op, attempt, day, units, probation, state); err != nil {
-		return Decision{}, AttemptRef{}, err
-	}
 	if err := m.commit(ctx, tx, "reserve"); err != nil {
 		return Decision{}, AttemptRef{}, err
 	}
-
 	if deniedScope != "" {
 		return holdDecision(holdReasonForScope(deniedScope), nextUTCMidnight(day)), out, nil
 	}
@@ -393,6 +474,7 @@ type noticeState struct {
 	eventID         string
 	audience        Audience
 	deliveryAttempt int
+	state           string
 	version         int
 	commitment      []byte
 }
@@ -549,7 +631,10 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 		).Scan(&st.planCode); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return st, Decision{}, fmt.Errorf("sendingpolicy: lock account limits: %w", err)
 		}
-		st.tenantMode, st.tenantName = tenantModeFor(policy, probeAccount, tenantName)
+		st.tenantMode, st.tenantName = tenantModeFor(policy, probePurpose, probeAccount, tenantName)
+	}
+	if !probePurpose.isCustomer() {
+		st.tenantMode, st.tenantName = tenantModeFor(policy, probePurpose, "", "")
 	}
 
 	// Notice delivery, when this operation is one. Locked before the provider
@@ -609,6 +694,21 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 			return st, holdDecision(ReasonTenantNotReady, time.Time{}), nil
 		}
 	}
+	// A required header with no name to put in it is not a header. The adapter
+	// would have to either omit it or send an empty value, and both defeat the
+	// isolation the header exists for, so the send waits for a real tenant.
+	if st.tenantMode == TenantModeRequired && strings.TrimSpace(st.tenantName) == "" {
+		return st, holdDecision(ReasonTenantUnnamed, time.Time{}), nil
+	}
+
+	// A delivery that already reached a terminal state must not be re-armed.
+	// The stable-operation design guarantees a retry is a greater ordinal on
+	// one logical notice; without this check it also permits a SECOND logical
+	// notice for a delivery already marked sent, which is the exact duplicate
+	// this module claims to make impossible.
+	if notice != nil && notice.state != "pending" {
+		return st, holdDecision(ReasonNoticeSettled, time.Time{}), nil
+	}
 
 	if notice != nil && notice.audience == AudienceOwner && !ownerExists {
 		// The account this notice was about is gone. There is nobody to tell,
@@ -619,8 +719,34 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 		return st, holdDecision(ReasonAccountDeleted, time.Time{}), nil
 	}
 
+	// The reputation class is immutable on the operation, but `sent_as` is not
+	// immutable on the message: the approval path rewrites it, and it depends
+	// on the domain's live verification state. If the operation was prepared
+	// while the customer's own domain was sending-verified and the message is
+	// now going out over the shared relay, sending it would put shared traffic
+	// through a dedicated budget — escaping both the 50/day shared cap and the
+	// probation pool. Refusing is the safe answer, and it makes a caller that
+	// prepared too early loud instead of silently cheap. (Tightening in the
+	// other direction needs no action: an operation already classed as shared
+	// stays shared.)
+	if op.Purpose == PurposeCustomerMessage {
+		_, nowShared, classErr := messageEnvelopeAndClass(ctx, tx, op.OperationID)
+		if classErr == nil && nowShared && !op.Shared {
+			return st, holdDecision(ReasonClassChanged, time.Time{}), nil
+		}
+	}
+
 	st.envelope, err = m.resolveEnvelope(ctx, tx, op, ref, notice, ownerEmail)
 	if err != nil {
+		// A source that has been deleted, or an envelope that no longer
+		// resolves, is a HOLD and not an error. Returning an error here rolls
+		// the transaction back with the attempt still marked reserved, and
+		// since every later execution fails at the same point, those units are
+		// stranded on the SHARED pools until midnight with nothing able to
+		// release them. A caller could farm that: reserve, delete, repeat.
+		if errors.Is(err, ErrSourceUnavailable) || errors.Is(err, ErrEnvelopeUnavailable) {
+			return st, holdDecision(ReasonSourceUnavailable, time.Time{}), nil
+		}
 		return st, Decision{}, err
 	}
 	st.units = len(st.envelope)
@@ -632,7 +758,18 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 // Canary is an explicit account list rather than a percentage: a tenant header
 // is either sent or not, and the rollout gate wants a named account it can
 // verify end to end, not a sample it has to go looking for.
-func tenantModeFor(policy RuntimePolicy, accountID, tenantName string) (TenantMode, string) {
+func tenantModeFor(policy RuntimePolicy, purpose Purpose, accountID, tenantName string) (TenantMode, string) {
+	// Operational and public-feedback mail is not a customer's traffic and has
+	// no customer tenant; it uses the fixed system tenant. Returning "no
+	// tenant" for them under an enforcing policy would fail OPEN — the one
+	// direction a header whose purpose is provider-side isolation must never
+	// fail.
+	if !purpose.isCustomer() {
+		if policy.TenantHeaderMode == TenantHeaderEnforce {
+			return TenantModeRequired, SystemPolicySubject
+		}
+		return TenantModeNone, ""
+	}
 	switch policy.TenantHeaderMode {
 	case TenantHeaderEnforce:
 		return TenantModeRequired, tenantName
@@ -663,6 +800,7 @@ func (m *Module) lockNoticeDelivery(ctx context.Context, tx pgx.Tx, operationID 
 		return nil, fmt.Errorf("sendingpolicy: lock notice delivery: %w", err)
 	}
 	st.audience = Audience(audience)
+	st.state = state
 	return &st, nil
 }
 
@@ -690,7 +828,10 @@ func (m *Module) markNoticeSkipped(ctx context.Context, tx pgx.Tx, notice *notic
 func (m *Module) resolveEnvelope(ctx context.Context, tx pgx.Tx, op operationRow, ref AttemptRef, notice *noticeState, ownerEmail string) ([]string, error) {
 	switch {
 	case notice != nil && notice.audience == AudienceOperator:
-		version := m.policyOperatorVersion(ctx, tx)
+		version, err := m.policyOperatorVersion(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
 		if m.secrets.Recipients == nil {
 			return nil, fmt.Errorf("%w: no operator recipient map is loaded", ErrEnvelopeUnavailable)
 		}
@@ -730,13 +871,24 @@ func (m *Module) resolveEnvelope(ctx context.Context, tx pgx.Tx, op operationRow
 
 // policyOperatorVersion returns the recipient version the current policy
 // selects. The database source is authoritative when it is in use.
-func (m *Module) policyOperatorVersion(ctx context.Context, tx pgx.Tx) int {
+// policyOperatorVersion returns the recipient version the current policy
+// selects.
+//
+// A read failure is propagated rather than absorbed. Falling back to the config
+// value would, on a hosted deployment whose database has rotated the operator
+// mailbox, silently select the RETIRED version — and because the redemption
+// recheck calls this same helper, the recheck would confirm the stale answer
+// instead of catching it. That is the one path whose whole guarantee is "zero
+// calls to the retired address".
+func (m *Module) policyOperatorVersion(ctx context.Context, tx pgx.Tx) (int, error) {
 	if m.source == PolicySourceDatabase {
-		if policy, err := m.currentPolicyForShare(ctx, tx); err == nil {
-			return policy.OperatorNoticeRecipientVersion
+		policy, err := m.currentPolicyForShare(ctx, tx)
+		if err != nil {
+			return 0, err
 		}
+		return policy.OperatorNoticeRecipientVersion, nil
 	}
-	return m.configPolicy.OperatorNoticeRecipientVersion
+	return m.configPolicy.OperatorNoticeRecipientVersion, nil
 }
 
 // releaseStoredUnits gives back whatever the stored attempt is holding.
@@ -745,7 +897,10 @@ func (m *Module) releaseStoredUnits(ctx context.Context, tx pgx.Tx, st authState
 	if !stored.Exists || stored.State != "reserved" {
 		return nil
 	}
-	oldKeys := stored.scopeKeys(st.op.Shared)
+	oldKeys, err := stored.scopeKeys(st.op.Shared)
+	if err != nil {
+		return err
+	}
 	refs := refsFor(oldKeys, stored.Day)
 	plan, err := lockLedger(ctx, tx, nil, refs)
 	if err != nil {
@@ -788,7 +943,10 @@ func (m *Module) reauthorizeBudget(ctx context.Context, tx pgx.Tx, st authState)
 		return allowDecision(), m.releaseStoredUnits(ctx, tx, st)
 	}
 
-	currentKeys := scopeKeys(st.op.Purpose, st.op.accountRef(), st.op.Shared, st.probation)
+	currentKeys, err := scopeKeys(st.op.Purpose, st.op.accountRef(), st.op.Shared, st.probation)
+	if err != nil {
+		return Decision{}, err
+	}
 	create := make(map[ledgerRef]int, len(currentKeys))
 	for _, key := range currentKeys {
 		create[ledgerRef{counterKey: key, Day: st.day}] = limitFor(key, st.policy, st.planCode)
@@ -796,7 +954,11 @@ func (m *Module) reauthorizeBudget(ctx context.Context, tx pgx.Tx, st authState)
 
 	var releaseRefs []ledgerRef
 	if stored.Exists && stored.State == "reserved" {
-		releaseRefs = refsFor(stored.scopeKeys(st.op.Shared), stored.Day)
+		storedKeys, err := stored.scopeKeys(st.op.Shared)
+		if err != nil {
+			return Decision{}, err
+		}
+		releaseRefs = refsFor(storedKeys, stored.Day)
 	}
 
 	plan, err := lockLedger(ctx, tx, create, releaseRefs)
@@ -840,7 +1002,7 @@ func (m *Module) reauthorizeBudget(ctx context.Context, tx pgx.Tx, st authState)
 		); err != nil {
 			return Decision{}, fmt.Errorf("sendingpolicy: release denied reservation: %w", err)
 		}
-		if err := m.recordDenialNotice(ctx, tx, st, deniedScope); err != nil {
+		if err := m.enqueueDenialNotice(ctx, tx, st.policy, st.op, st.day, deniedScope); err != nil {
 			return Decision{}, err
 		}
 		return holdDecision(holdReasonForScope(deniedScope), nextUTCMidnight(st.day)), nil
@@ -975,7 +1137,10 @@ func (m *Module) confirmIfCharged(ctx context.Context, tx pgx.Tx, st authState, 
 	if st.policy.BudgetMode == ModeDisabled || exempt || st.op.Purpose == PurposeTrustedSystem {
 		return nil
 	}
-	keys := scopeKeys(st.op.Purpose, st.op.accountRef(), st.op.Shared, st.probation)
+	keys, err := scopeKeys(st.op.Purpose, st.op.accountRef(), st.op.Shared, st.probation)
+	if err != nil {
+		return err
+	}
 	return confirmCounters(ctx, tx, refsFor(keys, st.day), st.units)
 }
 
@@ -992,17 +1157,29 @@ func (m *Module) recordCorrelation(ctx context.Context, tx pgx.Tx, st authState,
 	// every delivery event, so a token carrying an ID that no row holds would
 	// produce feedback nothing could ever be matched to — the failure would be
 	// invisible until the detector had been silently blind for days.
+	// Customer correlations get no expiry here: they must outlive the message
+	// for as long as the account exists, so that a controlled recipient cannot
+	// wait out a fixed timer before complaining. The post-deletion janitor sets
+	// their horizon. A non-customer operation has no account to outlive, so it
+	// receives the configured horizon at creation.
+	var expires *time.Time
+	if !st.op.Purpose.isCustomer() {
+		horizon := time.Now().UTC().Add(
+			time.Duration(st.policy.SendingFeedbackPostAcctRetention) * 24 * time.Hour)
+		expires = &horizon
+	}
+
 	var correlationID string
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO sending_feedback_correlations
 		    (correlation_id, operation_id, submission_attempt, source_account_ref,
-		     policy_subject_ref, purpose, shared_reputation, tenant_mode)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		     policy_subject_ref, purpose, shared_reputation, tenant_mode, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (operation_id, submission_attempt) DO UPDATE
 		    SET operation_id = EXCLUDED.operation_id
 		RETURNING correlation_id`,
 		randomID("cor_"), st.op.OperationID, attempt, st.op.SourceAccountRef,
-		st.op.PolicySubjectRef, st.op.Purpose, st.op.Shared, string(st.tenantMode),
+		st.op.PolicySubjectRef, st.op.Purpose, st.op.Shared, string(st.tenantMode), expires,
 	).Scan(&correlationID); err != nil {
 		return "", fmt.Errorf("sendingpolicy: record correlation: %w", err)
 	}
@@ -1026,7 +1203,7 @@ func (m *Module) recordCorrelation(ctx context.Context, tx pgx.Tx, st authState,
 	return correlationID, nil
 }
 
-// recordDenialNotice enqueues the notice an enforced denial owes, exactly once
+// enqueueDenialNotice writes the notice an enforced denial owes, exactly once
 // per account, scope, and UTC day.
 //
 // The three cases are deliberately asymmetric. An account-owned scope is the
@@ -1035,17 +1212,25 @@ func (m *Module) recordCorrelation(ctx context.Context, tx pgx.Tx, st authState,
 // collide with, so it produces one coalesced operator notice and blames nobody.
 // An operational purpose produces nothing at all: a notice that cannot be sent
 // because the notice pool is exhausted must not enqueue another notice.
-func (m *Module) recordDenialNotice(ctx context.Context, tx pgx.Tx, st authState, scope Scope) error {
-	if st.op.Purpose.isOperational() {
+//
+// Lock order note: this runs while the caller holds budget-counter locks, which
+// is later in the normative order than the notice keys. That inversion is
+// deliberate and bounded — the plan requires the notice to be inserted
+// ATOMICALLY with the denial, and the only rows touched are ones this
+// transaction is creating, so the sole contention point is the partial unique
+// index when two callers hit the same scope and day. No path locks an existing
+// delivery row and then reaches for a counter, so there is no cycle to close.
+func (m *Module) enqueueDenialNotice(ctx context.Context, tx pgx.Tx, policy RuntimePolicy, op operationRow, day time.Time, scope Scope) error {
+	if op.Purpose.isOperational() {
 		return nil
 	}
 
-	retention := time.Duration(st.policy.SendingControlAuditRetentionDays) * 24 * time.Hour
+	retention := time.Duration(policy.SendingControlAuditRetentionDays) * 24 * time.Hour
 	expires := time.Now().UTC().Add(retention)
 
 	switch scope {
 	case ScopeAccountDaily, ScopeAccountSharedDaily:
-		account := st.op.accountRef()
+		account := op.accountRef()
 		if account == "" {
 			return nil
 		}
@@ -1058,7 +1243,7 @@ func (m *Module) recordDenialNotice(ctx context.Context, tx pgx.Tx, st authState
 			    WHERE kind = 'budget_violation'
 			    DO NOTHING
 			RETURNING id`,
-			randomID("spn_"), account, string(scope), st.day, expires,
+			randomID("spn_"), account, string(scope), day, expires,
 		).Scan(&eventID)
 		if errors.Is(err, pgx.ErrNoRows) {
 			// Already enqueued for this account, scope, and day. Later holds
@@ -1081,7 +1266,7 @@ func (m *Module) recordDenialNotice(ctx context.Context, tx pgx.Tx, st authState
 			    WHERE kind = 'global_guardrail'
 			    DO NOTHING
 			RETURNING id`,
-			randomID("spn_"), string(scope), st.day, expires,
+			randomID("spn_"), string(scope), day, expires,
 		).Scan(&eventID)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
@@ -1214,7 +1399,10 @@ func (m *Module) noticeSelectorStillCurrent(ctx context.Context, tx pgx.Tx, auth
 		if m.secrets.Recipients == nil {
 			return false, nil
 		}
-		version := m.policyOperatorVersion(ctx, tx)
+		version, err := m.policyOperatorVersion(ctx, tx)
+		if err != nil {
+			return false, err
+		}
 		if version != *stored.NoticeVersion || version != auth.notice.recipientVersion {
 			return false, nil
 		}
@@ -1246,10 +1434,16 @@ func (m *Module) noticeSelectorStillCurrent(ctx context.Context, tx pgx.Tx, auth
 // is a reason to stop, not a reason to hand back reputation exposure that a
 // retry will immediately re-consume.
 func (m *Module) invalidate(ctx context.Context, tx pgx.Tx, ref AttemptRef) error {
+	// Guarded by the ordinal, not GREATEST(). An unguarded bump lets a worker
+	// arriving late with a SUPERSEDED token retire the live attempt another
+	// worker is holding — that worker's confirmed capacity is spent and never
+	// refunded, so a supply of stale tokens becomes a livelock that burns the
+	// account's budget without a single SES call. A stale token must retire
+	// only itself, and it is already stale, so the correct write is none.
 	if _, err := tx.Exec(ctx, `
 		UPDATE sending_provider_operations
-		   SET current_attempt = GREATEST(current_attempt, $2) + 1, updated_at = now()
-		 WHERE operation_id = $1`, ref.operationID, ref.attempt,
+		   SET current_attempt = current_attempt + 1, updated_at = now()
+		 WHERE operation_id = $1 AND current_attempt = $2`, ref.operationID, ref.attempt,
 	); err != nil {
 		return fmt.Errorf("sendingpolicy: invalidate attempt: %w", err)
 	}
@@ -1327,7 +1521,11 @@ func (m *Module) releaseAttempt(ctx context.Context, ref AttemptRef, what string
 		return m.commit(ctx, tx, what)
 	}
 
-	refs := refsFor(stored.scopeKeys(op.Shared), stored.Day)
+	storedKeys, err := stored.scopeKeys(op.Shared)
+	if err != nil {
+		return err
+	}
+	refs := refsFor(storedKeys, stored.Day)
 	plan, err := lockLedger(ctx, tx, nil, refs)
 	if err != nil {
 		return err
@@ -1379,6 +1577,13 @@ func (m *Module) SettleProvider(ctx context.Context, settlement ProviderSettleme
 		return err
 	}
 	if !stored.Exists {
+		return ErrAttemptStale
+	}
+	// Settlement reports what the PROVIDER did, so it is only meaningful for an
+	// attempt that was authorized to reach the provider. Accepting a reserved
+	// or released attempt would let a caller advance ramp progress for a send
+	// that never happened once Task 4 hangs the ramp mutation off this call.
+	if stored.State != "confirmed" {
 		return ErrAttemptStale
 	}
 

--- a/internal/sendingpolicy/gate.go
+++ b/internal/sendingpolicy/gate.go
@@ -1,0 +1,1390 @@
+package sendingpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Gate is the provider-authorization surface: the only way anything in this
+// codebase is permitted to hand a message to SES.
+//
+// The shape is deliberate. A caller cannot ask "am I allowed?" and then act on
+// the answer later, because an allow is not a boolean — it is a single-use
+// ProviderAuthorization bound to one durable attempt, which the SMTP adapter
+// must redeem immediately before it opens a socket. That removes the entire
+// class of bug where a decision goes stale between the check and the call: a
+// pause, a plan downgrade, a policy change, a midnight rollover, or a
+// competing worker all invalidate the token rather than being raced.
+type Gate interface {
+	PrepareExternalTx(ctx context.Context, tx pgx.Tx, messageID string) (AcceptanceDecision, OperationRef, error)
+	PrepareNotificationTx(context.Context, pgx.Tx, NotificationRef) (OperationRef, error)
+	PrepareProtectionNoticeTx(context.Context, pgx.Tx, ProtectionNoticeRef) (OperationRef, error)
+	PreparePublicFeedback(context.Context, PublicFeedbackRef) (OperationRef, error)
+	Reserve(context.Context, OperationRef) (Decision, AttemptRef, error)
+	ConsumeAttempt(context.Context, AttemptRef) (Decision, *ProviderAuthorization, error)
+	RedeemProviderCall(context.Context, ProviderAuthorization) error
+	DeferAttempt(context.Context, AttemptRef) error
+	CancelAttempt(context.Context, AttemptRef) error
+	SettleProvider(context.Context, ProviderSettlement) error
+}
+
+var _ Gate = (*Module)(nil)
+
+// NewGate binds the module to the deployment's policy authority and returns it
+// as the narrow provider-authorization role.
+//
+// The source is a constructor argument rather than a runtime lookup because it
+// decides where authority lives, and that must not be able to change under a
+// decision in flight. A hosted deployment reads the audited database singleton;
+// a self-host reads the config file it already validated at startup.
+func NewGate(pool *pgxpool.Pool, secrets Secrets, source PolicySource, configPolicy RuntimePolicy) Gate {
+	m := NewModule(pool, secrets)
+	m.source = source
+	m.configPolicy = configPolicy
+	return m
+}
+
+// Sentinel errors for the authorization surface.
+var (
+	// ErrAttemptStale means the reference names an attempt that is no longer
+	// the operation's current one, or one whose state forbids the requested
+	// transition. It is always zero writes to the ledger and zero provider
+	// calls.
+	ErrAttemptStale = errors.New("sendingpolicy: attempt is stale")
+	// ErrProviderCallStarted means the attempt already opened a socket, so its
+	// capacity cannot be given back. Retrying needs a new ordinal, not this one.
+	ErrProviderCallStarted = errors.New("sendingpolicy: provider call already started")
+	// ErrAuthorizationInvalid means a redemption failed its final recheck. The
+	// attempt is invalidated and a strictly greater ordinal must be allocated
+	// before any provider call.
+	ErrAuthorizationInvalid = errors.New("sendingpolicy: provider authorization is no longer valid")
+	// ErrEnvelopeUnavailable means the operation's authorized envelope could
+	// not be resolved from durable state or the caller's reference.
+	ErrEnvelopeUnavailable = errors.New("sendingpolicy: authorized envelope is unavailable")
+)
+
+// effectivePolicy reads the policy that governs this transaction.
+//
+// Database source takes a share lock on the singleton, which is the first key
+// in the normative lock order: a concurrent activation therefore either
+// completes before this decision reads it or waits until after the decision
+// commits. There is no window in which half a decision uses the old generation
+// and half the new one. Config source has no row and takes no lock — a
+// self-host's policy changes by redeploy, which is already a restart.
+func (m *Module) effectivePolicy(ctx context.Context, tx pgx.Tx) (RuntimePolicy, error) {
+	if m.source == PolicySourceDatabase {
+		return m.currentPolicyForShare(ctx, tx)
+	}
+	return m.configPolicy, nil
+}
+
+// reservationRow is one row of sending_budget_reservations.
+type reservationRow struct {
+	OperationID      string
+	Attempt          int
+	SourceAccountRef *string
+	PolicySubjectRef string
+	Purpose          Purpose
+	Day              time.Time
+	Units            int
+	Probation        bool
+	State            string
+	CallState        string
+	Nonce            *string
+	NoticeVersion    *int
+	NoticeCommitment []byte
+	Exists           bool
+}
+
+// scopeKeys returns the counters this stored reservation charged, using only
+// values persisted on the row itself.
+//
+// It deliberately does not consult the current policy. The units were taken
+// under whatever generation was in force at the time, and giving them back has
+// to target exactly those rows — otherwise a domain that graduated out of
+// probation, or a control that was disarmed, would leak reserved capacity until
+// midnight.
+func (r reservationRow) scopeKeys(shared bool) []counterKey {
+	account := ""
+	if r.SourceAccountRef != nil {
+		account = *r.SourceAccountRef
+	}
+	return scopeKeys(r.Purpose, account, shared, r.Probation)
+}
+
+// lockReservation reads and locks one attempt row.
+func lockReservation(ctx context.Context, tx pgx.Tx, operationID string, attempt int) (reservationRow, error) {
+	var r reservationRow
+	err := tx.QueryRow(ctx, `
+		SELECT operation_id, submission_attempt, source_account_ref, policy_subject_ref,
+		       purpose, day, units, probation, state, call_state, authorization_nonce,
+		       notice_recipient_version, notice_recipient_commitment
+		  FROM sending_budget_reservations
+		 WHERE operation_id = $1 AND submission_attempt = $2
+		   FOR UPDATE`, operationID, attempt,
+	).Scan(&r.OperationID, &r.Attempt, &r.SourceAccountRef, &r.PolicySubjectRef,
+		&r.Purpose, &r.Day, &r.Units, &r.Probation, &r.State, &r.CallState, &r.Nonce,
+		&r.NoticeVersion, &r.NoticeCommitment)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return reservationRow{}, nil
+	}
+	if err != nil {
+		return reservationRow{}, fmt.Errorf("sendingpolicy: lock reservation: %w", err)
+	}
+	r.Day = r.Day.UTC()
+	r.Exists = true
+	return r, nil
+}
+
+// messageEnvelope reads a customer message's provider-bound recipient set.
+//
+// To, Cc, and Bcc all become envelope recipients at the SMTP layer, so all
+// three are charged. Bcc especially: it is invisible in the message body and is
+// exactly how a naive accounting would undercount a fan-out by an order of
+// magnitude.
+func messageEnvelope(ctx context.Context, tx pgx.Tx, messageID string) ([]string, error) {
+	var to, cc, bcc []string
+	err := tx.QueryRow(ctx, `
+		SELECT COALESCE(to_recipients, '{}'), COALESCE(cc, '{}'), COALESCE(bcc, '{}')
+		  FROM messages
+		 WHERE id = $1 AND direction = 'outbound'`, messageID,
+	).Scan(&to, &cc, &bcc)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrSourceUnavailable
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sendingpolicy: read message envelope: %w", err)
+	}
+	all := make([]string, 0, len(to)+len(cc)+len(bcc))
+	all = append(all, to...)
+	all = append(all, cc...)
+	all = append(all, bcc...)
+	envelope, err := normalizeEnvelope(all)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEnvelopeUnavailable, err)
+	}
+	return envelope, nil
+}
+
+// plannedUnits is how much capacity an attempt intends to take.
+//
+// Reserve needs a size before anything is resolved, and the size must not be
+// larger than what final authorization will actually charge — an over-estimate
+// would hold capacity that is never used until midnight. Notice and
+// notification mail is exactly one recipient by construction; customer mail is
+// its own deduplicated envelope; public feedback is its fixed configured set.
+func plannedUnits(ctx context.Context, tx pgx.Tx, op operationRow, carried []string) (int, error) {
+	switch op.Purpose {
+	case PurposeCustomerMessage:
+		envelope, err := messageEnvelope(ctx, tx, op.OperationID)
+		if err != nil {
+			return 0, err
+		}
+		return len(envelope), nil
+	case PurposeCustomerNotification, PurposeCriticalOperational, PurposeViolationOperational:
+		return 1, nil
+	case PurposePublicFeedback, PurposeTrustedSystem:
+		envelope, err := normalizeEnvelope(carried)
+		if err != nil {
+			return 0, fmt.Errorf("%w: %v", ErrEnvelopeUnavailable, err)
+		}
+		return len(envelope), nil
+	}
+	return 0, fmt.Errorf("sendingpolicy: unsupported purpose %q", op.Purpose)
+}
+
+// Reserve allocates this operation's current durable submission attempt and,
+// as an optimization, tries to take its capacity early.
+//
+// It is explicitly not authority to submit. Its value is that a worker learns
+// about an exhausted budget before it does the expensive work of composing and
+// signing a message, and that the durable ordinal is allocated exactly once per
+// provider opportunity. That ordinal allocation is the load-bearing half: after
+// a crash, timeout, ambiguous SMTP result, or ordinary River retry, the next
+// execution sees a confirmed row and allocates N+1 rather than reusing an
+// ordinal that may already have reached the network.
+func (m *Module) Reserve(ctx context.Context, ref OperationRef) (Decision, AttemptRef, error) {
+	if ref.IsZero() {
+		return Decision{}, AttemptRef{}, ErrSourceUnavailable
+	}
+
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return Decision{}, AttemptRef{}, fmt.Errorf("sendingpolicy: begin reserve: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	policy, err := m.effectivePolicy(ctx, tx)
+	if err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
+
+	op, err := lockOperation(ctx, tx, ref.id)
+	if err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
+
+	attempt, current, err := allocateAttempt(ctx, tx, op)
+	if err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
+	out := AttemptRef{operationID: op.OperationID, attempt: attempt, recipients: ref.recipients}
+
+	// An attempt that already holds its capacity is not re-charged. Reserve is
+	// idempotent per ordinal precisely so a worker that is retried before it
+	// ever reached ConsumeAttempt does not accumulate reservations.
+	if current.Exists && current.Attempt == attempt && current.State == "reserved" {
+		return allowDecision(), out, m.commit(ctx, tx, "reserve")
+	}
+
+	units, err := plannedUnits(ctx, tx, op, ref.recipients)
+	if err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
+
+	day, err := ledgerDay(ctx, tx)
+	if err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
+
+	// Probation classification. Shared-domain traffic is probationary at every
+	// plan level and never graduates by age or payment — higher-volume
+	// initiated sending requires a customer-controlled domain. Custom-domain
+	// probation is the custom-domain ramp's answer, composed into this
+	// decision by Task 4; until then a dedicated domain is not probationary,
+	// which is correct while the ramp itself is pass-through.
+	probation := op.Shared
+
+	state := "reserved"
+	deniedScope := Scope("")
+	if policy.BudgetMode == ModeEnforce {
+		keys := scopeKeys(op.Purpose, op.accountRef(), op.Shared, probation)
+		create := make(map[ledgerRef]int, len(keys))
+		for _, key := range keys {
+			create[ledgerRef{counterKey: key, Day: day}] = optimisticLimitFor(key, policy)
+		}
+		plan, err := lockLedger(ctx, tx, create, nil)
+		if err != nil {
+			return Decision{}, AttemptRef{}, err
+		}
+		for _, key := range keys {
+			if !plan.acquire(ledgerRef{counterKey: key, Day: day}, units) {
+				deniedScope = key.Scope
+				break
+			}
+		}
+		if deniedScope != "" {
+			// Nothing is written: the plan's deltas are discarded, so this
+			// early denial leaves the ledger exactly as it found it. The row
+			// still records the intended size so a later ConsumeAttempt can
+			// re-arm it.
+			state = "released"
+		} else if err := plan.flush(ctx, tx); err != nil {
+			return Decision{}, AttemptRef{}, err
+		}
+	}
+
+	if err := upsertReservation(ctx, tx, op, attempt, day, units, probation, state); err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
+	if err := m.commit(ctx, tx, "reserve"); err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
+
+	if deniedScope != "" {
+		return holdDecision(holdReasonForScope(deniedScope), nextUTCMidnight(day)), out, nil
+	}
+	return allowDecision(), out, nil
+}
+
+// allocateAttempt returns the ordinal this operation's next provider
+// opportunity must use, advancing the durable counter when the current attempt
+// has already been authorized.
+//
+// The rule is one-way: an ordinal is reusable only while it is provably before
+// any network I/O. A confirmed reservation means capacity was irrevocably spent
+// and a socket may have been opened, so the only safe continuation is a greater
+// ordinal with fresh capacity. That is what bounds physical SES exposure to the
+// charged amount even across crashes.
+func allocateAttempt(ctx context.Context, tx pgx.Tx, op operationRow) (int, reservationRow, error) {
+	current, err := lockReservation(ctx, tx, op.OperationID, op.CurrentAttempt)
+	if err != nil {
+		return 0, reservationRow{}, err
+	}
+	if !current.Exists || current.State == "reserved" || (current.State == "released" && current.CallState == "none") {
+		return op.CurrentAttempt, current, nil
+	}
+
+	next := op.CurrentAttempt + 1
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_provider_operations
+		   SET current_attempt = $2, updated_at = now()
+		 WHERE operation_id = $1`, op.OperationID, next,
+	); err != nil {
+		return 0, reservationRow{}, fmt.Errorf("sendingpolicy: advance attempt: %w", err)
+	}
+	advanced, err := lockReservation(ctx, tx, op.OperationID, next)
+	if err != nil {
+		return 0, reservationRow{}, err
+	}
+	return next, advanced, nil
+}
+
+// upsertReservation writes the attempt row in a pre-provider state.
+func upsertReservation(ctx context.Context, tx pgx.Tx, op operationRow, attempt int, day time.Time, units int, probation bool, state string) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO sending_budget_reservations
+		    (operation_id, submission_attempt, source_account_ref, policy_subject_ref,
+		     purpose, day, units, probation, state, call_state)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'none')
+		ON CONFLICT (operation_id, submission_attempt) DO UPDATE
+		   SET day = EXCLUDED.day,
+		       units = EXCLUDED.units,
+		       probation = EXCLUDED.probation,
+		       state = EXCLUDED.state,
+		       call_state = 'none',
+		       authorization_nonce = NULL,
+		       provider_call_started_at = NULL,
+		       updated_at = now()`,
+		op.OperationID, attempt, op.SourceAccountRef, op.PolicySubjectRef,
+		op.Purpose, day, units, probation, state,
+	)
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: write reservation: %w", err)
+	}
+	return nil
+}
+
+// commit wraps tx.Commit with a named error so a failure is attributable.
+func (m *Module) commit(ctx context.Context, tx pgx.Tx, what string) error {
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("sendingpolicy: commit %s: %w", what, err)
+	}
+	return nil
+}
+
+// authState is everything ConsumeAttempt read under lock, in one value, so the
+// decision logic below reads as policy rather than as SQL.
+type authState struct {
+	policy    RuntimePolicy
+	op        operationRow
+	stored    reservationRow
+	day       time.Time
+	units     int
+	probation bool
+	planCode  string
+	class     string
+
+	tenantMode TenantMode
+	tenantName string
+
+	envelope []string
+	notice   *noticeState
+}
+
+// noticeState is the protection-notice half of a final authorization.
+type noticeState struct {
+	eventID         string
+	audience        Audience
+	deliveryAttempt int
+	version         int
+	commitment      []byte
+}
+
+// ConsumeAttempt is the final pre-I/O authorization: the one place where the
+// account's live state, the current policy generation, today's UTC date, and
+// every applicable pool are checked together under lock.
+//
+// It is a full re-evaluation, not a confirmation of what Reserve decided.
+// Everything Reserve saw may have changed: the policy can have been activated,
+// the plan downgraded, the account paused, the day rolled over, a control armed
+// or disarmed. Re-deriving from scratch — including releasing units Reserve
+// took on scopes that no longer apply — is what makes a policy change between
+// the two calls impossible to slip past.
+func (m *Module) ConsumeAttempt(ctx context.Context, ref AttemptRef) (Decision, *ProviderAuthorization, error) {
+	if ref.IsZero() {
+		return Decision{}, nil, ErrSourceUnavailable
+	}
+
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return Decision{}, nil, fmt.Errorf("sendingpolicy: begin consume: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	state, decision, err := m.readAuthState(ctx, tx, ref)
+	if err != nil {
+		return Decision{}, nil, err
+	}
+	if !decision.Allow {
+		// A state-based hold (pause, deleted owner, tenant not ready) still
+		// has to give back whatever the early reservation is holding, or the
+		// account loses that capacity until midnight for a message it never
+		// sent.
+		if err := m.releaseStoredUnits(ctx, tx, state); err != nil {
+			return Decision{}, nil, err
+		}
+		if err := m.commit(ctx, tx, "consume hold"); err != nil {
+			return Decision{}, nil, err
+		}
+		return decision, nil, nil
+	}
+
+	decision, err = m.reauthorizeBudget(ctx, tx, state)
+	if err != nil {
+		return Decision{}, nil, err
+	}
+	if !decision.Allow {
+		if err := m.commit(ctx, tx, "consume budget hold"); err != nil {
+			return Decision{}, nil, err
+		}
+		return decision, nil, nil
+	}
+
+	auth, err := m.authorize(ctx, tx, state)
+	if err != nil {
+		return Decision{}, nil, err
+	}
+	if err := m.commit(ctx, tx, "consume authorize"); err != nil {
+		return Decision{}, nil, err
+	}
+	return allowDecision(), auth, nil
+}
+
+// readAuthState takes every lock in the normative order and returns either the
+// assembled state or a state-based hold.
+//
+// The order is runtime policy → users → account control → plan → notice
+// delivery → provider operation → attempt, and it is the same order every
+// mutating path in this package uses. It is not arbitrary: locking the policy
+// first means an activation serializes against every decision; locking the user
+// row before the control row means a class change and a pause cannot
+// interleave; locking the plan under the same contract the billing writer uses
+// means a plan commit and an authorization cannot both believe they were first.
+//
+// Every lock is taken before any verdict is formed. Returning a hold early
+// would skip the attempt lock, and the caller could then not give back the
+// units an earlier Reserve is holding — the account would lose that capacity
+// until midnight for a message it never sent.
+func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (authState, Decision, error) {
+	var st authState
+
+	policy, err := m.effectivePolicy(ctx, tx)
+	if err != nil {
+		return st, Decision{}, err
+	}
+	st.policy = policy
+	// Every operation has a tenant mode; only a customer purpose can have it
+	// raised. Defaulting here rather than per-branch keeps the provenance row's
+	// closed enum satisfiable for the paths that never consider a tenant.
+	st.tenantMode = TenantModeNone
+
+	// Unlocked probe: the account and purpose decide WHICH keys this
+	// transaction must lock, so they have to be known before the ordered
+	// locking begins. Nothing here is used for a verdict — every value a
+	// decision rests on is re-read from the locked rows below.
+	var probeAccount string
+	var probePurpose Purpose
+	if err := tx.QueryRow(ctx, `
+		SELECT COALESCE(source_account_ref, ''), purpose
+		  FROM sending_provider_operations
+		 WHERE operation_id = $1`, ref.operationID,
+	).Scan(&probeAccount, &probePurpose); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return st, Decision{}, ErrSourceUnavailable
+		}
+		return st, Decision{}, fmt.Errorf("sendingpolicy: read operation: %w", err)
+	}
+
+	// The user row is locked for two different reasons, and only one of them
+	// is about authority. Customer traffic needs the class and the account's
+	// live state; an owner-audience notice needs only the current address, and
+	// deliberately does NOT consult that account's control row — an account
+	// that was just paused must still receive the email saying so.
+	var (
+		ownerEmail   string
+		ownerExists  bool
+		controlState = "active"
+		tenantReady  bool
+		tenantName   string
+	)
+	needsOwner := probeAccount != "" && (probePurpose.isCustomer() || probePurpose.isOperational())
+	if needsOwner {
+		// FOR SHARE, not FOR UPDATE: many concurrent authorizations for one
+		// account must proceed together, while an ordinary `UPDATE users` that
+		// changes account_class or the owner address takes the conflicting
+		// lock and serializes at exactly this boundary.
+		err := tx.QueryRow(ctx,
+			`SELECT account_class, email FROM users WHERE id = $1 FOR SHARE`, probeAccount,
+		).Scan(&st.class, &ownerEmail)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			ownerExists = false
+		case err != nil:
+			return st, Decision{}, fmt.Errorf("sendingpolicy: lock user: %w", err)
+		default:
+			ownerExists = true
+		}
+	}
+
+	if probePurpose.isCustomer() && ownerExists {
+		controlState, tenantName, tenantReady, err = ensureAccountControl(ctx, tx, probeAccount)
+		if err != nil {
+			return st, Decision{}, err
+		}
+
+		// The authoritative plan, read directly rather than through the limits
+		// enforcer's 60-second cache. A cached plan is fine for a quota error
+		// message and unacceptable here: a downgrade that committed 40 seconds
+		// ago must bind this decision, and the billing writer takes the same
+		// account-control lock so the two serialize.
+		if err := tx.QueryRow(ctx,
+			`SELECT COALESCE(plan_code, '') FROM account_limits WHERE user_id = $1 FOR SHARE`, probeAccount,
+		).Scan(&st.planCode); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return st, Decision{}, fmt.Errorf("sendingpolicy: lock account limits: %w", err)
+		}
+		st.tenantMode, st.tenantName = tenantModeFor(policy, probeAccount, tenantName)
+	}
+
+	// Notice delivery, when this operation is one. Locked before the provider
+	// operation so the drain worker and a concurrent notice mutation agree on
+	// order.
+	notice, err := m.lockNoticeDelivery(ctx, tx, ref.operationID)
+	if err != nil {
+		return st, Decision{}, err
+	}
+	st.notice = notice
+
+	op, err := lockOperation(ctx, tx, ref.operationID)
+	if err != nil {
+		return st, Decision{}, err
+	}
+	st.op = op
+
+	stored, err := lockReservation(ctx, tx, ref.operationID, ref.attempt)
+	if err != nil {
+		return st, Decision{}, err
+	}
+	st.stored = stored
+
+	// A reference that is not the operation's current ordinal is stale by
+	// definition, and a confirmed attempt has already been authorized once.
+	// Two workers that both observed reserved ordinal N therefore cannot both
+	// get a token: the second finds it confirmed and stops here.
+	if ref.attempt != op.CurrentAttempt {
+		return st, Decision{}, ErrAttemptStale
+	}
+	if stored.Exists && stored.State == "confirmed" {
+		return st, Decision{}, ErrAttemptStale
+	}
+
+	st.day, err = ledgerDay(ctx, tx)
+	if err != nil {
+		return st, Decision{}, err
+	}
+	st.probation = op.Shared
+
+	// Verdicts, now that every key is held.
+	//
+	// Pause is checked independently of the budget mode. A paused account is
+	// explicit operator or detector state, not a computed limit, and an
+	// account paused for abuse must stop sending even in a deployment that has
+	// not armed budgets yet. This is where the pause guarantee linearizes: a
+	// pause that commits first prevents authorization, and an authorization
+	// that commits first may already be entering its one SES call.
+	if op.Purpose.isCustomer() {
+		if !ownerExists {
+			return st, holdDecision(ReasonAccountDeleted, time.Time{}), nil
+		}
+		if controlState == "paused" {
+			return st, holdDecision(ReasonAccountPaused, time.Time{}), nil
+		}
+		if st.tenantMode == TenantModeRequired && !tenantReady {
+			return st, holdDecision(ReasonTenantNotReady, time.Time{}), nil
+		}
+	}
+
+	if notice != nil && notice.audience == AudienceOwner && !ownerExists {
+		// The account this notice was about is gone. There is nobody to tell,
+		// so the delivery is closed rather than retried forever.
+		if err := m.markNoticeSkipped(ctx, tx, notice); err != nil {
+			return st, Decision{}, err
+		}
+		return st, holdDecision(ReasonAccountDeleted, time.Time{}), nil
+	}
+
+	st.envelope, err = m.resolveEnvelope(ctx, tx, op, ref, notice, ownerEmail)
+	if err != nil {
+		return st, Decision{}, err
+	}
+	st.units = len(st.envelope)
+	return st, allowDecision(), nil
+}
+
+// tenantModeFor resolves the tenant-header mode for one account.
+//
+// Canary is an explicit account list rather than a percentage: a tenant header
+// is either sent or not, and the rollout gate wants a named account it can
+// verify end to end, not a sample it has to go looking for.
+func tenantModeFor(policy RuntimePolicy, accountID, tenantName string) (TenantMode, string) {
+	switch policy.TenantHeaderMode {
+	case TenantHeaderEnforce:
+		return TenantModeRequired, tenantName
+	case TenantHeaderCanary:
+		for _, id := range policy.TenantHeaderCanaryAccountIDs {
+			if id == accountID {
+				return TenantModeRequired, tenantName
+			}
+		}
+	}
+	return TenantModeNone, ""
+}
+
+// lockNoticeDelivery locks the delivery row this operation serves, if any.
+func (m *Module) lockNoticeDelivery(ctx context.Context, tx pgx.Tx, operationID string) (*noticeState, error) {
+	var st noticeState
+	var audience, state string
+	err := tx.QueryRow(ctx, `
+		SELECT event_id, audience, delivery_attempt, state
+		  FROM sending_protection_notice_deliveries
+		 WHERE current_operation_id = $1
+		   FOR UPDATE`, operationID,
+	).Scan(&st.eventID, &audience, &st.deliveryAttempt, &state)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sendingpolicy: lock notice delivery: %w", err)
+	}
+	st.audience = Audience(audience)
+	return &st, nil
+}
+
+// markNoticeSkipped closes a delivery whose owner no longer exists.
+func (m *Module) markNoticeSkipped(ctx context.Context, tx pgx.Tx, notice *noticeState) error {
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_protection_notice_deliveries
+		   SET state = 'skipped_account_deleted', updated_at = now()
+		 WHERE event_id = $1 AND audience = $2`,
+		notice.eventID, string(notice.audience),
+	); err != nil {
+		return fmt.Errorf("sendingpolicy: close notice delivery: %w", err)
+	}
+	return nil
+}
+
+// resolveEnvelope produces the exact final recipient set, under the locks that
+// were just taken.
+//
+// Resolution happens here and not at preparation because the answer can change:
+// an account owner can edit their address between the pause being decided and
+// the notice being sent, and the operator mailbox map can be rotated. Binding
+// the address at the last locked moment is what guarantees no notice is mailed
+// to a retired address.
+func (m *Module) resolveEnvelope(ctx context.Context, tx pgx.Tx, op operationRow, ref AttemptRef, notice *noticeState, ownerEmail string) ([]string, error) {
+	switch {
+	case notice != nil && notice.audience == AudienceOperator:
+		version := m.policyOperatorVersion(ctx, tx)
+		if m.secrets.Recipients == nil {
+			return nil, fmt.Errorf("%w: no operator recipient map is loaded", ErrEnvelopeUnavailable)
+		}
+		if err := m.requireSelectedOperatorRecipient(ctx, tx, version); err != nil {
+			return nil, err
+		}
+		mailbox, ok := m.secrets.Recipients.Mailbox(version)
+		if !ok {
+			return nil, ErrOperatorRecipientUnavailable
+		}
+		commitment, _ := m.secrets.Recipients.Commitment(version)
+		notice.version = version
+		notice.commitment = []byte(commitment)
+		return normalizeEnvelope([]string{mailbox})
+
+	case notice != nil:
+		return normalizeEnvelope([]string{ownerEmail})
+
+	case op.Purpose == PurposeCustomerMessage:
+		return messageEnvelope(ctx, tx, op.OperationID)
+
+	case op.Purpose == PurposeCustomerNotification:
+		if ownerEmail == "" {
+			return nil, fmt.Errorf("%w: the notified account has no address", ErrEnvelopeUnavailable)
+		}
+		return normalizeEnvelope([]string{ownerEmail})
+
+	case op.Purpose == PurposePublicFeedback || op.Purpose == PurposeTrustedSystem:
+		envelope, err := normalizeEnvelope(ref.recipients)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrEnvelopeUnavailable, err)
+		}
+		return envelope, nil
+	}
+	return nil, fmt.Errorf("sendingpolicy: unsupported purpose %q", op.Purpose)
+}
+
+// policyOperatorVersion returns the recipient version the current policy
+// selects. The database source is authoritative when it is in use.
+func (m *Module) policyOperatorVersion(ctx context.Context, tx pgx.Tx) int {
+	if m.source == PolicySourceDatabase {
+		if policy, err := m.currentPolicyForShare(ctx, tx); err == nil {
+			return policy.OperatorNoticeRecipientVersion
+		}
+	}
+	return m.configPolicy.OperatorNoticeRecipientVersion
+}
+
+// releaseStoredUnits gives back whatever the stored attempt is holding.
+func (m *Module) releaseStoredUnits(ctx context.Context, tx pgx.Tx, st authState) error {
+	stored := st.stored
+	if !stored.Exists || stored.State != "reserved" {
+		return nil
+	}
+	oldKeys := stored.scopeKeys(st.op.Shared)
+	refs := refsFor(oldKeys, stored.Day)
+	plan, err := lockLedger(ctx, tx, nil, refs)
+	if err != nil {
+		return err
+	}
+	for _, r := range refs {
+		plan.release(r, stored.Units)
+	}
+	if err := plan.flush(ctx, tx); err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		UPDATE sending_budget_reservations
+		   SET state = 'released', call_state = 'none', authorization_nonce = NULL,
+		       provider_call_started_at = NULL, updated_at = now()
+		 WHERE operation_id = $1 AND submission_attempt = $2`,
+		stored.OperationID, stored.Attempt)
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: release reservation: %w", err)
+	}
+	return nil
+}
+
+// reauthorizeBudget releases the attempt's stale units and takes exactly what
+// the current generation, plan, class, and UTC day require.
+//
+// Both halves happen against one ordered set of locked rows, so the release and
+// the acquisition cannot deadlock against each other or against another worker
+// doing the mirror image. A denial leaves the attempt released rather than
+// half-charged: a later fire-time pass re-arms it from scratch.
+func (m *Module) reauthorizeBudget(ctx context.Context, tx pgx.Tx, st authState) (Decision, error) {
+	stored := st.stored
+
+	// Trusted first-party accounts and the disabled budget mode both mean "no
+	// pool applies". They are handled together because the downstream effect
+	// is identical: nothing is charged, and anything an earlier Reserve took
+	// under a different policy is given back.
+	exempt := accountClassExempt(st.class) && st.op.Purpose.isCustomer()
+	if st.policy.BudgetMode == ModeDisabled || exempt || st.op.Purpose == PurposeTrustedSystem {
+		return allowDecision(), m.releaseStoredUnits(ctx, tx, st)
+	}
+
+	currentKeys := scopeKeys(st.op.Purpose, st.op.accountRef(), st.op.Shared, st.probation)
+	create := make(map[ledgerRef]int, len(currentKeys))
+	for _, key := range currentKeys {
+		create[ledgerRef{counterKey: key, Day: st.day}] = limitFor(key, st.policy, st.planCode)
+	}
+
+	var releaseRefs []ledgerRef
+	if stored.Exists && stored.State == "reserved" {
+		releaseRefs = refsFor(stored.scopeKeys(st.op.Shared), stored.Day)
+	}
+
+	plan, err := lockLedger(ctx, tx, create, releaseRefs)
+	if err != nil {
+		return Decision{}, err
+	}
+	for _, r := range releaseRefs {
+		plan.release(r, stored.Units)
+	}
+
+	deniedScope := Scope("")
+	for _, key := range currentKeys {
+		if !plan.acquire(ledgerRef{counterKey: key, Day: st.day}, st.units) {
+			deniedScope = key.Scope
+			if st.policy.BudgetMode == ModeEnforce {
+				break
+			}
+			// Shadow deliberately overruns. Clamping the counter at the limit
+			// would make the shadow window prove only that the limit exists;
+			// what the rollout gate needs is the real aggregate demand, which
+			// is only visible if the counter is allowed past the cap.
+			plan.overrun(ledgerRef{counterKey: key, Day: st.day}, st.units)
+		}
+	}
+
+	if deniedScope != "" && st.policy.BudgetMode == ModeEnforce {
+		// The release is kept; the acquisitions are discarded by not
+		// flushing them. Re-lock nothing: the same plan is reused with only
+		// the release deltas applied.
+		plan.discardAcquisitions()
+		if err := plan.flush(ctx, tx); err != nil {
+			return Decision{}, err
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE sending_budget_reservations
+			   SET state = 'released', call_state = 'none', authorization_nonce = NULL,
+			       provider_call_started_at = NULL, day = $3, units = $4,
+			       probation = $5, updated_at = now()
+			 WHERE operation_id = $1 AND submission_attempt = $2`,
+			st.op.OperationID, stored.Attempt, st.day, st.units, st.probation,
+		); err != nil {
+			return Decision{}, fmt.Errorf("sendingpolicy: release denied reservation: %w", err)
+		}
+		if err := m.recordDenialNotice(ctx, tx, st, deniedScope); err != nil {
+			return Decision{}, err
+		}
+		return holdDecision(holdReasonForScope(deniedScope), nextUTCMidnight(st.day)), nil
+	}
+
+	if deniedScope != "" {
+		log.Printf("[sending-protection] shadow denial: purpose=%s scope=%s operation=%s units=%d",
+			st.op.Purpose, deniedScope, st.op.OperationID, st.units)
+	}
+	if err := plan.flush(ctx, tx); err != nil {
+		return Decision{}, err
+	}
+	return allowDecision(), nil
+}
+
+// authorize confirms the capacity, mints the single-use nonce, records the
+// provenance correlation, and returns the token.
+func (m *Module) authorize(ctx context.Context, tx pgx.Tx, st authState) (*ProviderAuthorization, error) {
+	nonce := randomNonce()
+	attempt := st.stored.Attempt
+	if !st.stored.Exists {
+		attempt = st.op.CurrentAttempt
+	}
+
+	var noticeVersion *int
+	var noticeCommitment []byte
+	var binding *noticeBinding
+	if st.notice != nil {
+		version, commitment, err := m.noticeCommitmentFor(st)
+		if err != nil {
+			return nil, err
+		}
+		noticeVersion, noticeCommitment = &version, commitment
+		binding = &noticeBinding{
+			eventID:             st.notice.eventID,
+			audience:            st.notice.audience,
+			deliveryAttempt:     st.notice.deliveryAttempt,
+			recipientVersion:    version,
+			recipientCommitment: commitment,
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO sending_budget_reservations
+		    (operation_id, submission_attempt, source_account_ref, policy_subject_ref,
+		     purpose, day, units, probation, state, call_state, authorization_nonce,
+		     notice_recipient_version, notice_recipient_commitment)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'confirmed', 'authorized', $9, $10, $11)
+		ON CONFLICT (operation_id, submission_attempt) DO UPDATE
+		   SET day = EXCLUDED.day,
+		       units = EXCLUDED.units,
+		       probation = EXCLUDED.probation,
+		       state = 'confirmed',
+		       call_state = 'authorized',
+		       authorization_nonce = EXCLUDED.authorization_nonce,
+		       notice_recipient_version = EXCLUDED.notice_recipient_version,
+		       notice_recipient_commitment = EXCLUDED.notice_recipient_commitment,
+		       provider_call_started_at = NULL,
+		       updated_at = now()`,
+		st.op.OperationID, attempt, st.op.SourceAccountRef, st.op.PolicySubjectRef,
+		st.op.Purpose, st.day, st.units, st.probation, nonce,
+		noticeVersion, noticeCommitment,
+	); err != nil {
+		return nil, fmt.Errorf("sendingpolicy: confirm reservation: %w", err)
+	}
+
+	// Confirm the counters only after the reservation says confirmed, so a
+	// failure anywhere in this transaction leaves both consistent.
+	if err := m.confirmIfCharged(ctx, tx, st, attempt); err != nil {
+		return nil, err
+	}
+
+	correlationID, err := m.recordCorrelation(ctx, tx, st, attempt)
+	if err != nil {
+		return nil, err
+	}
+	if st.notice != nil {
+		if _, err := tx.Exec(ctx, `
+			UPDATE sending_protection_notice_deliveries
+			   SET delivery_attempt = $3, updated_at = now()
+			 WHERE event_id = $1 AND audience = $2`,
+			st.notice.eventID, string(st.notice.audience), attempt,
+		); err != nil {
+			return nil, fmt.Errorf("sendingpolicy: advance notice delivery: %w", err)
+		}
+	}
+
+	set := make(map[string]struct{}, len(st.envelope))
+	for _, addr := range st.envelope {
+		set[addr] = struct{}{}
+	}
+	return &ProviderAuthorization{
+		attempt:       AttemptRef{operationID: st.op.OperationID, attempt: attempt},
+		correlationID: correlationID,
+		purpose:       st.op.Purpose,
+		nonce:         nonce,
+		recipients:    append([]string(nil), st.envelope...),
+		recipientSet:  set,
+		tenantMode:    st.tenantMode,
+		tenantName:    st.tenantName,
+		notice:        binding,
+	}, nil
+}
+
+// noticeCommitmentFor returns the (version, commitment, hmac key version)
+// triple a notice attempt persists.
+//
+// The two audiences use the same column pair for different proofs, which is
+// what lets one durable shape cover both. An operator delivery commits to the
+// non-secret logical version and its keyed commitment, so a rotation of the
+// mailbox map invalidates the attempt. An owner delivery commits to the HMAC of
+// the address itself under a named key version, so an owner who changes their
+// email invalidates it. Neither stores an address.
+func (m *Module) noticeCommitmentFor(st authState) (int, []byte, error) {
+	if st.notice.audience == AudienceOperator {
+		return st.notice.version, st.notice.commitment, nil
+	}
+	if m.secrets.Keyring == nil {
+		return 0, nil, fmt.Errorf("%w: no feedback keyring is loaded", ErrEnvelopeUnavailable)
+	}
+	if len(st.envelope) != 1 {
+		return 0, nil, fmt.Errorf("%w: an owner notice must have exactly one recipient", ErrEnvelopeUnavailable)
+	}
+	version, mac := m.secrets.Keyring.Sign([]byte(st.envelope[0]))
+	return version, mac, nil
+}
+
+// confirmIfCharged moves this attempt's units from reserved to confirmed on
+// every counter it actually charged.
+func (m *Module) confirmIfCharged(ctx context.Context, tx pgx.Tx, st authState, attempt int) error {
+	exempt := accountClassExempt(st.class) && st.op.Purpose.isCustomer()
+	if st.policy.BudgetMode == ModeDisabled || exempt || st.op.Purpose == PurposeTrustedSystem {
+		return nil
+	}
+	keys := scopeKeys(st.op.Purpose, st.op.accountRef(), st.op.Shared, st.probation)
+	return confirmCounters(ctx, tx, refsFor(keys, st.day), st.units)
+}
+
+// recordCorrelation writes the provenance row this attempt's delivery feedback
+// will later be matched against, plus the keyed HMAC of every recipient.
+//
+// Recipients are stored only as HMACs. The detector needs to count outcomes per
+// recipient, which requires a stable identifier, but it never needs to read an
+// address — and a table of customer contact addresses that outlives the message
+// is exactly the asset that must not exist.
+func (m *Module) recordCorrelation(ctx context.Context, tx pgx.Tx, st authState, attempt int) (string, error) {
+	// The DURABLE row decides the correlation ID, not the value this call
+	// happened to mint. The ID travels to SES as a header and comes back on
+	// every delivery event, so a token carrying an ID that no row holds would
+	// produce feedback nothing could ever be matched to — the failure would be
+	// invisible until the detector had been silently blind for days.
+	var correlationID string
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO sending_feedback_correlations
+		    (correlation_id, operation_id, submission_attempt, source_account_ref,
+		     policy_subject_ref, purpose, shared_reputation, tenant_mode)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (operation_id, submission_attempt) DO UPDATE
+		    SET operation_id = EXCLUDED.operation_id
+		RETURNING correlation_id`,
+		randomID("cor_"), st.op.OperationID, attempt, st.op.SourceAccountRef,
+		st.op.PolicySubjectRef, st.op.Purpose, st.op.Shared, string(st.tenantMode),
+	).Scan(&correlationID); err != nil {
+		return "", fmt.Errorf("sendingpolicy: record correlation: %w", err)
+	}
+
+	if m.secrets.Keyring == nil {
+		// A self-host with every control disabled legitimately has no keyring;
+		// there is nothing to correlate because no detector runs.
+		return correlationID, nil
+	}
+	for _, addr := range st.envelope {
+		version, mac := m.secrets.Keyring.Sign([]byte(addr))
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO sending_feedback_recipients (correlation_id, recipient_hmac, hmac_key_version)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (correlation_id, recipient_hmac) DO NOTHING`,
+			correlationID, mac, version,
+		); err != nil {
+			return "", fmt.Errorf("sendingpolicy: record recipient provenance: %w", err)
+		}
+	}
+	return correlationID, nil
+}
+
+// recordDenialNotice enqueues the notice an enforced denial owes, exactly once
+// per account, scope, and UTC day.
+//
+// The three cases are deliberately asymmetric. An account-owned scope is the
+// customer's own violation, so both the owner and the operator hear about it. A
+// global pool is a platform incident that innocent accounts merely happened to
+// collide with, so it produces one coalesced operator notice and blames nobody.
+// An operational purpose produces nothing at all: a notice that cannot be sent
+// because the notice pool is exhausted must not enqueue another notice.
+func (m *Module) recordDenialNotice(ctx context.Context, tx pgx.Tx, st authState, scope Scope) error {
+	if st.op.Purpose.isOperational() {
+		return nil
+	}
+
+	retention := time.Duration(st.policy.SendingControlAuditRetentionDays) * 24 * time.Hour
+	expires := time.Now().UTC().Add(retention)
+
+	switch scope {
+	case ScopeAccountDaily, ScopeAccountSharedDaily:
+		account := st.op.accountRef()
+		if account == "" {
+			return nil
+		}
+		var eventID string
+		err := tx.QueryRow(ctx, `
+			INSERT INTO sending_protection_notice_events
+			    (id, account_ref, kind, reason_code, budget_scope, ledger_day, expires_at)
+			VALUES ($1, $2, 'budget_violation', 'budget_limit', $3, $4, $5)
+			ON CONFLICT (account_ref, budget_scope, ledger_day)
+			    WHERE kind = 'budget_violation'
+			    DO NOTHING
+			RETURNING id`,
+			randomID("spn_"), account, string(scope), st.day, expires,
+		).Scan(&eventID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Already enqueued for this account, scope, and day. Later holds
+			// for the same tuple deliberately enqueue nothing: one violation
+			// email per day per failed scope, not one per held message.
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("sendingpolicy: enqueue violation notice: %w", err)
+		}
+		return insertNoticeDeliveries(ctx, tx, eventID, AudienceOwner, AudienceOperator)
+
+	case ScopeGlobalAll, ScopeGlobalProbation:
+		var eventID string
+		err := tx.QueryRow(ctx, `
+			INSERT INTO sending_protection_notice_events
+			    (id, account_ref, kind, reason_code, budget_scope, ledger_day, expires_at)
+			VALUES ($1, NULL, 'global_guardrail', 'global_budget_exhausted', $2, $3, $4)
+			ON CONFLICT (budget_scope, ledger_day)
+			    WHERE kind = 'global_guardrail'
+			    DO NOTHING
+			RETURNING id`,
+			randomID("spn_"), string(scope), st.day, expires,
+		).Scan(&eventID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("sendingpolicy: enqueue guardrail notice: %w", err)
+		}
+		return insertNoticeDeliveries(ctx, tx, eventID, AudienceOperator)
+	}
+	return nil
+}
+
+// insertNoticeDeliveries creates the outbox rows for one event.
+func insertNoticeDeliveries(ctx context.Context, tx pgx.Tx, eventID string, audiences ...Audience) error {
+	for _, audience := range audiences {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO sending_protection_notice_deliveries (event_id, audience)
+			VALUES ($1, $2)
+			ON CONFLICT (event_id, audience) DO NOTHING`,
+			eventID, string(audience),
+		); err != nil {
+			return fmt.Errorf("sendingpolicy: enqueue notice delivery: %w", err)
+		}
+	}
+	return nil
+}
+
+// RedeemProviderCall consumes the single-use authorization immediately before
+// the socket opens.
+//
+// It exists because ConsumeAttempt's transaction has committed by the time the
+// adapter runs, and everything it checked can have changed in the meantime.
+// Re-proving the whole chain here — policy, owner, delivery, operation,
+// ordinal, nonce, recipient selector — costs one short transaction and closes
+// the window in which an owner edit, a policy rotation, a supersession, or a
+// mixed-slot secret rotation could mail a retired address.
+func (m *Module) RedeemProviderCall(ctx context.Context, auth ProviderAuthorization) error {
+	if auth.IsZero() || auth.nonce == "" {
+		return ErrAuthorizationInvalid
+	}
+
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: begin redeem: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := m.effectivePolicy(ctx, tx); err != nil {
+		return err
+	}
+
+	var ownerEmail string
+	if auth.notice != nil && auth.notice.audience == AudienceOwner {
+		if err := tx.QueryRow(ctx, `
+			SELECT users.email
+			  FROM sending_protection_notice_events AS event
+			  JOIN users ON users.id = event.account_ref
+			 WHERE event.id = $1
+			   FOR SHARE OF users`, auth.notice.eventID,
+		).Scan(&ownerEmail); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return m.invalidate(ctx, tx, auth.attempt)
+			}
+			return fmt.Errorf("sendingpolicy: lock notice owner: %w", err)
+		}
+	}
+
+	if auth.notice != nil {
+		var boundOperation *string
+		if err := tx.QueryRow(ctx, `
+			SELECT current_operation_id
+			  FROM sending_protection_notice_deliveries
+			 WHERE event_id = $1 AND audience = $2
+			   FOR UPDATE`, auth.notice.eventID, string(auth.notice.audience),
+		).Scan(&boundOperation); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return m.invalidate(ctx, tx, auth.attempt)
+			}
+			return fmt.Errorf("sendingpolicy: lock notice delivery: %w", err)
+		}
+		if boundOperation == nil || *boundOperation != auth.attempt.operationID {
+			return m.invalidate(ctx, tx, auth.attempt)
+		}
+	}
+
+	op, err := lockOperation(ctx, tx, auth.attempt.operationID)
+	if err != nil {
+		return err
+	}
+	if op.CurrentAttempt != auth.attempt.attempt {
+		return m.invalidate(ctx, tx, auth.attempt)
+	}
+
+	stored, err := lockReservation(ctx, tx, auth.attempt.operationID, auth.attempt.attempt)
+	if err != nil {
+		return err
+	}
+	if !stored.Exists || stored.CallState != "authorized" || stored.Nonce == nil || *stored.Nonce != auth.nonce {
+		return m.invalidate(ctx, tx, auth.attempt)
+	}
+
+	if auth.notice != nil {
+		ok, err := m.noticeSelectorStillCurrent(ctx, tx, auth, stored, ownerEmail)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return m.invalidate(ctx, tx, auth.attempt)
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_budget_reservations
+		   SET call_state = 'started', provider_call_started_at = now(), updated_at = now()
+		 WHERE operation_id = $1 AND submission_attempt = $2 AND call_state = 'authorized'`,
+		auth.attempt.operationID, auth.attempt.attempt,
+	); err != nil {
+		return fmt.Errorf("sendingpolicy: redeem authorization: %w", err)
+	}
+	return m.commit(ctx, tx, "redeem")
+}
+
+// noticeSelectorStillCurrent re-proves that the recipient this token was built
+// for is still the recipient the system would choose right now.
+func (m *Module) noticeSelectorStillCurrent(ctx context.Context, tx pgx.Tx, auth ProviderAuthorization, stored reservationRow, ownerEmail string) (bool, error) {
+	if stored.NoticeVersion == nil || len(stored.NoticeCommitment) == 0 {
+		return false, nil
+	}
+	if auth.notice.audience == AudienceOperator {
+		if m.secrets.Recipients == nil {
+			return false, nil
+		}
+		version := m.policyOperatorVersion(ctx, tx)
+		if version != *stored.NoticeVersion || version != auth.notice.recipientVersion {
+			return false, nil
+		}
+		commitment, ok := m.secrets.Recipients.Commitment(version)
+		if !ok || commitment != string(stored.NoticeCommitment) || commitment != string(auth.notice.recipientCommitment) {
+			return false, nil
+		}
+		return true, nil
+	}
+
+	if m.secrets.Keyring == nil {
+		return false, nil
+	}
+	normalized, err := normalizeEnvelope([]string{ownerEmail})
+	if err != nil {
+		return false, nil
+	}
+	if !m.secrets.Keyring.Verify(*stored.NoticeVersion, []byte(normalized[0]), stored.NoticeCommitment) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// invalidate retires an attempt whose final recheck failed, forcing a strictly
+// greater ordinal before any provider call.
+//
+// The confirmed capacity is deliberately not refunded. The attempt was charged
+// because a socket might open; discovering at the last moment that it must not
+// is a reason to stop, not a reason to hand back reputation exposure that a
+// retry will immediately re-consume.
+func (m *Module) invalidate(ctx context.Context, tx pgx.Tx, ref AttemptRef) error {
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_provider_operations
+		   SET current_attempt = GREATEST(current_attempt, $2) + 1, updated_at = now()
+		 WHERE operation_id = $1`, ref.operationID, ref.attempt,
+	); err != nil {
+		return fmt.Errorf("sendingpolicy: invalidate attempt: %w", err)
+	}
+	if err := m.commit(ctx, tx, "invalidate"); err != nil {
+		return err
+	}
+	return ErrAuthorizationInvalid
+}
+
+// DeferAttempt gives back only the sending budget for a rate deferral.
+//
+// The ramp reservation is deliberately retained: a message deferred by the
+// per-agent rate limiter has not been rejected by the provider and has not
+// used a ramp day, so releasing its ramp claim would let the same message
+// re-qualify a stage it already qualified.
+func (m *Module) DeferAttempt(ctx context.Context, ref AttemptRef) error {
+	return m.releaseAttempt(ctx, ref, "defer")
+}
+
+// CancelAttempt gives back both ledgers for a terminal local cancellation such
+// as a suppression match.
+func (m *Module) CancelAttempt(ctx context.Context, ref AttemptRef) error {
+	// The ramp half arrives with Task 4's adapter; until the ramp is composed
+	// into final authorization there is no ramp reservation for this module
+	// to release, and the existing message-keyed ledger stays with its
+	// current owner.
+	return m.releaseAttempt(ctx, ref, "cancel")
+}
+
+// releaseAttempt is the shared release path. Both callers are valid only while
+// provider I/O is provably not begun; once a socket has opened, the capacity is
+// spent whatever the outcome.
+func (m *Module) releaseAttempt(ctx context.Context, ref AttemptRef, what string) error {
+	if ref.IsZero() {
+		return ErrSourceUnavailable
+	}
+
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: begin %s: %w", what, err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := m.effectivePolicy(ctx, tx); err != nil {
+		return err
+	}
+	op, err := lockOperation(ctx, tx, ref.operationID)
+	if err != nil {
+		return err
+	}
+	stored, err := lockReservation(ctx, tx, ref.operationID, ref.attempt)
+	if err != nil {
+		return err
+	}
+	if !stored.Exists {
+		return ErrAttemptStale
+	}
+	if stored.CallState == "started" {
+		return ErrProviderCallStarted
+	}
+	if stored.State == "confirmed" {
+		// The attempt was already authorized, so its capacity is irrevocably
+		// spent whether or not a socket followed. Marking it released here
+		// would leave the row disagreeing with the counter — the counter's
+		// confirmed floor correctly refuses the refund, so the row would claim
+		// a give-back that never happened. The worker order puts both callers
+		// BEFORE final authorization, so reaching this is a caller bug; the
+		// honest answer is that this ordinal is finished and the next provider
+		// opportunity needs a new one.
+		return ErrAttemptStale
+	}
+	if stored.State == "released" {
+		// Already given back. Releases run on retry-prone paths, so repeating
+		// one must be a no-op rather than an error or a double refund.
+		return m.commit(ctx, tx, what)
+	}
+
+	refs := refsFor(stored.scopeKeys(op.Shared), stored.Day)
+	plan, err := lockLedger(ctx, tx, nil, refs)
+	if err != nil {
+		return err
+	}
+	for _, r := range refs {
+		plan.release(r, stored.Units)
+	}
+	if err := plan.flush(ctx, tx); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_budget_reservations
+		   SET state = 'released', call_state = 'none', authorization_nonce = NULL,
+		       provider_call_started_at = NULL, updated_at = now()
+		 WHERE operation_id = $1 AND submission_attempt = $2`,
+		ref.operationID, ref.attempt,
+	); err != nil {
+		return fmt.Errorf("sendingpolicy: %s reservation: %w", what, err)
+	}
+	return m.commit(ctx, tx, what)
+}
+
+// SettleProvider records an authoritative provider outcome.
+//
+// It changes only the custom-domain ramp ledger, never the sending budget: the
+// budget was spent when the attempt was authorized, and SES rejecting a message
+// does not give back the reputation exposure of having asked. Idempotent by
+// construction, because both the synchronous success branch and the delayed
+// delivery-feedback finalizer call it for the same attempt.
+func (m *Module) SettleProvider(ctx context.Context, settlement ProviderSettlement) error {
+	if settlement.Attempt.IsZero() {
+		return ErrSourceUnavailable
+	}
+	if !settlement.Outcome.valid() {
+		return fmt.Errorf("sendingpolicy: unsupported settlement outcome %q", settlement.Outcome)
+	}
+
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: begin settle: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := lockOperation(ctx, tx, settlement.Attempt.operationID); err != nil {
+		return err
+	}
+	stored, err := lockReservation(ctx, tx, settlement.Attempt.operationID, settlement.Attempt.attempt)
+	if err != nil {
+		return err
+	}
+	if !stored.Exists {
+		return ErrAttemptStale
+	}
+
+	// The ramp ledger is Task 4's to move. Validating the attempt here — and
+	// taking its locks in the normative order — is what makes that composition
+	// a body change rather than a reshaping of the interface every caller
+	// already uses.
+	return m.commit(ctx, tx, "settle")
+}

--- a/internal/sendingpolicy/operations.go
+++ b/internal/sendingpolicy/operations.go
@@ -1,0 +1,474 @@
+package sendingpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// This file turns a durable source row into a provider operation: the record
+// that says who is about to be charged, on whose authority, and whether the
+// traffic borrows platform reputation.
+//
+// Everything a later decision depends on is derived here, under a lock on the
+// source, and then persisted as immutable. That is deliberate. Purpose,
+// attribution, and the shared-reputation class are exactly the fields an
+// attacker would want to change between acceptance and submission — relabel
+// customer mail as operational, point attribution at another account, or claim
+// a dedicated domain to escape the 50/day shared cap. Deriving them once from a
+// locked row, and never reading them from a caller argument, River payload, or
+// MIME header again, is what makes those attacks structurally unavailable
+// rather than merely unimplemented.
+
+// operationTTL is how long a provider operation and its attempts stay
+// referencable. It matches the 30-day window migration 113 used when it
+// adopted legacy jobs; the janitor in Task 12 reaps past it.
+const operationTTL = 30 * 24 * time.Hour
+
+// Sentinel errors for the preparation surface.
+var (
+	// ErrSourceUnavailable means the referenced durable source row is absent,
+	// deleted, or not of the shape its constructor promised. It is always
+	// fail-closed: no operation is created, so no provider call can follow.
+	ErrSourceUnavailable = errors.New("sendingpolicy: notification source is unavailable")
+	// ErrAudienceNotAllowed means a notice event was asked for an audience its
+	// kind forbids — the global guardrail has no owner to blame.
+	ErrAudienceNotAllowed = errors.New("sendingpolicy: audience is not allowed for this notice")
+)
+
+// operationRow is one row of sending_provider_operations.
+type operationRow struct {
+	OperationID      string
+	SourceAccountRef *string
+	PolicySubjectRef string
+	Purpose          Purpose
+	Shared           bool
+	CurrentAttempt   int
+}
+
+// ref rebuilds the caller-facing reference from stored, authoritative values.
+func (o operationRow) ref() OperationRef {
+	ref := OperationRef{
+		id:            o.OperationID,
+		purpose:       o.Purpose,
+		policySubject: o.PolicySubjectRef,
+		shared:        o.Shared,
+	}
+	if o.SourceAccountRef != nil {
+		ref.sourceAccount = *o.SourceAccountRef
+	}
+	return ref
+}
+
+// accountRef returns the attributed account, or "" when there is none.
+func (o operationRow) accountRef() string {
+	if o.SourceAccountRef == nil {
+		return ""
+	}
+	return *o.SourceAccountRef
+}
+
+// lockOperation reads and locks one provider operation.
+func lockOperation(ctx context.Context, tx pgx.Tx, id string) (operationRow, error) {
+	var row operationRow
+	err := tx.QueryRow(ctx, `
+		SELECT operation_id, source_account_ref, policy_subject_ref, purpose,
+		       shared_reputation, current_attempt
+		  FROM sending_provider_operations
+		 WHERE operation_id = $1
+		   FOR UPDATE`, id,
+	).Scan(&row.OperationID, &row.SourceAccountRef, &row.PolicySubjectRef,
+		&row.Purpose, &row.Shared, &row.CurrentAttempt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return operationRow{}, ErrSourceUnavailable
+	}
+	if err != nil {
+		return operationRow{}, fmt.Errorf("sendingpolicy: lock operation: %w", err)
+	}
+	// A purpose this binary does not implement can only have been written by a
+	// newer one. Guessing which pools it should charge is the one mistake that
+	// silently un-budgets traffic during a mixed-version rollout, so an
+	// unknown purpose fails closed instead.
+	if !row.Purpose.valid() {
+		return operationRow{}, fmt.Errorf("sendingpolicy: operation %s has unsupported purpose %q",
+			row.OperationID, row.Purpose)
+	}
+	return row, nil
+}
+
+// insertOperation creates one operation, or returns the existing row when the
+// caller's ID is already taken. Idempotency is by operation ID, which each
+// constructor derives from something stable about its source.
+func insertOperation(ctx context.Context, tx pgx.Tx, row operationRow, notBefore time.Time) (operationRow, error) {
+	expires := time.Now().UTC()
+	if notBefore.After(expires) {
+		expires = notBefore.UTC()
+	}
+	expires = expires.Add(operationTTL)
+
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO sending_provider_operations
+		    (operation_id, source_account_ref, policy_subject_ref, purpose,
+		     shared_reputation, current_attempt, expires_at)
+		VALUES ($1, $2, $3, $4, $5, 1, $6)
+		ON CONFLICT (operation_id) DO NOTHING`,
+		row.OperationID, row.SourceAccountRef, row.PolicySubjectRef,
+		row.Purpose, row.Shared, expires,
+	)
+	if err != nil {
+		return operationRow{}, fmt.Errorf("sendingpolicy: create operation: %w", err)
+	}
+	if tag.RowsAffected() == 1 {
+		row.CurrentAttempt = 1
+		return row, nil
+	}
+	// Already present: return the stored values, never the caller's. A repeat
+	// preparation of the same source must not be able to re-derive a different
+	// purpose or attribution and have it silently believed.
+	return lockOperation(ctx, tx, row.OperationID)
+}
+
+// ensureAccountControl creates the account's sending-control row when absent
+// and returns its current state, holding the row lock.
+//
+// Creating it here — rather than at signup — is what guarantees every account
+// that has ever tried to send has budget and detector state, including accounts
+// created before this system existed and accounts created by a code path that
+// forgets. The row is the account's sending identity; a missing one must never
+// read as "no restrictions".
+func ensureAccountControl(ctx context.Context, tx pgx.Tx, userID string) (state string, tenantName string, tenantReady bool, err error) {
+	err = tx.QueryRow(ctx, `
+		INSERT INTO account_sending_controls (user_id)
+		VALUES ($1)
+		ON CONFLICT (user_id) DO UPDATE SET user_id = EXCLUDED.user_id
+		RETURNING state, ses_tenant_name, ses_tenant_ready`, userID,
+	).Scan(&state, &tenantName, &tenantReady)
+	if err != nil {
+		return "", "", false, fmt.Errorf("sendingpolicy: ensure account control: %w", err)
+	}
+	return state, tenantName, tenantReady, nil
+}
+
+// PrepareExternalTx derives the provider operation for an accepted outbound
+// customer message, inside the same transaction that durably inserts it.
+//
+// It returns an acceptance verdict rather than a budget verdict on purpose.
+// Budgets are decided immediately before the provider call, so a customer who
+// has used today's allowance still gets their message queued and sent after
+// midnight; only a paused account is refused at the door, because queueing mail
+// that can never leave is worse than saying no.
+func (m *Module) PrepareExternalTx(ctx context.Context, tx pgx.Tx, messageID string) (AcceptanceDecision, OperationRef, error) {
+	if strings.TrimSpace(messageID) == "" {
+		return "", OperationRef{}, ErrSourceUnavailable
+	}
+
+	// Agent before message, matching migration 113 and the irreversible
+	// deletion path: deletion locks an agent and then its messages, so taking
+	// them in the other order here would deadlock against a concurrent purge.
+	var agentID string
+	err := tx.QueryRow(ctx,
+		`SELECT agent_id FROM messages WHERE id = $1 AND direction = 'outbound'`, messageID,
+	).Scan(&agentID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", OperationRef{}, ErrSourceUnavailable
+	}
+	if err != nil {
+		return "", OperationRef{}, fmt.Errorf("sendingpolicy: read message: %w", err)
+	}
+
+	var userID string
+	err = tx.QueryRow(ctx,
+		`SELECT user_id FROM agent_identities WHERE id = $1 FOR UPDATE`, agentID,
+	).Scan(&userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", OperationRef{}, ErrSourceUnavailable
+	}
+	if err != nil {
+		return "", OperationRef{}, fmt.Errorf("sendingpolicy: lock agent: %w", err)
+	}
+
+	// Recheck identity and direction under the message lock. Between the
+	// unlocked read above and this one the row could have been retargeted or
+	// removed; attribution must come from the locked tuple.
+	var sentAs, method *string
+	var scheduledAt *time.Time
+	err = tx.QueryRow(ctx, `
+		SELECT sent_as, method, scheduled_at
+		  FROM messages
+		 WHERE id = $1 AND agent_id = $2 AND direction = 'outbound'
+		   FOR UPDATE`, messageID, agentID,
+	).Scan(&sentAs, &method, &scheduledAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", OperationRef{}, ErrSourceUnavailable
+	}
+	if err != nil {
+		return "", OperationRef{}, fmt.Errorf("sendingpolicy: lock message: %w", err)
+	}
+
+	state, _, _, err := ensureAccountControl(ctx, tx, userID)
+	if err != nil {
+		return "", OperationRef{}, err
+	}
+	if state == "paused" {
+		return AcceptanceSendingPaused, OperationRef{}, nil
+	}
+
+	// An exact agent-to-itself local delivery never reaches SES, so it gets no
+	// provider operation and consumes nothing. The zero reference is the
+	// contract: a caller holding one has nothing to reserve, which is exactly
+	// right for a message that will never open a socket.
+	if method != nil && *method == "loopback" {
+		return AcceptanceAccept, OperationRef{}, nil
+	}
+
+	notBefore := time.Time{}
+	if scheduledAt != nil {
+		notBefore = *scheduledAt
+	}
+	row, err := insertOperation(ctx, tx, operationRow{
+		OperationID:      messageID,
+		SourceAccountRef: &userID,
+		PolicySubjectRef: userID,
+		Purpose:          PurposeCustomerMessage,
+		Shared:           sharedFromSentAs(sentAs),
+	}, notBefore)
+	if err != nil {
+		return "", OperationRef{}, err
+	}
+	return AcceptanceAccept, row.ref(), nil
+}
+
+// sharedFromSentAs classifies a message's reputation surface from the
+// server-owned sent_as column.
+//
+// Unknown reads as shared. `own_address` is the only value that proves the
+// customer's own verified domain carried the mail; anything else — the shared
+// relay, a legacy row written before the column existed, a future value this
+// binary does not know — is treated as borrowing platform reputation, which
+// only ever tightens the applicable cap. Guessing the other way would hand a
+// 50/day exemption to whatever wrote an unexpected value.
+func sharedFromSentAs(sentAs *string) bool {
+	return sentAs == nil || *sentAs != "own_address"
+}
+
+// PrepareNotificationTx derives the provider operation for platform mail a
+// customer's own action triggered.
+//
+// These are attributed to and budgeted against the triggering customer, not the
+// platform, because a customer controls how much of this mail exists: every
+// held message is an approval email and every failing webhook is a health
+// warning. Their From identity is platform-owned, so they also carry the shared
+// reputation class and the stricter shared-domain cap that comes with it.
+func (m *Module) PrepareNotificationTx(ctx context.Context, tx pgx.Tx, ref NotificationRef) (OperationRef, error) {
+	if strings.TrimSpace(ref.id) == "" {
+		return OperationRef{}, ErrSourceUnavailable
+	}
+
+	var userID string
+	var err error
+	switch ref.source {
+	case NotificationHITLMessage:
+		userID, err = lockHITLSourceOwner(ctx, tx, ref.id)
+	case NotificationWebhookHealth:
+		err = tx.QueryRow(ctx,
+			`SELECT user_id FROM webhooks WHERE id = $1 FOR UPDATE`, ref.id,
+		).Scan(&userID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			err = ErrSourceUnavailable
+		}
+	default:
+		return OperationRef{}, ErrSourceUnavailable
+	}
+	if err != nil {
+		if errors.Is(err, ErrSourceUnavailable) {
+			return OperationRef{}, err
+		}
+		return OperationRef{}, fmt.Errorf("sendingpolicy: lock notification source: %w", err)
+	}
+
+	if _, _, _, err := ensureAccountControl(ctx, tx, userID); err != nil {
+		return OperationRef{}, err
+	}
+
+	row, err := insertOperation(ctx, tx, operationRow{
+		OperationID:      randomID("op_"),
+		SourceAccountRef: &userID,
+		PolicySubjectRef: userID,
+		Purpose:          PurposeCustomerNotification,
+		Shared:           true,
+	}, time.Time{})
+	if err != nil {
+		return OperationRef{}, err
+	}
+	return row.ref(), nil
+}
+
+// lockHITLSourceOwner resolves and locks the owner of a pending message.
+func lockHITLSourceOwner(ctx context.Context, tx pgx.Tx, messageID string) (string, error) {
+	var agentID string
+	err := tx.QueryRow(ctx,
+		`SELECT agent_id FROM messages WHERE id = $1 AND direction = 'outbound'`, messageID,
+	).Scan(&agentID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrSourceUnavailable
+	}
+	if err != nil {
+		return "", err
+	}
+
+	var userID string
+	err = tx.QueryRow(ctx,
+		`SELECT user_id FROM agent_identities WHERE id = $1 FOR UPDATE`, agentID,
+	).Scan(&userID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrSourceUnavailable
+	}
+	if err != nil {
+		return "", err
+	}
+
+	var exists bool
+	err = tx.QueryRow(ctx, `
+		SELECT true FROM messages
+		 WHERE id = $1 AND agent_id = $2 AND direction = 'outbound'
+		   FOR UPDATE`, messageID, agentID,
+	).Scan(&exists)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrSourceUnavailable
+	}
+	if err != nil {
+		return "", err
+	}
+	return userID, nil
+}
+
+// PrepareProtectionNoticeTx allocates or resumes the one stable operation for a
+// committed notice event and audience.
+//
+// Stability is the point. A pause notice may be retried for days; every
+// physical retry must be a greater submission ordinal on the SAME operation, so
+// that the ledger can prove at most one socket per ordinal and so a retry can
+// never mint a second logical notice. Deliberately no recipient is resolved
+// here: the owner address is whatever it is at final authorization, and binding
+// it now would mail a retired address after a legitimate account edit.
+func (m *Module) PrepareProtectionNoticeTx(ctx context.Context, tx pgx.Tx, ref ProtectionNoticeRef) (OperationRef, error) {
+	if strings.TrimSpace(ref.eventID) == "" || !ref.audience.valid() {
+		return OperationRef{}, ErrSourceUnavailable
+	}
+
+	var kind string
+	var accountRef *string
+	var existingOperation *string
+	var state string
+	err := tx.QueryRow(ctx, `
+		SELECT event.kind, event.account_ref, delivery.current_operation_id, delivery.state
+		  FROM sending_protection_notice_deliveries AS delivery
+		  JOIN sending_protection_notice_events AS event ON event.id = delivery.event_id
+		 WHERE delivery.event_id = $1 AND delivery.audience = $2
+		   FOR UPDATE OF delivery`, ref.eventID, string(ref.audience),
+	).Scan(&kind, &accountRef, &existingOperation, &state)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return OperationRef{}, ErrSourceUnavailable
+	}
+	if err != nil {
+		return OperationRef{}, fmt.Errorf("sendingpolicy: lock notice delivery: %w", err)
+	}
+
+	// A global guardrail incident has no customer to blame, so it has no owner
+	// to mail. The schema already forbids the row; refusing here as well means
+	// the invariant holds even if a future migration relaxes the constraint.
+	if kind == "global_guardrail" && ref.audience == AudienceOwner {
+		return OperationRef{}, ErrAudienceNotAllowed
+	}
+
+	if existingOperation != nil && *existingOperation != "" {
+		row, err := lockOperation(ctx, tx, *existingOperation)
+		if err != nil {
+			return OperationRef{}, err
+		}
+		return row.ref(), nil
+	}
+
+	purpose := PurposeViolationOperational
+	if kind == "pause" {
+		purpose = PurposeCriticalOperational
+	}
+
+	// The affected customer is the SOURCE of the notice, never its authority.
+	// A paused account must still receive the email telling it that it was
+	// paused, so the policy subject is the fixed system account whose state no
+	// customer action can change.
+	row, err := insertOperation(ctx, tx, operationRow{
+		OperationID:      randomID("opn_"),
+		SourceAccountRef: accountRef,
+		PolicySubjectRef: SystemPolicySubject,
+		Purpose:          purpose,
+		Shared:           false,
+	}, time.Time{})
+	if err != nil {
+		return OperationRef{}, err
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_protection_notice_deliveries
+		   SET current_operation_id = $3, updated_at = now()
+		 WHERE event_id = $1 AND audience = $2`,
+		ref.eventID, string(ref.audience), row.OperationID,
+	); err != nil {
+		return OperationRef{}, fmt.Errorf("sendingpolicy: bind notice operation: %w", err)
+	}
+	return row.ref(), nil
+}
+
+// PreparePublicFeedback derives the operation for one /api/feedback fan-out.
+//
+// The unauthenticated endpoint has no account to charge, but its mail leaves
+// through the same provider and damages the same reputation, so it consumes the
+// platform and probation pools. Neither the recipient set nor the purpose comes
+// from the request: the submission ID is server-minted and the envelope is
+// configuration, which is what stops the form from becoming an open relay.
+func (m *Module) PreparePublicFeedback(ctx context.Context, ref PublicFeedbackRef) (OperationRef, error) {
+	if strings.TrimSpace(ref.submissionID) == "" {
+		return OperationRef{}, ErrSourceUnavailable
+	}
+	recipients, err := normalizeEnvelope(ref.recipients)
+	if err != nil {
+		return OperationRef{}, err
+	}
+
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return OperationRef{}, fmt.Errorf("sendingpolicy: begin public feedback: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	row, err := insertOperation(ctx, tx, operationRow{
+		// Keyed by the submission so a handler retry inside one request
+		// reuses the operation rather than minting a second one that would
+		// charge the pools twice for the same feedback.
+		OperationID:      "opf_" + ref.submissionID,
+		SourceAccountRef: nil,
+		PolicySubjectRef: SystemPolicySubject,
+		Purpose:          PurposePublicFeedback,
+		Shared:           false,
+	}, time.Time{})
+	if err != nil {
+		return OperationRef{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return OperationRef{}, fmt.Errorf("sendingpolicy: commit public feedback: %w", err)
+	}
+
+	out := row.ref()
+	// The configured envelope rides on the in-memory reference because there
+	// is nowhere durable to re-derive it from and nothing that should:
+	// public feedback runs inside one request's bounded retry loop and never
+	// crosses a process boundary. A reference deserialized from anywhere else
+	// arrives without recipients and is refused at final authorization.
+	out.recipients = recipients
+	return out, nil
+}

--- a/internal/sendingpolicy/operations.go
+++ b/internal/sendingpolicy/operations.go
@@ -38,6 +38,9 @@ var (
 	// ErrAudienceNotAllowed means a notice event was asked for an audience its
 	// kind forbids — the global guardrail has no owner to blame.
 	ErrAudienceNotAllowed = errors.New("sendingpolicy: audience is not allowed for this notice")
+	// ErrNoticeSettled means the notice delivery already reached a terminal
+	// state, so there is nothing left to send.
+	ErrNoticeSettled = errors.New("sendingpolicy: notice delivery is already settled")
 )
 
 // operationRow is one row of sending_provider_operations.
@@ -196,12 +199,16 @@ func (m *Module) PrepareExternalTx(ctx context.Context, tx pgx.Tx, messageID str
 	// removed; attribution must come from the locked tuple.
 	var sentAs, method *string
 	var scheduledAt *time.Time
+	var toCount, ccCount, bccCount int
 	err = tx.QueryRow(ctx, `
-		SELECT sent_as, method, scheduled_at
+		SELECT sent_as, method, scheduled_at,
+		       COALESCE(cardinality(to_recipients), 0),
+		       COALESCE(cardinality(cc), 0),
+		       COALESCE(cardinality(bcc), 0)
 		  FROM messages
 		 WHERE id = $1 AND agent_id = $2 AND direction = 'outbound'
 		   FOR UPDATE`, messageID, agentID,
-	).Scan(&sentAs, &method, &scheduledAt)
+	).Scan(&sentAs, &method, &scheduledAt, &toCount, &ccCount, &bccCount)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", OperationRef{}, ErrSourceUnavailable
 	}
@@ -221,7 +228,13 @@ func (m *Module) PrepareExternalTx(ctx context.Context, tx pgx.Tx, messageID str
 	// provider operation and consumes nothing. The zero reference is the
 	// contract: a caller holding one has nothing to reserve, which is exactly
 	// right for a message that will never open a socket.
-	if method != nil && *method == "loopback" {
+	//
+	// The exemption is granted on the message's SHAPE, not on its label. A
+	// `method` column saying "loopback" is one write away from being the whole
+	// bypass, so the row must also look like the only thing the spec exempts:
+	// exactly one To and no Cc or Bcc. Anything else is treated as ordinary
+	// provider-bound mail and budgeted.
+	if method != nil && *method == "loopback" && toCount == 1 && ccCount == 0 && bccCount == 0 {
 		return AcceptanceAccept, OperationRef{}, nil
 	}
 
@@ -331,10 +344,15 @@ func lockHITLSourceOwner(ctx context.Context, tx pgx.Tx, messageID string) (stri
 		return "", err
 	}
 
+	// Recheck identity, direction AND review state under the lock. A
+	// notification is owed only for a message actually awaiting approval;
+	// deriving one from a message in any other state would let a settled
+	// message mint customer-attributed provider capacity.
 	var exists bool
 	err = tx.QueryRow(ctx, `
 		SELECT true FROM messages
 		 WHERE id = $1 AND agent_id = $2 AND direction = 'outbound'
+		   AND status = 'pending_review'
 		   FOR UPDATE`, messageID, agentID,
 	).Scan(&exists)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -383,6 +401,15 @@ func (m *Module) PrepareProtectionNoticeTx(ctx context.Context, tx pgx.Tx, ref P
 	// the invariant holds even if a future migration relaxes the constraint.
 	if kind == "global_guardrail" && ref.audience == AudienceOwner {
 		return OperationRef{}, ErrAudienceNotAllowed
+	}
+
+	// A delivery that already reached a terminal state is finished. Re-preparing
+	// it would resume its stable operation and let a fresh ordinal authorize a
+	// SECOND physical send of a notice already sent — the one thing the stable
+	// operation exists to prevent. Terminality has to live here rather than in
+	// the drain worker's query, or it is only as good as the caller.
+	if state != "pending" {
+		return OperationRef{}, ErrNoticeSettled
 	}
 
 	if existingOperation != nil && *existingOperation != "" {

--- a/internal/sendingpolicy/provider_attempt_integration_test.go
+++ b/internal/sendingpolicy/provider_attempt_integration_test.go
@@ -245,11 +245,74 @@ func TestEnvelopeComparisonIgnoresCaseAndOrder(t *testing.T) {
 		upperFirst(authorized[2]),
 		authorized[0],
 		upperFirst(authorized[1]),
-		authorized[0], // a duplicate spelling is still one recipient
 	}
 	if _, err := auth.ValidateEnvelope(reshaped); err != nil {
 		t.Fatalf("reshaped envelope rejected: %v", err)
 	}
+}
+
+// TestDuplicateSpellingsCannotAmplifyOneChargedUnit is the reputation
+// amplifier the envelope contract exists to close.
+//
+// Normalization collapses case, so a token for one mailbox would "match" an
+// envelope of fifty case-variant spellings of that mailbox — one unit of
+// charged budget authorizing fifty RCPT TO commands, and fifty chances to
+// bounce against the shared SES reputation. The accounting rule that duplicates
+// count once only holds if the submitted envelope IS the deduplicated set.
+func TestDuplicateSpellingsCannotAmplifyOneChargedUnit(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	_, attempt := f.prepareAndReserve(g, agent, 1)
+
+	_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	authorized := auth.AuthorizedRecipients()
+	if len(authorized) != 1 {
+		t.Fatalf("authorized = %v, want one recipient", authorized)
+	}
+
+	padded := []string{authorized[0]}
+	for i := 0; i < 49; i++ {
+		padded = append(padded, caseVariant(authorized[0], i))
+	}
+
+	var s socket
+	if err := s.send(t, g, auth, padded); !errors.Is(err, sendingpolicy.ErrEnvelopeMismatch) {
+		t.Fatalf("50 case-variant spellings for 1 charged unit = %v, want ErrEnvelopeMismatch", err)
+	}
+	if s.count() != 0 {
+		t.Fatalf("opened %d sockets for a padded envelope, want 0", s.count())
+	}
+
+	// An exact repeat of the same spelling is refused for the same reason: the
+	// caller must collapse To/Cc overlap before submitting, because that is
+	// what it was charged for.
+	if _, err := auth.ValidateEnvelope([]string{authorized[0], authorized[0]}); !errors.Is(err, sendingpolicy.ErrEnvelopeMismatch) {
+		t.Errorf("repeated recipient = %v, want ErrEnvelopeMismatch", err)
+	}
+}
+
+// caseVariant flips the case of the i-th flippable byte of the local part.
+func caseVariant(addr string, i int) string {
+	b := []byte(addr)
+	at := 0
+	for at < len(b) && b[at] != '@' {
+		at++
+	}
+	seen := 0
+	for j := 0; j < at; j++ {
+		if b[j] >= 'a' && b[j] <= 'z' {
+			if seen == i%at {
+				b[j] -= 32
+				return string(b)
+			}
+			seen++
+		}
+	}
+	return string(b)
 }
 
 func upperFirst(addr string) string {
@@ -991,47 +1054,365 @@ func TestTokenCorrelationMatchesTheDurableRow(t *testing.T) {
 	}
 }
 
-// TestReserveNeverDefersAPaidAccountItCannotJudge is the asymmetry that makes
-// the early check safe to act on. Reserve does not hold the locks that make a
-// plan read authoritative, and the worker treats an early hold as "snooze until
-// midnight" — so guessing the Free cap for a paying customer would defer their
-// mail for a day that final authorization would have allowed.
-func TestReserveNeverDefersAPaidAccountItCannotJudge(t *testing.T) {
+// TestReserveJudgesTheAuthoritativePlanAndClass replaces an earlier design in
+// which Reserve guessed.
+//
+// Guessing was wrong in both directions, and neither direction was cheap.
+// Judging the account scope PESSIMISTICALLY deferred a paying customer's mail
+// to the next midnight, because the worker treats an early hold as "snooze".
+// Judging it OPTIMISTICALLY — while still charging the shared global pools at
+// their real limits — let one Free account hold the whole platform pool in
+// reservations it could never confirm. Reading the class and the plan costs one
+// FOR SHARE each and removes both failure modes.
+func TestReserveJudgesTheAuthoritativePlanAndClass(t *testing.T) {
+	t.Run("paid account is not deferred", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+			p.DefaultAccountDailyRecipients = 2
+			p.AllCustomerGlobalDailyRecipients = 50
+		}))
+		user := f.user("standard")
+		f.plan(user, "pro")
+		agent := f.agent(user)
+
+		_, ref := f.prepareMessage(g, f.message(agent, "own_address", 10))
+		early, attempt, err := g.Reserve(f.ctx, ref)
+		if err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+		if !early.Allow {
+			t.Fatalf("Reserve deferred a paid account within its cap (%q)", early.Reason)
+		}
+		if d, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || !d.Allow || auth == nil {
+			t.Fatalf("final authorization: allow=%v reason=%q err=%v", d.Allow, d.Reason, err)
+		}
+	})
+
+	t.Run("free account cannot hold the global pool", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+			p.DefaultAccountDailyRecipients = 2
+			p.AllCustomerGlobalDailyRecipients = 200
+		}))
+		agent := f.agent(f.user("standard"))
+
+		// Ten 20-recipient messages from an account entitled to 2/day. Every
+		// one must be refused at its own scope WITHOUT taking global units.
+		for i := 0; i < 10; i++ {
+			_, ref := f.prepareMessage(g, f.message(agent, "own_address", 20))
+			d, _, err := g.Reserve(f.ctx, ref)
+			if err != nil {
+				t.Fatalf("reserve %d: %v", i, err)
+			}
+			if d.Allow {
+				t.Fatalf("reserve %d allowed 20 recipients against a cap of 2", i)
+			}
+			if d.Reason != sendingpolicy.ReasonAccountDailyBudget {
+				t.Fatalf("reserve %d reason = %q, want the account scope", i, d.Reason)
+			}
+		}
+		if reserved, _ := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers"); reserved != 0 {
+			t.Fatalf("a Free account parked %d units in the platform pool, want 0", reserved)
+		}
+
+		// A paying tenant still finds the pool empty and is not paged about it.
+		paid := f.user("standard")
+		f.plan(paid, "scale")
+		if d := f.send(g, f.message(f.agent(paid), "own_address", 5)); !d.Allow {
+			t.Fatalf("an unrelated paid tenant was denied: %q", d.Reason)
+		}
+		var guardrails int
+		if err := f.pool.QueryRow(f.ctx,
+			`SELECT count(*) FROM sending_protection_notice_events WHERE kind = 'global_guardrail'`,
+		).Scan(&guardrails); err != nil {
+			t.Fatalf("count guardrails: %v", err)
+		}
+		if guardrails != 0 {
+			t.Errorf("phantom reservations paged the operator %d times, want 0", guardrails)
+		}
+	})
+
+	t.Run("trusted class is not deferred either", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+			p.DefaultAccountDailyRecipients = 1
+			p.AllCustomerGlobalDailyRecipients = 1
+			p.ProbationGlobalDailyRecipients = 1
+			p.SharedDomainAccountDailyRecip = 1
+		}))
+		// Exhaust every pool with ordinary traffic first.
+		if d := f.send(g, f.message(f.agent(f.user("standard")), "relay", 1)); !d.Allow {
+			t.Fatalf("priming send: %q", d.Reason)
+		}
+
+		// The prober must still work during exactly this situation. An
+		// exemption that lives only in ConsumeAttempt is dead here, because the
+		// worker snoozes on Reserve's hold and never gets that far.
+		prober := f.agent(f.user("system"))
+		_, ref := f.prepareMessage(g, f.message(prober, "relay", 5))
+		early, attempt, err := g.Reserve(f.ctx, ref)
+		if err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+		if !early.Allow {
+			t.Fatalf("Reserve deferred a trusted account (%q) during an exhausted-pool window", early.Reason)
+		}
+		if d, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || !d.Allow || auth == nil {
+			t.Fatalf("trusted final authorization: allow=%v reason=%q err=%v", d.Allow, d.Reason, err)
+		}
+	})
+}
+
+// TestEarlyDenialStillOwesItsNotice proves the violation notice is written
+// wherever the denial happens.
+//
+// Every scope except the account-daily one is judged identically by Reserve and
+// ConsumeAttempt, so a denial that stops at Reserve is a denial the customer
+// and the operator would otherwise never hear about: the worker snoozes, and
+// the notice writer that used to live only in final authorization is never
+// reached.
+func TestEarlyDenialStillOwesItsNotice(t *testing.T) {
 	f := newFixture(t)
 	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
-		p.DefaultAccountDailyRecipients = 2
-		p.AllCustomerGlobalDailyRecipients = 50
+		p.SharedDomainAccountDailyRecip = 1
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
 	}))
 	user := f.user("standard")
-	f.plan(user, "pro")
 	agent := f.agent(user)
 
-	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 10))
-	early, attempt, err := g.Reserve(f.ctx, ref)
+	if d := f.send(g, f.message(agent, "relay", 1)); !d.Allow {
+		t.Fatalf("first unit: %q", d.Reason)
+	}
+	// This one is refused by Reserve, before ConsumeAttempt is ever called.
+	_, ref := f.prepareMessage(g, f.message(agent, "relay", 1))
+	early, _, err := g.Reserve(f.ctx, ref)
 	if err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
-	if !early.Allow {
-		t.Fatalf("Reserve deferred a paid account it cannot judge (%q) — an optimization must not over-deny", early.Reason)
+	if early.Allow {
+		t.Fatal("the second shared unit must be refused")
+	}
+
+	var events int
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT count(*) FROM sending_protection_notice_events
+		 WHERE kind = 'budget_violation' AND account_ref = $1`, user,
+	).Scan(&events); err != nil {
+		t.Fatalf("count violation events: %v", err)
+	}
+	if events != 1 {
+		t.Fatalf("violation events after an early denial = %d, want 1", events)
+	}
+	var audiences int
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT count(*) FROM sending_protection_notice_deliveries AS d
+		  JOIN sending_protection_notice_events AS e ON e.id = d.event_id
+		 WHERE e.kind = 'budget_violation'`).Scan(&audiences); err != nil {
+		t.Fatalf("count deliveries: %v", err)
+	}
+	if audiences != 2 {
+		t.Errorf("deliveries = %d, want owner + operator", audiences)
+	}
+}
+
+// TestArmingDoesNotReleaseUnitsNobodyTook is the phantom-release invariant.
+//
+// A reservation made while budgets were disabled holds no capacity, so the
+// first ConsumeAttempt after enforcement is armed must not hand capacity back
+// on its behalf. Getting this wrong is invisible in isolation — the counter's
+// confirmed floor hides it whenever nothing else is in flight — and shows up
+// as the global pool silently over-admitting on the exact day phase 4 arms.
+func TestArmingDoesNotReleaseUnitsNobodyTook(t *testing.T) {
+	f := newFixture(t)
+	armed := enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.DefaultAccountDailyRecipients = 100
+	})
+
+	// Account A reserves while the budget is disabled: nothing is charged.
+	off := f.gate(sendingpolicy.DisabledPolicy())
+	agentA := f.agent(f.user("standard"))
+	_, refA := f.prepareMessage(off, f.message(agentA, "own_address", 5))
+	_, attemptA, err := off.Reserve(f.ctx, refA)
+	if err != nil {
+		t.Fatalf("reserve A: %v", err)
+	}
+
+	// Account B reserves under the armed policy: 10 real units in flight.
+	on := f.gate(armed)
+	agentB := f.agent(f.user("standard"))
+	_, refB := f.prepareMessage(on, f.message(agentB, "own_address", 10))
+	if _, _, err := on.Reserve(f.ctx, refB); err != nil {
+		t.Fatalf("reserve B: %v", err)
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers"); reserved != 10 {
+		t.Fatalf("global reserved = %d, want 10", reserved)
+	}
+
+	if d, auth, err := on.ConsumeAttempt(f.ctx, attemptA); err != nil || !d.Allow || auth == nil {
+		t.Fatalf("A final authorization: allow=%v reason=%q err=%v", d.Allow, d.Reason, err)
+	}
+	reserved, confirmed := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers")
+	if reserved != 15 || confirmed != 5 {
+		t.Fatalf("global reserved=%d confirmed=%d, want 15/5 — B's in-flight units must survive A's arrival",
+			reserved, confirmed)
+	}
+}
+
+// TestDeletedSourceReleasesRatherThanStrands closes a repeatable denial-of-
+// service against the shared pools.
+//
+// When the source row disappears between Reserve and ConsumeAttempt, treating
+// that as an ERROR rolls the transaction back with the attempt still marked
+// reserved — and because every later execution fails at the same point, those
+// units sit on the global pools until midnight with nothing able to release
+// them. Reserve, delete, repeat.
+func TestDeletedSourceReleasesRatherThanStrands(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.AllCustomerGlobalDailyRecipients = 10
+		p.DefaultAccountDailyRecipients = 10
+	}))
+	agent := f.agent(f.user("standard"))
+	messageID := f.message(agent, "own_address", 4)
+	_, ref := f.prepareMessage(g, messageID)
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers"); reserved != 4 {
+		t.Fatalf("global reserved = %d, want 4", reserved)
+	}
+
+	if _, err := f.pool.Exec(f.ctx, `DELETE FROM messages WHERE id = $1`, messageID); err != nil {
+		t.Fatalf("delete message: %v", err)
+	}
+
+	d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		t.Fatalf("consume after delete: %v", err)
+	}
+	if d.Allow || auth != nil {
+		t.Fatal("a deleted source must not authorize")
+	}
+	if d.Reason != sendingpolicy.ReasonSourceUnavailable {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonSourceUnavailable)
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers"); reserved != 0 {
+		t.Fatalf("deleting the source stranded %d units on the shared pool, want 0", reserved)
+	}
+
+	// The pool is fully usable again by everyone else.
+	if d := f.send(g, f.message(f.agent(f.user("standard")), "own_address", 10)); !d.Allow {
+		t.Fatalf("the released capacity is not reusable: %q", d.Reason)
+	}
+}
+
+// TestStaleRedemptionDoesNotRetireTheLiveAttempt proves a late worker cannot
+// destroy a live authorization it has nothing to do with.
+//
+// A stale token is already stale; retiring it retires nothing. Bumping the
+// ordinal unconditionally instead lets it retire the CURRENT attempt another
+// worker is holding — whose confirmed capacity is spent and never refunded, so
+// a supply of stale tokens becomes a livelock that burns the account's budget
+// without a single SES call.
+func TestStaleRedemptionDoesNotRetireTheLiveAttempt(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 20
+	}))
+	agent := f.agent(f.user("standard"))
+	ref, first := f.prepareAndReserve(g, agent, 1)
+
+	_, staleAuth, err := g.ConsumeAttempt(f.ctx, first)
+	if err != nil || staleAuth == nil {
+		t.Fatalf("first authorization: auth=%v err=%v", staleAuth, err)
+	}
+
+	// A second worker goes around and gets the live ordinal.
+	_, second, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("second reserve: %v", err)
+	}
+	_, liveAuth, err := g.ConsumeAttempt(f.ctx, second)
+	if err != nil || liveAuth == nil {
+		t.Fatalf("second authorization: auth=%v err=%v", liveAuth, err)
+	}
+	if got := f.currentAttempt(ref.ID()); got != 2 {
+		t.Fatalf("current attempt = %d, want 2", got)
+	}
+
+	// The first worker finally wakes up and redeems its superseded token.
+	var s socket
+	if err := s.send(t, g, staleAuth, staleAuth.AuthorizedRecipients()); !errors.Is(err, sendingpolicy.ErrAuthorizationInvalid) {
+		t.Fatalf("stale redemption = %v, want ErrAuthorizationInvalid", err)
+	}
+	if got := f.currentAttempt(ref.ID()); got != 2 {
+		t.Fatalf("a stale redemption moved the ordinal to %d, want it left at 2", got)
+	}
+
+	// The live token still works.
+	if err := s.send(t, g, liveAuth, liveAuth.AuthorizedRecipients()); err != nil {
+		t.Fatalf("live redemption after a stale one: %v", err)
+	}
+	if s.count() != 1 {
+		t.Fatalf("sockets = %d, want 1", s.count())
+	}
+}
+
+// TestSettledNoticeCannotBeResent proves terminality lives in this module and
+// not in the caller's query.
+func TestSettledNoticeCannotBeResent(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	user := f.user("standard")
+	eventID := f.pauseNotice(user)
+
+	var ref sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		ref, err = g.PrepareProtectionNoticeTx(f.ctx, tx,
+			sendingpolicy.NewProtectionNoticeRef(eventID, sendingpolicy.AudienceOwner))
+		return err
+	})
+	if d := f.authorize(g, ref); !d.Allow {
+		t.Fatalf("first notice: %q", d.Reason)
+	}
+
+	if _, err := f.pool.Exec(f.ctx,
+		`UPDATE sending_protection_notice_deliveries SET state = 'sent'
+		  WHERE event_id = $1 AND audience = 'owner'`, eventID); err != nil {
+		t.Fatalf("settle delivery: %v", err)
+	}
+
+	// Preparation refuses outright.
+	tx, err := f.pool.Begin(f.ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	_, err = g.PrepareProtectionNoticeTx(f.ctx, tx,
+		sendingpolicy.NewProtectionNoticeRef(eventID, sendingpolicy.AudienceOwner))
+	_ = tx.Rollback(f.ctx)
+	if !errors.Is(err, sendingpolicy.ErrNoticeSettled) {
+		t.Fatalf("re-preparing a sent notice = %v, want ErrNoticeSettled", err)
+	}
+
+	// And a caller still holding the old reference cannot authorize another
+	// physical send either.
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
 	}
 	d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
 	if err != nil {
 		t.Fatalf("consume: %v", err)
 	}
-	if !d.Allow || auth == nil {
-		t.Fatalf("final authorization held a paid account within its cap: %q", d.Reason)
+	if d.Allow || auth != nil {
+		t.Fatal("a settled notice must not authorize a second send")
 	}
-
-	// The mirror: a Free account past every possible cap is still denied early,
-	// so the optimization keeps its value.
-	poor := f.user("standard")
-	poorAgent := f.agent(poor)
-	_, bigRef := f.prepareMessage(g, f.message(poorAgent, "own_address", 60))
-	tooBig, _, err := g.Reserve(f.ctx, bigRef)
-	if err != nil {
-		t.Fatalf("reserve oversize: %v", err)
-	}
-	if tooBig.Allow {
-		t.Error("Reserve must still deny what no plan could fit")
+	if d.Reason != sendingpolicy.ReasonNoticeSettled {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonNoticeSettled)
 	}
 }

--- a/internal/sendingpolicy/provider_attempt_integration_test.go
+++ b/internal/sendingpolicy/provider_attempt_integration_test.go
@@ -1416,3 +1416,197 @@ func TestSettledNoticeCannotBeResent(t *testing.T) {
 		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonNoticeSettled)
 	}
 }
+
+// TestTerminalHoldsAreMarkedTerminal proves the worker can tell "come back
+// later" from "this can never proceed".
+//
+// Without the distinction every hold reads as retryable, and an operation that
+// is permanently void — its account deleted, its notice already sent, its
+// reputation class no longer the one it was derived from — would be snoozed
+// forever instead of failed once. A terminal hold carries no RetryAt because
+// there is no time at which the answer changes.
+func TestTerminalHoldsAreMarkedTerminal(t *testing.T) {
+	t.Run("deleted account", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(nil))
+		user := f.user("standard")
+		_, attempt := f.prepareAndReserve(g, f.agent(user), 1)
+		if _, err := f.pool.Exec(f.ctx, `DELETE FROM users WHERE id = $1`, user); err != nil {
+			t.Fatalf("delete account: %v", err)
+		}
+		d, _, err := g.ConsumeAttempt(f.ctx, attempt)
+		if err != nil {
+			t.Fatalf("consume: %v", err)
+		}
+		assertTerminal(t, d, sendingpolicy.ReasonAccountDeleted)
+	})
+
+	t.Run("reputation class changed", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(nil))
+		agent := f.agent(f.user("standard"))
+		messageID := f.message(agent, "own_address", 1)
+		_, ref := f.prepareMessage(g, messageID)
+		if _, err := f.pool.Exec(f.ctx,
+			`UPDATE messages SET sent_as = 'relay' WHERE id = $1`, messageID); err != nil {
+			t.Fatalf("downgrade sent_as: %v", err)
+		}
+		assertTerminal(t, f.authorize(g, ref), sendingpolicy.ReasonClassChanged)
+	})
+
+	t.Run("deleted source", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(nil))
+		agent := f.agent(f.user("standard"))
+		messageID := f.message(agent, "own_address", 1)
+		_, ref := f.prepareMessage(g, messageID)
+		_, attempt, err := g.Reserve(f.ctx, ref)
+		if err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+		if _, err := f.pool.Exec(f.ctx, `DELETE FROM messages WHERE id = $1`, messageID); err != nil {
+			t.Fatalf("delete message: %v", err)
+		}
+		d, _, err := g.ConsumeAttempt(f.ctx, attempt)
+		if err != nil {
+			t.Fatalf("consume: %v", err)
+		}
+		assertTerminal(t, d, sendingpolicy.ReasonSourceUnavailable)
+	})
+
+	t.Run("budget hold is retryable, not terminal", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+			p.DefaultAccountDailyRecipients = 1
+		}))
+		agent := f.agent(f.user("standard"))
+		if d := f.send(g, f.message(agent, "own_address", 1)); !d.Allow {
+			t.Fatalf("first send: %q", d.Reason)
+		}
+		d := f.send(g, f.message(agent, "own_address", 1))
+		if d.Allow || d.Terminal {
+			t.Fatalf("a daily budget hold must be retryable (allow=%v terminal=%v)", d.Allow, d.Terminal)
+		}
+		if d.RetryAt.IsZero() {
+			t.Error("a retryable hold must advise when to come back")
+		}
+	})
+}
+
+func assertTerminal(t *testing.T, d sendingpolicy.Decision, wantReason string) {
+	t.Helper()
+	if d.Allow {
+		t.Fatalf("expected a hold, got allow")
+	}
+	if d.Reason != wantReason {
+		t.Fatalf("reason = %q, want %q", d.Reason, wantReason)
+	}
+	if !d.Terminal {
+		t.Errorf("reason %q must be terminal — a retry can never clear it", d.Reason)
+	}
+	if !d.RetryAt.IsZero() {
+		t.Errorf("a terminal hold must not advise a retry time (got %s)", d.RetryAt)
+	}
+}
+
+// TestSettlementRejectsAnAttemptThatWasNeverAuthorized proves settlement
+// reports what the PROVIDER did, so it is meaningless for an attempt that was
+// never allowed to reach one. Accepting a reserved or released attempt would
+// advance ramp progress for a send that never happened.
+func TestSettlementRejectsAnAttemptThatWasNeverAuthorized(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	_, attempt := f.prepareAndReserve(g, agent, 1)
+
+	// Reserved but never consumed.
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: attempt, Outcome: sendingpolicy.SettlementProviderAccepted,
+	}); !errors.Is(err, sendingpolicy.ErrAttemptStale) {
+		t.Fatalf("settling an unauthorized attempt = %v, want ErrAttemptStale", err)
+	}
+
+	// Authorized: now it settles.
+	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: attempt, Outcome: sendingpolicy.SettlementProviderAccepted,
+	}); err != nil {
+		t.Fatalf("settle authorized attempt: %v", err)
+	}
+}
+
+// TestTenantHeaderSurface exercises the tenant-header modes, which otherwise
+// ship entirely unexecuted — every other fixture leaves the mode disabled.
+//
+// The two things that must not fail open: an operational or public-feedback
+// operation gets the fixed system tenant rather than silently none, and a
+// customer whose tenant has no name is held rather than handed a token whose
+// required header value is empty.
+func TestTenantHeaderSurface(t *testing.T) {
+	t.Run("operational mail uses the system tenant", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+			p.TenantHeaderMode = sendingpolicy.TenantHeaderEnforce
+		}))
+		eventID := f.pauseNotice(f.user("standard"))
+		var ref sendingpolicy.OperationRef
+		f.inTx(func(tx pgx.Tx) error {
+			var err error
+			ref, err = g.PrepareProtectionNoticeTx(f.ctx, tx,
+				sendingpolicy.NewProtectionNoticeRef(eventID, sendingpolicy.AudienceOperator))
+			return err
+		})
+		_, attempt, err := g.Reserve(f.ctx, ref)
+		if err != nil {
+			t.Fatalf("reserve: %v", err)
+		}
+		_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+		if err != nil || auth == nil {
+			t.Fatalf("authorize: auth=%v err=%v", auth, err)
+		}
+		headers, err := auth.ValidateEnvelope(auth.AuthorizedRecipients())
+		if err != nil {
+			t.Fatalf("validate: %v", err)
+		}
+		if !headers.TenantRequired || headers.TenantName != sendingpolicy.SystemPolicySubject {
+			t.Errorf("operational tenant = %v/%q, want required/%q",
+				headers.TenantRequired, headers.TenantName, sendingpolicy.SystemPolicySubject)
+		}
+	})
+
+	t.Run("customer with an unnamed tenant is held", func(t *testing.T) {
+		f := newFixture(t)
+		g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+			p.TenantHeaderMode = sendingpolicy.TenantHeaderEnforce
+		}))
+		user := f.user("standard")
+		agent := f.agent(user)
+		// The control row exists with ses_tenant_name '' and ready=false.
+		d := f.send(g, f.message(agent, "relay", 1))
+		if d.Allow {
+			t.Fatal("an enforcing tenant policy must not authorize an account with no tenant")
+		}
+		if d.Reason != sendingpolicy.ReasonTenantNotReady && d.Reason != sendingpolicy.ReasonTenantUnnamed {
+			t.Errorf("reason = %q, want a tenant hold", d.Reason)
+		}
+	})
+
+	t.Run("canary selects only the named account", func(t *testing.T) {
+		f := newFixture(t)
+		user := f.user("standard")
+		g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+			p.TenantHeaderMode = sendingpolicy.TenantHeaderCanary
+			p.TenantHeaderCanaryAccountIDs = []string{user}
+		}))
+		// The canary account is selected and therefore held (no tenant yet).
+		if d := f.send(g, f.message(f.agent(user), "relay", 1)); d.Allow {
+			t.Fatal("the canary account must be tenant-gated")
+		}
+		// An account outside the list is untouched by the canary.
+		if d := f.send(g, f.message(f.agent(f.user("standard")), "relay", 1)); !d.Allow {
+			t.Fatalf("a non-canary account must be unaffected: %q", d.Reason)
+		}
+	})
+}

--- a/internal/sendingpolicy/provider_attempt_integration_test.go
+++ b/internal/sendingpolicy/provider_attempt_integration_test.go
@@ -1,0 +1,1037 @@
+package sendingpolicy_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/tokencanopy/e2a/internal/sendingpolicy"
+)
+
+// This file is about the durable attempt: the thing that makes "exactly one SES
+// call per charged unit of capacity" true across crashes, retries, races, and
+// deliberate abuse of the reference types.
+//
+// A fake socket counter stands in for SES. Every test that claims "zero
+// provider calls" asserts it against that counter, not against an absence of
+// errors, because the failure that matters is a call that happened anyway.
+
+// socket is a stand-in for the SMTP adapter: it will only "connect" for a token
+// it successfully redeemed, exactly as the real adapter must.
+type socket struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *socket) send(t *testing.T, g sendingpolicy.Gate, auth *sendingpolicy.ProviderAuthorization, envelope []string) error {
+	t.Helper()
+	if auth == nil {
+		return errors.New("no authorization")
+	}
+	if _, err := auth.ValidateEnvelope(envelope); err != nil {
+		return err
+	}
+	if err := g.RedeemProviderCall(t.Context(), *auth); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *socket) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// prepareAndReserve runs the first two worker steps for a fresh message.
+func (f *fixture) prepareAndReserve(g sendingpolicy.Gate, agentID string, count int) (sendingpolicy.OperationRef, sendingpolicy.AttemptRef) {
+	f.t.Helper()
+	_, ref := f.prepareMessage(g, f.message(agentID, "own_address", count))
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		f.t.Fatalf("reserve: %v", err)
+	}
+	return ref, attempt
+}
+
+func (f *fixture) reservationState(operationID string, attempt int) (state, callState string) {
+	f.t.Helper()
+	err := f.pool.QueryRow(f.ctx, `
+		SELECT state, call_state FROM sending_budget_reservations
+		 WHERE operation_id = $1 AND submission_attempt = $2`, operationID, attempt,
+	).Scan(&state, &callState)
+	if err != nil {
+		f.t.Fatalf("read reservation: %v", err)
+	}
+	return state, callState
+}
+
+func (f *fixture) currentAttempt(operationID string) int {
+	f.t.Helper()
+	var n int
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT current_attempt FROM sending_provider_operations WHERE operation_id = $1`, operationID,
+	).Scan(&n); err != nil {
+		f.t.Fatalf("read current attempt: %v", err)
+	}
+	return n
+}
+
+// TestOnlyOneWorkerAuthorizesOneOrdinal is the duplicate-worker invariant. Two
+// executions of the same job routinely observe the same reserved ordinal; only
+// one of them may ever get a token, or one message becomes two SES calls
+// against one charge.
+func TestOnlyOneWorkerAuthorizesOneOrdinal(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	_, attempt := f.prepareAndReserve(g, agent, 1)
+
+	var wg sync.WaitGroup
+	tokens := make([]*sendingpolicy.ProviderAuthorization, 2)
+	errs := make([]error, 2)
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+			tokens[i], errs[i] = auth, err
+		}(i)
+	}
+	wg.Wait()
+
+	granted := 0
+	for i := range tokens {
+		if tokens[i] != nil {
+			granted++
+			continue
+		}
+		if !errors.Is(errs[i], sendingpolicy.ErrAttemptStale) {
+			t.Errorf("loser %d error = %v, want ErrAttemptStale", i, errs[i])
+		}
+	}
+	if granted != 1 {
+		t.Fatalf("%d workers were authorized for one ordinal, want exactly 1", granted)
+	}
+}
+
+// TestConfirmedAttemptForcesTheNextOrdinal proves the one-way rule: once
+// capacity is irrevocably spent, the only continuation is a greater ordinal
+// with fresh capacity. This is what bounds physical exposure across a crash
+// between authorization and the socket.
+func TestConfirmedAttemptForcesTheNextOrdinal(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 4
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+	ref, attempt := f.prepareAndReserve(g, agent, 1)
+
+	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+		t.Fatalf("first authorization: auth=%v err=%v", auth, err)
+	}
+	if got := f.currentAttempt(ref.ID()); got != 1 {
+		t.Fatalf("current attempt = %d, want 1 before the retry", got)
+	}
+
+	// The worker dies here. A later execution starts again at Reserve.
+	_, next, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("second reserve: %v", err)
+	}
+	if next.Attempt() != 2 {
+		t.Fatalf("second ordinal = %d, want 2", next.Attempt())
+	}
+	if _, auth, err := g.ConsumeAttempt(f.ctx, next); err != nil || auth == nil {
+		t.Fatalf("second authorization: auth=%v err=%v", auth, err)
+	}
+
+	// Both attempts are charged. A retry costs capacity precisely because it
+	// exposes SES again; refunding the first would make crash-looping free.
+	if _, confirmed := f.counter(sendingpolicy.ScopeAccountDaily, user); confirmed != 2 {
+		t.Errorf("confirmed = %d, want 2 — a retry must consume fresh capacity", confirmed)
+	}
+}
+
+// TestRedemptionIsSingleUseAndPrecedesIO proves the token is spent, not merely
+// checked: a second redemption of the same token opens no socket.
+func TestRedemptionIsSingleUseAndPrecedesIO(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	ref, attempt := f.prepareAndReserve(g, agent, 1)
+
+	_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	envelope := auth.AuthorizedRecipients()
+
+	var s socket
+	if err := s.send(t, g, auth, envelope); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	if state, callState := f.reservationState(ref.ID(), 1); state != "confirmed" || callState != "started" {
+		t.Errorf("after redemption state=%s call_state=%s, want confirmed/started", state, callState)
+	}
+
+	if err := s.send(t, g, auth, envelope); !errors.Is(err, sendingpolicy.ErrAuthorizationInvalid) {
+		t.Fatalf("second redemption error = %v, want ErrAuthorizationInvalid", err)
+	}
+	if s.count() != 1 {
+		t.Fatalf("socket opened %d times for one authorization, want 1", s.count())
+	}
+	if got := f.currentAttempt(ref.ID()); got <= 1 {
+		t.Errorf("current attempt = %d, want > 1 after an invalidated redemption", got)
+	}
+}
+
+// TestEnvelopeMismatchFailsBeforeRedemption proves a token cannot be pointed at
+// recipients it did not authorize — the check runs before any redemption, so a
+// mismatch costs nothing and sends nothing.
+func TestEnvelopeMismatchFailsBeforeRedemption(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	ref, attempt := f.prepareAndReserve(g, agent, 2)
+
+	_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	authorized := auth.AuthorizedRecipients()
+
+	var s socket
+	for name, envelope := range map[string][]string{
+		"extra recipient":   append(append([]string(nil), authorized...), "attacker@example.test"),
+		"swapped recipient": {authorized[0], "attacker@example.test"},
+		"missing recipient": {authorized[0]},
+	} {
+		if err := s.send(t, g, auth, envelope); !errors.Is(err, sendingpolicy.ErrEnvelopeMismatch) {
+			t.Errorf("%s: error = %v, want ErrEnvelopeMismatch", name, err)
+		}
+	}
+	if s.count() != 0 {
+		t.Fatalf("socket opened %d times on mismatched envelopes, want 0", s.count())
+	}
+	if state, callState := f.reservationState(ref.ID(), 1); callState != "authorized" {
+		t.Errorf("state=%s call_state=%s — a rejected envelope must not consume the token", state, callState)
+	}
+}
+
+// TestEnvelopeComparisonIgnoresCaseAndOrder proves the normalization contract
+// the adapter depends on: it may reassemble To/Cc/Bcc in any order, and a
+// mailbox spelled with different case is not a different recipient.
+func TestEnvelopeComparisonIgnoresCaseAndOrder(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	_, attempt := f.prepareAndReserve(g, agent, 3)
+
+	_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	authorized := auth.AuthorizedRecipients()
+	reshaped := []string{
+		upperFirst(authorized[2]),
+		authorized[0],
+		upperFirst(authorized[1]),
+		authorized[0], // a duplicate spelling is still one recipient
+	}
+	if _, err := auth.ValidateEnvelope(reshaped); err != nil {
+		t.Fatalf("reshaped envelope rejected: %v", err)
+	}
+}
+
+func upperFirst(addr string) string {
+	if addr == "" {
+		return addr
+	}
+	return string(addr[0]-32) + addr[1:]
+}
+
+// TestForgedReferencesAuthorizeNothing proves the reference types are not
+// capabilities. A caller that round-trips an operation through JSON — the only
+// serialization this package permits — gets an ID and nothing else, and a
+// fabricated ID resolves to no authority at all.
+func TestForgedReferencesAuthorizeNothing(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 1))
+
+	raw, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("marshal ref: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("inspect wire form: %v", err)
+	}
+	if len(wire) != 2 || wire["v"] != float64(1) || wire["id"] != ref.ID() {
+		t.Fatalf("wire form = %v, want exactly {v:1, id:%q}", wire, ref.ID())
+	}
+
+	var revived sendingpolicy.OperationRef
+	if err := json.Unmarshal(raw, &revived); err != nil {
+		t.Fatalf("unmarshal ref: %v", err)
+	}
+	if revived.Purpose() != "" {
+		t.Errorf("a deserialized reference carried purpose %q — it must be reloaded from the row", revived.Purpose())
+	}
+	// It still works, because every method reloads from the durable row.
+	if _, _, err := g.Reserve(f.ctx, revived); err != nil {
+		t.Fatalf("reserve on a round-tripped reference: %v", err)
+	}
+
+	// A fabricated ID names nothing.
+	var forged sendingpolicy.OperationRef
+	if err := json.Unmarshal([]byte(`{"v":1,"id":"op_not_a_real_operation"}`), &forged); err != nil {
+		t.Fatalf("unmarshal forged: %v", err)
+	}
+	if _, _, err := g.Reserve(f.ctx, forged); !errors.Is(err, sendingpolicy.ErrSourceUnavailable) {
+		t.Errorf("forged reference error = %v, want ErrSourceUnavailable", err)
+	}
+
+	// An unsupported version is refused rather than reinterpreted.
+	if err := json.Unmarshal([]byte(`{"v":2,"id":"op_x"}`), &forged); err == nil {
+		t.Error("an unsupported reference version must not decode")
+	}
+}
+
+// TestDeferReleasesBudgetAndCancelDoesToo proves a message that never reaches
+// the provider gives its capacity back, and that neither call can undo a
+// started one.
+func TestDeferReleasesBudgetAndCancelDoesToo(t *testing.T) {
+	for name, release := range map[string]func(sendingpolicy.Gate, sendingpolicy.AttemptRef) error{
+		"defer": func(g sendingpolicy.Gate, a sendingpolicy.AttemptRef) error {
+			return g.DeferAttempt(t.Context(), a)
+		},
+		"cancel": func(g sendingpolicy.Gate, a sendingpolicy.AttemptRef) error {
+			return g.CancelAttempt(t.Context(), a)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t)
+			g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+				p.DefaultAccountDailyRecipients = 2
+			}))
+			user := f.user("standard")
+			agent := f.agent(user)
+			ref, attempt := f.prepareAndReserve(g, agent, 2)
+
+			if reserved, _ := f.counter(sendingpolicy.ScopeAccountDaily, user); reserved != 2 {
+				t.Fatalf("reserved = %d, want 2 after Reserve", reserved)
+			}
+			if err := release(g, attempt); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if reserved, _ := f.counter(sendingpolicy.ScopeAccountDaily, user); reserved != 0 {
+				t.Fatalf("reserved = %d after %s, want 0", reserved, name)
+			}
+			// Repeating it is a no-op, not a second refund.
+			if err := release(g, attempt); err != nil {
+				t.Fatalf("repeat %s: %v", name, err)
+			}
+			if reserved, _ := f.counter(sendingpolicy.ScopeAccountDaily, user); reserved != 0 {
+				t.Fatalf("reserved = %d after a repeated %s, want 0", reserved, name)
+			}
+
+			// Once the attempt is authorized its capacity is spent, so a
+			// release is refused rather than silently recorded: the counter's
+			// confirmed floor would keep the units anyway, and a row claiming
+			// a give-back that never happened is worse than an error.
+			_, again, err := g.Reserve(f.ctx, ref)
+			if err != nil {
+				t.Fatalf("re-reserve: %v", err)
+			}
+			_, auth, err := g.ConsumeAttempt(f.ctx, again)
+			if err != nil || auth == nil {
+				t.Fatalf("authorize: auth=%v err=%v", auth, err)
+			}
+			if err := release(g, again); !errors.Is(err, sendingpolicy.ErrAttemptStale) {
+				t.Fatalf("%s after authorization = %v, want ErrAttemptStale", name, err)
+			}
+			if _, confirmed := f.counter(sendingpolicy.ScopeAccountDaily, user); confirmed != 2 {
+				t.Fatalf("confirmed = %d after a refused %s, want 2", confirmed, name)
+			}
+
+			// And after a real provider call the reason is more specific.
+			var s socket
+			if err := s.send(t, g, auth, auth.AuthorizedRecipients()); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+			if err := release(g, again); !errors.Is(err, sendingpolicy.ErrProviderCallStarted) {
+				t.Fatalf("%s after a started call = %v, want ErrProviderCallStarted", name, err)
+			}
+		})
+	}
+}
+
+// TestPlanDowngradeBetweenReserveAndConsume is the cliff the pricing work
+// flagged: two 75-unit reservations admitted under a paid cap must not both
+// submit once the account is Free.
+func TestPlanDowngradeBetweenReserveAndConsume(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 5000
+	}))
+	user := f.user("standard")
+	f.plan(user, "pro")
+	agent := f.agent(user)
+
+	_, first := f.prepareAndReserve(g, agent, 75)
+	_, second := f.prepareAndReserve(g, agent, 75)
+
+	// The billing writer downgrades the account after both reservations.
+	f.plan(user, "free")
+
+	d1, auth1, err := g.ConsumeAttempt(f.ctx, first)
+	if err != nil {
+		t.Fatalf("first consume: %v", err)
+	}
+	d2, auth2, err := g.ConsumeAttempt(f.ctx, second)
+	if err != nil {
+		t.Fatalf("second consume: %v", err)
+	}
+	allowed := 0
+	for _, d := range []sendingpolicy.Decision{d1, d2} {
+		if d.Allow {
+			allowed++
+		}
+	}
+	if allowed != 1 {
+		t.Fatalf("%d of two 75-unit attempts were authorized under a 100-unit cap, want exactly 1", allowed)
+	}
+	_ = auth1
+	_ = auth2
+	if _, confirmed := f.counter(sendingpolicy.ScopeAccountDaily, user); confirmed != 75 {
+		t.Errorf("confirmed = %d, want 75 — the downgrade must bind at final authorization", confirmed)
+	}
+}
+
+// TestPolicyChangeBetweenReserveAndConsumeArmsTheNewControls proves a control
+// armed after Reserve still applies, and one disarmed after Reserve gives its
+// units back rather than leaking them until midnight.
+func TestPolicyChangeBetweenReserveAndConsumeArmsTheNewControls(t *testing.T) {
+	f := newFixture(t)
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	// Reserve under a policy with no budgets at all.
+	off := f.gate(sendingpolicy.DisabledPolicy())
+	_, ref := f.prepareMessage(off, f.message(agent, "relay", 3))
+	_, attempt, err := off.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeAccountSharedDaily, user); reserved != 0 {
+		t.Fatalf("a disabled policy charged %d units at reserve", reserved)
+	}
+
+	// The operator arms enforcement with a cap this attempt cannot fit.
+	on := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.SharedDomainAccountDailyRecip = 2
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+	d, auth, err := on.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if d.Allow || auth != nil {
+		t.Fatal("a newly armed budget must bind an attempt reserved before it was armed")
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeAccountSharedDaily, user); reserved != 0 {
+		t.Errorf("a denied attempt left %d units reserved, want 0", reserved)
+	}
+}
+
+// TestDisarmedControlReleasesItsUnits is the mirror image: units taken under an
+// armed control must come back when the control is disarmed, not sit reserved
+// against a limit nobody is enforcing.
+func TestDisarmedControlReleasesItsUnits(t *testing.T) {
+	f := newFixture(t)
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	on := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 10
+	}))
+	_, ref := f.prepareMessage(on, f.message(agent, "own_address", 3))
+	_, attempt, err := on.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeAccountDaily, user); reserved != 3 {
+		t.Fatalf("reserved = %d, want 3", reserved)
+	}
+
+	off := f.gate(sendingpolicy.DisabledPolicy())
+	d, auth, err := off.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if !d.Allow || auth == nil {
+		t.Fatalf("a disabled budget must allow, got %q", d.Reason)
+	}
+	reserved, confirmed := f.counter(sendingpolicy.ScopeAccountDaily, user)
+	if reserved != 0 || confirmed != 0 {
+		t.Errorf("counter reserved=%d confirmed=%d after disarming, want 0/0", reserved, confirmed)
+	}
+}
+
+// TestAccountClassChangeBetweenReserveAndConsume proves the final class read is
+// authoritative: promoting an account to a trusted class between the two calls
+// releases its units, and it is the LOCKED read that decides, not the one
+// Reserve happened to see.
+func TestAccountClassChangeBetweenReserveAndConsume(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 10
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+	_, attempt := f.prepareAndReserve(g, agent, 4)
+
+	if _, err := f.pool.Exec(f.ctx, `UPDATE users SET account_class = 'internal' WHERE id = $1`, user); err != nil {
+		t.Fatalf("promote account: %v", err)
+	}
+
+	d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if !d.Allow || auth == nil {
+		t.Fatalf("a trusted account must not be budgeted, got hold %q", d.Reason)
+	}
+	if reserved, confirmed := f.counter(sendingpolicy.ScopeAccountDaily, user); reserved != 0 || confirmed != 0 {
+		t.Errorf("counter reserved=%d confirmed=%d, want 0/0 after the class change", reserved, confirmed)
+	}
+}
+
+// TestSharedClassificationIsImmutableAcrossAttempts proves the reputation class
+// is decided once from the server-owned column and cannot be edited into
+// something cheaper afterwards.
+func TestSharedClassificationIsImmutableAcrossAttempts(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.SharedDomainAccountDailyRecip = 5
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+	messageID := f.message(agent, "relay", 1)
+	_, ref := f.prepareMessage(g, messageID)
+
+	// Rewrite the source row to claim a dedicated domain, which is the
+	// cheapest possible lie: it would skip the 50/day shared cap entirely.
+	if _, err := f.pool.Exec(f.ctx, `UPDATE messages SET sent_as = 'own_address' WHERE id = $1`, messageID); err != nil {
+		t.Fatalf("rewrite sent_as: %v", err)
+	}
+
+	if d := f.authorize(g, ref); !d.Allow {
+		t.Fatalf("authorize: %q", d.Reason)
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeAccountSharedDaily, user); confirmed != 1 {
+		t.Errorf("shared counter confirmed = %d, want 1 — the class is fixed at preparation", confirmed)
+	}
+}
+
+// TestAdjacentDayPhysicalSubmissionBound proves the day boundary is honest.
+// A run that spans midnight may expose at most one cap on each side, and every
+// physical call must be backed by a confirmed attempt on the day it was charged.
+func TestAdjacentDayPhysicalSubmissionBound(t *testing.T) {
+	const cap = 3
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = cap
+		p.AllCustomerGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	var s socket
+	drain := func() int {
+		sent := 0
+		for i := 0; i < cap*3; i++ {
+			_, ref := f.prepareMessage(g, f.message(agent, "own_address", 1))
+			_, attempt, err := g.Reserve(f.ctx, ref)
+			if err != nil {
+				t.Fatalf("reserve: %v", err)
+			}
+			d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+			if err != nil {
+				t.Fatalf("consume: %v", err)
+			}
+			if !d.Allow {
+				continue
+			}
+			if err := s.send(t, g, auth, auth.AuthorizedRecipients()); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+			sent++
+		}
+		return sent
+	}
+
+	dayOne := drain()
+	if dayOne != cap {
+		t.Fatalf("day one sent %d, want exactly the cap %d", dayOne, cap)
+	}
+
+	// Roll the ledger forward a day by aging every counter row, which is what
+	// midnight does from the ledger's point of view.
+	if _, err := f.pool.Exec(f.ctx, `UPDATE sending_budget_counters SET day = day - 1`); err != nil {
+		t.Fatalf("advance day: %v", err)
+	}
+
+	dayTwo := drain()
+	if dayTwo != cap {
+		t.Fatalf("day two sent %d, want exactly the cap %d", dayTwo, cap)
+	}
+	if s.count() != 2*cap {
+		t.Fatalf("adjacent-day physical calls = %d, want at most %d", s.count(), 2*cap)
+	}
+
+	// Every physical call is backed by exactly one started attempt.
+	var started int
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT count(*) FROM sending_budget_reservations WHERE call_state = 'started'`,
+	).Scan(&started); err != nil {
+		t.Fatalf("count started attempts: %v", err)
+	}
+	if started != s.count() {
+		t.Errorf("started attempts = %d but sockets = %d — every call must be charged", started, s.count())
+	}
+}
+
+// TestDeletionCannotRefundConfirmedExposure is the deletion-safety invariant.
+// The ledger references accounts only by opaque ID and has no foreign key into
+// the customer tree, so a delete-and-resend loop cannot mint free reputation
+// exposure by erasing its own history.
+func TestDeletionCannotRefundConfirmedExposure(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.AllCustomerGlobalDailyRecipients = 4
+		p.DefaultAccountDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	if d := f.send(g, f.message(agent, "own_address", 3)); !d.Allow {
+		t.Fatalf("first send: %q", d.Reason)
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers"); confirmed != 3 {
+		t.Fatalf("global confirmed = %d, want 3", confirmed)
+	}
+
+	// Irreversible account deletion, cascading through the customer tree.
+	if _, err := f.pool.Exec(f.ctx, `DELETE FROM users WHERE id = $1`, user); err != nil {
+		t.Fatalf("delete account: %v", err)
+	}
+
+	reserved, confirmed := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers")
+	if confirmed != 3 || reserved != 3 {
+		t.Fatalf("after deletion reserved=%d confirmed=%d, want 3/3 — exposure must survive its account", reserved, confirmed)
+	}
+
+	// The replacement account finds only the remaining headroom.
+	fresh := f.agent(f.user("standard"))
+	if d := f.send(g, f.message(fresh, "own_address", 1)); !d.Allow {
+		t.Fatalf("the remaining headroom must be usable: %q", d.Reason)
+	}
+	if d := f.send(g, f.message(fresh, "own_address", 1)); d.Allow {
+		t.Fatal("deleting an account must not refund the global pool")
+	}
+}
+
+// TestDeletedOwnerHoldsRatherThanMails proves a customer purpose whose account
+// vanished mid-flight is held, not sent, and that its early reservation is
+// given back.
+func TestDeletedOwnerHoldsRatherThanMails(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 10
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+	_, attempt := f.prepareAndReserve(g, agent, 2)
+
+	if _, err := f.pool.Exec(f.ctx, `DELETE FROM users WHERE id = $1`, user); err != nil {
+		t.Fatalf("delete account: %v", err)
+	}
+
+	d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if d.Allow || auth != nil {
+		t.Fatal("a deleted account must not be authorized")
+	}
+	if d.Reason != sendingpolicy.ReasonAccountDeleted {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonAccountDeleted)
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeAccountDaily, user); reserved != 0 {
+		t.Errorf("a held attempt left %d units reserved, want 0", reserved)
+	}
+}
+
+// TestOwnerNoticeRecipientChangeInvalidatesTheAttempt proves the last-moment
+// recipient recheck: an owner who edits their address after authorization is
+// never mailed at the retired one.
+func TestOwnerNoticeRecipientChangeInvalidatesTheAttempt(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	user := f.user("standard")
+	eventID := f.pauseNotice(user)
+
+	var ref sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		ref, err = g.PrepareProtectionNoticeTx(f.ctx, tx,
+			sendingpolicy.NewProtectionNoticeRef(eventID, sendingpolicy.AudienceOwner))
+		return err
+	})
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	if got := auth.AuthorizedRecipients(); len(got) != 1 || got[0] != user+"@example.test" {
+		t.Fatalf("authorized recipients = %v", got)
+	}
+
+	if _, err := f.pool.Exec(f.ctx,
+		`UPDATE users SET email = $2 WHERE id = $1`, user, "moved-"+user+"@example.test"); err != nil {
+		t.Fatalf("change owner address: %v", err)
+	}
+
+	var s socket
+	if err := s.send(t, g, auth, auth.AuthorizedRecipients()); !errors.Is(err, sendingpolicy.ErrAuthorizationInvalid) {
+		t.Fatalf("redemption after an owner change = %v, want ErrAuthorizationInvalid", err)
+	}
+	if s.count() != 0 {
+		t.Fatalf("mailed the retired address %d times, want 0", s.count())
+	}
+	if got := f.currentAttempt(ref.ID()); got <= 1 {
+		t.Errorf("current attempt = %d, want a strictly greater ordinal after invalidation", got)
+	}
+}
+
+// TestOperatorNoticeRotationInvalidatesTheAttempt is the operator-side mirror:
+// rotating the mailbox map retires an authorization built against the old
+// version rather than mailing a mailbox the operator has retired.
+func TestOperatorNoticeRotationInvalidatesTheAttempt(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	user := f.user("standard")
+	eventID := f.pauseNotice(user)
+
+	var ref sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		ref, err = g.PrepareProtectionNoticeTx(f.ctx, tx,
+			sendingpolicy.NewProtectionNoticeRef(eventID, sendingpolicy.AudienceOperator))
+		return err
+	})
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+
+	// A slot that has already picked up a rotated map and a policy selecting
+	// version 2 must refuse to redeem a version-1 token.
+	rotated := `{"commitment_key":"AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI",` +
+		`"recipients":{"1":"gate-operator@example.test","2":"gate-operator-two@example.test"}}`
+	recipients, err := sendingpolicy.LoadOperatorRecipients(rotated)
+	if err != nil {
+		t.Fatalf("load rotated map: %v", err)
+	}
+	secrets := f.secrets()
+	secrets.Recipients = recipients
+	module := sendingpolicy.NewModule(f.pool, secrets)
+	if _, err := module.RegisterOperatorRecipients(f.ctx, "fixture", "rotate"); err != nil {
+		t.Fatalf("register rotated map: %v", err)
+	}
+	policy := enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.OperatorNoticeRecipientVersion = 2
+	})
+	rotatedGate := sendingpolicy.NewGate(f.pool, secrets, sendingpolicy.PolicySourceConfig, policy)
+
+	var s socket
+	if err := s.send(t, rotatedGate, auth, auth.AuthorizedRecipients()); !errors.Is(err, sendingpolicy.ErrAuthorizationInvalid) {
+		t.Fatalf("redemption after rotation = %v, want ErrAuthorizationInvalid", err)
+	}
+	if s.count() != 0 {
+		t.Fatalf("mailed the retired operator mailbox %d times, want 0", s.count())
+	}
+}
+
+// TestNoticeOperationIsStableAcrossRetries proves a retried notice keeps one
+// logical identity: the same operation, a greater ordinal, never a second
+// notice.
+func TestNoticeOperationIsStableAcrossRetries(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	user := f.user("standard")
+	eventID := f.pauseNotice(user)
+
+	var first, second sendingpolicy.OperationRef
+	for _, target := range []*sendingpolicy.OperationRef{&first, &second} {
+		ref := target
+		f.inTx(func(tx pgx.Tx) error {
+			var err error
+			*ref, err = g.PrepareProtectionNoticeTx(f.ctx, tx,
+				sendingpolicy.NewProtectionNoticeRef(eventID, sendingpolicy.AudienceOwner))
+			return err
+		})
+	}
+	if first.ID() != second.ID() {
+		t.Fatalf("notice operation changed across retries: %s vs %s", first.ID(), second.ID())
+	}
+
+	_, attempt, err := g.Reserve(f.ctx, first)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	_, next, err := g.Reserve(f.ctx, second)
+	if err != nil {
+		t.Fatalf("second reserve: %v", err)
+	}
+	if next.Attempt() != attempt.Attempt()+1 {
+		t.Errorf("retry ordinal = %d, want %d", next.Attempt(), attempt.Attempt()+1)
+	}
+}
+
+// TestSettleProviderValidatesAndIsIdempotent pins the settlement contract this
+// slice owns: closed outcomes, a real attempt, and no effect on the sending
+// budget. The ramp half arrives with the ramp adapter.
+func TestSettleProviderValidatesAndIsIdempotent(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	user := f.user("standard")
+	agent := f.agent(user)
+	_, attempt := f.prepareAndReserve(g, agent, 2)
+	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+			Attempt: attempt, Outcome: sendingpolicy.SettlementProviderAccepted,
+		}); err != nil {
+			t.Fatalf("settle %d: %v", i, err)
+		}
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeAccountDaily, user); confirmed != 2 {
+		t.Errorf("confirmed = %d after settlement, want 2 — settlement must not move the budget", confirmed)
+	}
+
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: attempt, Outcome: sendingpolicy.SettlementOutcome("delivered_probably"),
+	}); err == nil {
+		t.Error("an outcome outside the closed set must be refused")
+	}
+}
+
+// TestConcurrentAccountSendsNeverExceedTheCap runs the real race: many workers
+// on one account with a cap that only some of them can fit. The ledger must
+// admit exactly the cap, with no deadlock and no over-admission.
+func TestConcurrentAccountSendsNeverExceedTheCap(t *testing.T) {
+	const cap = 5
+	const workers = 12
+
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = cap
+		p.SharedDomainAccountDailyRecip = cap
+		p.ProbationGlobalDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	refs := make([]sendingpolicy.OperationRef, workers)
+	for i := range refs {
+		_, refs[i] = f.prepareMessage(g, f.message(agent, "relay", 1))
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	allowed := 0
+	var failures []error
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(ref sendingpolicy.OperationRef) {
+			defer wg.Done()
+			_, attempt, err := g.Reserve(f.ctx, ref)
+			if err != nil {
+				mu.Lock()
+				failures = append(failures, fmt.Errorf("reserve: %w", err))
+				mu.Unlock()
+				return
+			}
+			d, _, err := g.ConsumeAttempt(f.ctx, attempt)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				failures = append(failures, fmt.Errorf("consume: %w", err))
+				return
+			}
+			if d.Allow {
+				allowed++
+			}
+		}(refs[i])
+	}
+	wg.Wait()
+
+	for _, err := range failures {
+		t.Errorf("worker error (a deadlock or lock-order bug shows up here): %v", err)
+	}
+	if allowed != cap {
+		t.Fatalf("%d of %d concurrent workers were authorized, want exactly the cap %d", allowed, workers, cap)
+	}
+	_, confirmed := f.counter(sendingpolicy.ScopeAccountDaily, user)
+	if confirmed != cap {
+		t.Errorf("confirmed = %d, want %d", confirmed, cap)
+	}
+}
+
+// TestHoldAdvisesTheNextRollover proves a day-bounded hold tells the worker
+// when to come back, so a full account snoozes instead of spinning.
+func TestHoldAdvisesTheNextRollover(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 1
+	}))
+	agent := f.agent(f.user("standard"))
+	if d := f.send(g, f.message(agent, "own_address", 1)); !d.Allow {
+		t.Fatalf("first send: %q", d.Reason)
+	}
+	d := f.send(g, f.message(agent, "own_address", 1))
+	if d.Allow {
+		t.Fatal("the second send must be held")
+	}
+	now := time.Now().UTC()
+	if !d.RetryAt.After(now) || d.RetryAt.Sub(now) > 24*time.Hour+time.Minute {
+		t.Errorf("retry at %s is not the next UTC midnight (now %s)", d.RetryAt, now)
+	}
+	if d.RetryAt.Hour() != 0 || d.RetryAt.Minute() != 0 {
+		t.Errorf("retry at %s is not a midnight boundary", d.RetryAt)
+	}
+}
+
+// TestTokenCorrelationMatchesTheDurableRow proves the header value the adapter
+// will stamp on the SES submission is the one delivery feedback can be matched
+// back to. A token carrying an unstored ID would leave the detector silently
+// blind rather than visibly broken, so the durable row is authoritative.
+func TestTokenCorrelationMatchesTheDurableRow(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	ref, attempt := f.prepareAndReserve(g, agent, 2)
+
+	_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	headers, err := auth.ValidateEnvelope(auth.AuthorizedRecipients())
+	if err != nil {
+		t.Fatalf("validate envelope: %v", err)
+	}
+
+	var stored string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT correlation_id FROM sending_feedback_correlations
+		 WHERE operation_id = $1 AND submission_attempt = $2`, ref.ID(), attempt.Attempt(),
+	).Scan(&stored); err != nil {
+		t.Fatalf("read correlation: %v", err)
+	}
+	if headers.AttemptCorrelationID != stored {
+		t.Errorf("token correlation %q != stored %q", headers.AttemptCorrelationID, stored)
+	}
+	if headers.TenantRequired || headers.TenantName != "" {
+		t.Errorf("tenant headers = %v/%q, want none before the tenant rollout", headers.TenantRequired, headers.TenantName)
+	}
+
+	// One provenance row per authorized recipient, HMAC only: no address may
+	// outlive the message in this table.
+	var recipients int
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT count(*) FROM sending_feedback_recipients WHERE correlation_id = $1`, stored,
+	).Scan(&recipients); err != nil {
+		t.Fatalf("count recipients: %v", err)
+	}
+	if recipients != 2 {
+		t.Errorf("recipient provenance rows = %d, want 2", recipients)
+	}
+}
+
+// TestReserveNeverDefersAPaidAccountItCannotJudge is the asymmetry that makes
+// the early check safe to act on. Reserve does not hold the locks that make a
+// plan read authoritative, and the worker treats an early hold as "snooze until
+// midnight" — so guessing the Free cap for a paying customer would defer their
+// mail for a day that final authorization would have allowed.
+func TestReserveNeverDefersAPaidAccountItCannotJudge(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 2
+		p.AllCustomerGlobalDailyRecipients = 50
+	}))
+	user := f.user("standard")
+	f.plan(user, "pro")
+	agent := f.agent(user)
+
+	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 10))
+	early, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if !early.Allow {
+		t.Fatalf("Reserve deferred a paid account it cannot judge (%q) — an optimization must not over-deny", early.Reason)
+	}
+	d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if !d.Allow || auth == nil {
+		t.Fatalf("final authorization held a paid account within its cap: %q", d.Reason)
+	}
+
+	// The mirror: a Free account past every possible cap is still denied early,
+	// so the optimization keeps its value.
+	poor := f.user("standard")
+	poorAgent := f.agent(poor)
+	_, bigRef := f.prepareMessage(g, f.message(poorAgent, "own_address", 60))
+	tooBig, _, err := g.Reserve(f.ctx, bigRef)
+	if err != nil {
+		t.Fatalf("reserve oversize: %v", err)
+	}
+	if tooBig.Allow {
+		t.Error("Reserve must still deny what no plan could fit")
+	}
+}

--- a/internal/sendingpolicy/store.go
+++ b/internal/sendingpolicy/store.go
@@ -63,8 +63,16 @@ const attestationCommitRecoveryTimeout = 5 * time.Second
 // by this same object; the Postgres store stays private because there is only
 // ever one adapter.
 type Module struct {
-	pool              *pgxpool.Pool
-	secrets           Secrets
+	pool    *pgxpool.Pool
+	secrets Secrets
+
+	// source and configPolicy say where provider authorization reads its
+	// policy. NewGate sets them from validated startup state; NewModule leaves
+	// the safe self-host default in place, because the operator commands
+	// address the database row explicitly and never consult these.
+	source       PolicySource
+	configPolicy RuntimePolicy
+
 	commitAttestation func(context.Context, pgx.Tx) error
 }
 
@@ -73,8 +81,10 @@ type Module struct {
 // on config source) must not pay for a query.
 func NewModule(pool *pgxpool.Pool, secrets Secrets) *Module {
 	return &Module{
-		pool:    pool,
-		secrets: secrets,
+		pool:         pool,
+		secrets:      secrets,
+		source:       PolicySourceConfig,
+		configPolicy: DisabledPolicy(),
 		commitAttestation: func(ctx context.Context, tx pgx.Tx) error {
 			return tx.Commit(ctx)
 		},

--- a/internal/sendingpolicy/store_integration_test.go
+++ b/internal/sendingpolicy/store_integration_test.go
@@ -1,0 +1,945 @@
+package sendingpolicy_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tokencanopy/e2a/internal/sendingpolicy"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// These tests drive the real ledger against real Postgres. Every address is a
+// .test or example.test domain and every account is synthetic: nothing here may
+// resemble a customer.
+//
+// Where a test is about POLICY NUMBERS it asserts the documented defaults
+// directly. Where it is about MECHANISM it uses deliberately distinct, small,
+// non-default caps per pool — if the code ever reads
+// critical_operational_daily_recipients where it meant violation_, a test using
+// the real 100/100 defaults would pass and a test using 2/3 fails.
+
+const (
+	fxHMAC     = `{"active":1,"keys":{"1":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}}`
+	fxOperator = `{"commitment_key":"AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI","recipients":{"1":"gate-operator@example.test"}}`
+)
+
+type fixture struct {
+	t    *testing.T
+	ctx  context.Context
+	pool *pgxpool.Pool
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	return &fixture{t: t, ctx: context.Background(), pool: testutil.TestDB(t)}
+}
+
+// secrets builds the trust roots a hosted gate holds.
+func (f *fixture) secrets() sendingpolicy.Secrets {
+	f.t.Helper()
+	keyring, err := sendingpolicy.LoadKeyring(fxHMAC)
+	if err != nil {
+		f.t.Fatalf("load keyring: %v", err)
+	}
+	recipients, err := sendingpolicy.LoadOperatorRecipients(fxOperator)
+	if err != nil {
+		f.t.Fatalf("load operator map: %v", err)
+	}
+	return sendingpolicy.Secrets{Keyring: keyring, Recipients: recipients}
+}
+
+// gate returns a config-source gate running `policy`.
+//
+// Config source is the right harness for almost every behavior here: it lets
+// one test pin an exact policy without an activation CAS, and it is the same
+// code path a self-host runs. The tests that are specifically about a policy
+// CHANGE use two gates with different policies, which is exactly the mixed-slot
+// situation the design has to survive.
+func (f *fixture) gate(policy sendingpolicy.RuntimePolicy) sendingpolicy.Gate {
+	f.t.Helper()
+	secrets := f.secrets()
+	// The operator registry is the permanent record a notice recipient is
+	// checked against; register it the way the audited operator command does.
+	module := sendingpolicy.NewModule(f.pool, secrets)
+	if _, err := module.RegisterOperatorRecipients(f.ctx, "fixture", "gate test bootstrap"); err != nil {
+		f.t.Fatalf("register operator recipients: %v", err)
+	}
+	return sendingpolicy.NewGate(f.pool, secrets, sendingpolicy.PolicySourceConfig, policy)
+}
+
+// enforcing returns the disabled default policy with budgets armed and the
+// named caps replaced. Distinct values per pool make a mis-wired field visible.
+func enforcingPolicy(mutate func(*sendingpolicy.RuntimePolicy)) sendingpolicy.RuntimePolicy {
+	p := sendingpolicy.DisabledPolicy()
+	p.BudgetMode = sendingpolicy.ModeEnforce
+	if mutate != nil {
+		mutate(&p)
+	}
+	return p
+}
+
+var userSeq int
+
+func (f *fixture) user(class string) string {
+	f.t.Helper()
+	userSeq++
+	id := fmt.Sprintf("usr_gate_%d", userSeq)
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO users (id, email, google_subject, account_class) VALUES ($1, $2, $3, $4)`,
+		id, id+"@example.test", "sub_"+id, class,
+	); err != nil {
+		f.t.Fatalf("insert user: %v", err)
+	}
+	return id
+}
+
+func (f *fixture) plan(userID, planCode string) {
+	f.t.Helper()
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO account_limits (user_id, plan_code, max_agents, max_domains, max_messages_month, max_storage_bytes)
+		 VALUES ($1, $2, 100, 100, 1000000, 1000000000)
+		 ON CONFLICT (user_id) DO UPDATE SET plan_code = EXCLUDED.plan_code`,
+		userID, planCode,
+	); err != nil {
+		f.t.Fatalf("insert account limits: %v", err)
+	}
+}
+
+func (f *fixture) pause(userID string) {
+	f.t.Helper()
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO account_sending_controls (user_id, state, reason, actor)
+		 VALUES ($1, 'paused', 'test', 'test')
+		 ON CONFLICT (user_id) DO UPDATE SET state = 'paused'`, userID,
+	); err != nil {
+		f.t.Fatalf("pause account: %v", err)
+	}
+}
+
+var agentSeq int
+
+func (f *fixture) agent(userID string) string {
+	f.t.Helper()
+	agentSeq++
+	id := fmt.Sprintf("agt_gate_%d", agentSeq)
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO agent_identities (id, user_id, registered_domain, name) VALUES ($1, $2, $3, $4)`,
+		id, userID, "agents.e2a.dev", id,
+	); err != nil {
+		f.t.Fatalf("insert agent: %v", err)
+	}
+	return id
+}
+
+var messageSeq int
+
+// message inserts an outbound message with `count` distinct recipients.
+func (f *fixture) message(agentID, sentAs string, count int) string {
+	f.t.Helper()
+	messageSeq++
+	id := fmt.Sprintf("msg_gate_%d", messageSeq)
+	to := make([]string, count)
+	for i := range to {
+		to[i] = fmt.Sprintf("rcpt-%d-%d@example.test", messageSeq, i)
+	}
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO messages (id, agent_id, direction, to_recipients, sent_as, status)
+		 VALUES ($1, $2, 'outbound', $3, $4, 'sent')`,
+		id, agentID, to, sentAs,
+	); err != nil {
+		f.t.Fatalf("insert message: %v", err)
+	}
+	return id
+}
+
+func (f *fixture) webhook(userID string) string {
+	f.t.Helper()
+	id := fmt.Sprintf("wh_gate_%d", messageSeq+1000)
+	messageSeq++
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO webhooks (id, user_id, url, signing_secret, events)
+		 VALUES ($1, $2, $3, $4, ARRAY['message.received'])`,
+		id, userID, "https://hook.example.test/"+id, "secret",
+	); err != nil {
+		f.t.Fatalf("insert webhook: %v", err)
+	}
+	return id
+}
+
+// inTx runs fn inside a committed transaction, the way an acceptance surface
+// calls the Prepare* methods.
+func (f *fixture) inTx(fn func(tx pgx.Tx) error) {
+	f.t.Helper()
+	tx, err := f.pool.Begin(f.ctx)
+	if err != nil {
+		f.t.Fatalf("begin: %v", err)
+	}
+	if err := fn(tx); err != nil {
+		_ = tx.Rollback(f.ctx)
+		f.t.Fatalf("tx body: %v", err)
+	}
+	if err := tx.Commit(f.ctx); err != nil {
+		f.t.Fatalf("commit: %v", err)
+	}
+}
+
+// prepareMessage runs the acceptance half and returns the operation reference.
+func (f *fixture) prepareMessage(g sendingpolicy.Gate, messageID string) (sendingpolicy.AcceptanceDecision, sendingpolicy.OperationRef) {
+	f.t.Helper()
+	var decision sendingpolicy.AcceptanceDecision
+	var ref sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		decision, ref, err = g.PrepareExternalTx(f.ctx, tx, messageID)
+		return err
+	})
+	return decision, ref
+}
+
+// send runs the whole worker sequence for one message and reports the final
+// authorization decision.
+func (f *fixture) send(g sendingpolicy.Gate, messageID string) sendingpolicy.Decision {
+	f.t.Helper()
+	accept, ref := f.prepareMessage(g, messageID)
+	if accept != sendingpolicy.AcceptanceAccept {
+		return sendingpolicy.Decision{Allow: false, Reason: string(accept)}
+	}
+	return f.authorize(g, ref)
+}
+
+// authorize runs Reserve then ConsumeAttempt, asserting only that the two
+// agree: an early hold must not be followed by a final allow for the same
+// exhausted pool.
+func (f *fixture) authorize(g sendingpolicy.Gate, ref sendingpolicy.OperationRef) sendingpolicy.Decision {
+	f.t.Helper()
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		f.t.Fatalf("reserve: %v", err)
+	}
+	decision, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		f.t.Fatalf("consume: %v", err)
+	}
+	if decision.Allow != (auth != nil) {
+		f.t.Fatalf("allow=%v but token presence=%v — a hold must never return a token", decision.Allow, auth != nil)
+	}
+	return decision
+}
+
+func (f *fixture) counter(scope sendingpolicy.Scope, scopeID string) (reserved, confirmed int) {
+	f.t.Helper()
+	err := f.pool.QueryRow(f.ctx, `
+		SELECT COALESCE(SUM(reserved_count), 0), COALESCE(SUM(confirmed_count), 0)
+		  FROM sending_budget_counters
+		 WHERE scope = $1 AND scope_id = $2`, string(scope), scopeID,
+	).Scan(&reserved, &confirmed)
+	if err != nil {
+		f.t.Fatalf("read counter: %v", err)
+	}
+	return reserved, confirmed
+}
+
+// --- Documented policy numbers -------------------------------------------
+
+// TestDocumentedDefaultCaps pins the six numbers the rollout record approves.
+// They are the ones an activation gate signs off on, so a silent edit to any of
+// them must fail a test rather than ship as a config tweak.
+func TestDocumentedDefaultCaps(t *testing.T) {
+	p := sendingpolicy.DisabledPolicy()
+	for _, tc := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"free account daily", p.DefaultAccountDailyRecipients, 100},
+		{"shared domain account daily", p.SharedDomainAccountDailyRecip, 50},
+		{"probation global daily", p.ProbationGlobalDailyRecipients, 150},
+		{"all customer global daily", p.AllCustomerGlobalDailyRecipients, 5000},
+		{"critical operational daily", p.CriticalOperationalDailyRecip, 100},
+		{"violation operational daily", p.ViolationOperationalDailyRecip, 100},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// --- Account caps and classification -------------------------------------
+
+// TestFreeAccountDailyCapBoundsDedicatedSending proves the Free ceiling applies
+// to a customer's own verified domain, where the shared cap does not.
+func TestFreeAccountDailyCapBoundsDedicatedSending(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 4
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	if d := f.send(g, f.message(agent, "own_address", 4)); !d.Allow {
+		t.Fatalf("first 4 recipients must fit the Free allowance, got hold %q", d.Reason)
+	}
+	d := f.send(g, f.message(agent, "own_address", 1))
+	if d.Allow {
+		t.Fatal("the 5th recipient must be held")
+	}
+	if d.Reason != sendingpolicy.ReasonAccountDailyBudget {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonAccountDailyBudget)
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeAccountSharedDaily, user); confirmed != 0 {
+		t.Errorf("dedicated sending charged the shared-domain counter (%d)", confirmed)
+	}
+}
+
+// TestPaidPlanRaisesAccountCapToTheGlobalCeiling proves a paid plan is not
+// "unlimited" — it is limited at the platform ceiling and still recorded per
+// account, so one paid customer's day remains visible and bounded.
+func TestPaidPlanRaisesAccountCapToTheGlobalCeiling(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 2
+		p.AllCustomerGlobalDailyRecipients = 6
+	}))
+	user := f.user("standard")
+	f.plan(user, "pro")
+	agent := f.agent(user)
+
+	if d := f.send(g, f.message(agent, "own_address", 6)); !d.Allow {
+		t.Fatalf("a paid account may use the whole ceiling, got hold %q", d.Reason)
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeAccountDaily, user); confirmed != 6 {
+		t.Errorf("account_daily confirmed = %d, want 6 — paid usage must still be recorded", confirmed)
+	}
+	if d := f.send(g, f.message(agent, "own_address", 1)); d.Allow {
+		t.Fatal("a paid account must still stop at the platform ceiling")
+	}
+}
+
+// TestUnknownPlanCodeFallsBackToFree proves an unnamed plan is not evidence of
+// payment. A stale or attacker-influenced plan_code must not widen a cap.
+func TestUnknownPlanCodeFallsBackToFree(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 2
+		p.AllCustomerGlobalDailyRecipients = 50
+	}))
+	user := f.user("standard")
+	f.plan(user, "enterprise_unlimited_totally_real")
+	agent := f.agent(user)
+
+	if d := f.send(g, f.message(agent, "own_address", 2)); !d.Allow {
+		t.Fatalf("first 2 must fit, got hold %q", d.Reason)
+	}
+	if d := f.send(g, f.message(agent, "own_address", 1)); d.Allow {
+		t.Fatal("an unknown plan code must be capped at the Free default")
+	}
+}
+
+// TestSharedDomainCapAppliesRegardlessOfPlan proves paying does not buy more
+// shared-reputation sending: the way to send more is a verified custom domain.
+func TestSharedDomainCapAppliesRegardlessOfPlan(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.SharedDomainAccountDailyRecip = 3
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	f.plan(user, "scale")
+	agent := f.agent(user)
+
+	if d := f.send(g, f.message(agent, "relay", 3)); !d.Allow {
+		t.Fatalf("first 3 shared recipients must fit, got hold %q", d.Reason)
+	}
+	d := f.send(g, f.message(agent, "relay", 1))
+	if d.Allow {
+		t.Fatal("a paid account must still be bounded by the shared-domain cap")
+	}
+	if d.Reason != sendingpolicy.ReasonAccountSharedBudget {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonAccountSharedBudget)
+	}
+}
+
+// TestSharedMailboxAndNotificationsShareOneAccountCounter is the mixed-path
+// invariant: a customer cannot get a second 50-recipient allowance by causing
+// platform notification mail instead of sending its own.
+func TestSharedMailboxAndNotificationsShareOneAccountCounter(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.SharedDomainAccountDailyRecip = 3
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	// Two shared-mailbox recipients.
+	if d := f.send(g, f.message(agent, "relay", 2)); !d.Allow {
+		t.Fatalf("shared message must fit, got hold %q", d.Reason)
+	}
+
+	// One HITL notification: same pool, one unit.
+	held := f.message(agent, "relay", 1)
+	var noticeRef sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		noticeRef, err = g.PrepareNotificationTx(f.ctx, tx, sendingpolicy.NewHITLNotificationRef(held))
+		return err
+	})
+	if d := f.authorize(g, noticeRef); !d.Allow {
+		t.Fatalf("the third unit must fit, got hold %q", d.Reason)
+	}
+
+	// A webhook-health notification is the fourth unit and must be held.
+	hook := f.webhook(user)
+	var hookRef sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		hookRef, err = g.PrepareNotificationTx(f.ctx, tx, sendingpolicy.NewWebhookHealthNotificationRef(hook))
+		return err
+	})
+	d := f.authorize(g, hookRef)
+	if d.Allow {
+		t.Fatal("customer-triggered notifications must share the account's shared-domain pool")
+	}
+	if d.Reason != sendingpolicy.ReasonAccountSharedBudget {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonAccountSharedBudget)
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeAccountSharedDaily, user); confirmed != 3 {
+		t.Errorf("shared counter confirmed = %d, want exactly the cap 3", confirmed)
+	}
+}
+
+// TestProbationPoolBoundsSybilGrowth proves the shared probation pool is what
+// stops "more accounts" from multiplying the per-account allowance.
+func TestProbationPoolBoundsSybilGrowth(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.SharedDomainAccountDailyRecip = 2
+		p.ProbationGlobalDailyRecipients = 4
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+	}))
+
+	for i := 0; i < 2; i++ {
+		agent := f.agent(f.user("standard"))
+		if d := f.send(g, f.message(agent, "relay", 2)); !d.Allow {
+			t.Fatalf("account %d must fit the probation pool, got hold %q", i, d.Reason)
+		}
+	}
+	third := f.agent(f.user("standard"))
+	d := f.send(g, f.message(third, "relay", 1))
+	if d.Allow {
+		t.Fatal("a fresh account must not find fresh probation capacity")
+	}
+	if d.Reason != sendingpolicy.ReasonGlobalProbation {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonGlobalProbation)
+	}
+}
+
+// TestDedicatedDomainSkipsProbationAndSharedPools proves the classification is
+// derived from the server-owned sent_as column, not from anything a caller says.
+func TestDedicatedDomainSkipsProbationAndSharedPools(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.SharedDomainAccountDailyRecip = 1
+		p.ProbationGlobalDailyRecipients = 1
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+	}))
+	agent := f.agent(f.user("standard"))
+
+	if d := f.send(g, f.message(agent, "own_address", 5)); !d.Allow {
+		t.Fatalf("custom-domain sending must not touch the shared pools, got hold %q", d.Reason)
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeGlobalProbation, "probation"); reserved != 0 {
+		t.Errorf("probation counter = %d, want 0", reserved)
+	}
+}
+
+// TestUnknownSentAsIsTreatedAsShared proves the fail-closed direction: a row
+// whose sent_as is absent or unrecognized gets the STRICTER cap, never the
+// exemption.
+func TestUnknownSentAsIsTreatedAsShared(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.SharedDomainAccountDailyRecip = 1
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	messageSeq++
+	id := fmt.Sprintf("msg_gate_null_%d", messageSeq)
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO messages (id, agent_id, direction, to_recipients, status)
+		 VALUES ($1, $2, 'outbound', ARRAY['a@example.test'], 'sent')`, id, agent,
+	); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+	if d := f.send(g, id); !d.Allow {
+		t.Fatalf("first unit must fit, got hold %q", d.Reason)
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeAccountSharedDaily, user); confirmed != 1 {
+		t.Fatalf("an unknown sent_as must charge the shared counter, confirmed = %d", confirmed)
+	}
+}
+
+// TestTrustedClassesBypassEveryPoolAndOthersDoNot proves the exemption list is
+// closed and positive. `demo`, an unknown class, and the empty string are all
+// budgeted — a public demo must not become the abuse bypass.
+func TestTrustedClassesBypassEveryPoolAndOthersDoNot(t *testing.T) {
+	for _, tc := range []struct {
+		class  string
+		exempt bool
+	}{
+		{"system", true},
+		{"internal", true},
+		{"standard", false},
+		{"demo", false},
+	} {
+		t.Run(tc.class, func(t *testing.T) {
+			f := newFixture(t)
+			g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+				p.DefaultAccountDailyRecipients = 1
+				p.SharedDomainAccountDailyRecip = 1
+				p.ProbationGlobalDailyRecipients = 1
+				p.AllCustomerGlobalDailyRecipients = 1
+			}))
+			user := f.user(tc.class)
+			agent := f.agent(user)
+
+			d := f.send(g, f.message(agent, "relay", 5))
+			if d.Allow != tc.exempt {
+				t.Fatalf("class %q allow = %v, want %v (reason %q)", tc.class, d.Allow, tc.exempt, d.Reason)
+			}
+			reserved, _ := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers")
+			if tc.exempt && reserved != 0 {
+				t.Errorf("a trusted class charged the global pool (%d)", reserved)
+			}
+		})
+	}
+}
+
+// TestPublicFeedbackUsesGlobalPoolsAndNoAccountCounter proves the
+// unauthenticated form shares the reputation surface without inventing an
+// account to blame.
+func TestPublicFeedbackUsesGlobalPoolsAndNoAccountCounter(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+
+	ref, err := g.PreparePublicFeedback(f.ctx, sendingpolicy.NewPublicFeedbackRef(
+		"sub_1", []string{"feedback@example.test", "Feedback@example.test", "ops@example.test"}))
+	if err != nil {
+		t.Fatalf("prepare public feedback: %v", err)
+	}
+	if d := f.authorize(g, ref); !d.Allow {
+		t.Fatalf("public feedback must be allowed with capacity, got hold %q", d.Reason)
+	}
+
+	// The duplicate spelling counts once.
+	if _, confirmed := f.counter(sendingpolicy.ScopeGlobalAll, "all-customers"); confirmed != 2 {
+		t.Errorf("global_all confirmed = %d, want 2 (duplicates collapse)", confirmed)
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeGlobalProbation, "probation"); confirmed != 2 {
+		t.Errorf("global_probation confirmed = %d, want 2", confirmed)
+	}
+	var accountRows int
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT count(*) FROM sending_budget_counters WHERE scope IN ('account_daily','account_shared_daily')`,
+	).Scan(&accountRows); err != nil {
+		t.Fatalf("count account counters: %v", err)
+	}
+	if accountRows != 0 {
+		t.Errorf("public feedback created %d account counter rows, want 0", accountRows)
+	}
+}
+
+// --- Notices --------------------------------------------------------------
+
+// noticeEvent inserts a committed pause event with both audiences, the way the
+// pause transition does.
+func (f *fixture) pauseNotice(userID string) string {
+	f.t.Helper()
+	controlEvent := fmt.Sprintf("ace_%s", userID)
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO account_sending_control_events (id, account_ref, old_state, new_state, reason, actor, expires_at)
+		VALUES ($1, $2, 'active', 'paused', 'test', 'test', now() + interval '90 days')`,
+		controlEvent, userID,
+	); err != nil {
+		f.t.Fatalf("insert control event: %v", err)
+	}
+	eventID := fmt.Sprintf("spn_%s", userID)
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO sending_protection_notice_events
+		    (id, account_ref, kind, reason_code, source_event_id, expires_at)
+		VALUES ($1, $2, 'pause', 'manual', $3, now() + interval '90 days')`,
+		eventID, userID, controlEvent,
+	); err != nil {
+		f.t.Fatalf("insert notice event: %v", err)
+	}
+	for _, audience := range []string{"owner", "operator"} {
+		if _, err := f.pool.Exec(f.ctx,
+			`INSERT INTO sending_protection_notice_deliveries (event_id, audience) VALUES ($1, $2)`,
+			eventID, audience,
+		); err != nil {
+			f.t.Fatalf("insert notice delivery: %v", err)
+		}
+	}
+	return eventID
+}
+
+// TestPauseNoticeUsesTheCriticalPoolAndReachesBothAudiences proves a paused
+// account still gets told, on a pool no customer traffic can exhaust, and that
+// the operator copy goes to the registered mailbox version rather than to
+// anything derived from the customer.
+func TestPauseNoticeUsesTheCriticalPoolAndReachesBothAudiences(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		// Every customer pool is exhausted at zero headroom; the notice must
+		// still go out.
+		p.DefaultAccountDailyRecipients = 1
+		p.SharedDomainAccountDailyRecip = 1
+		p.ProbationGlobalDailyRecipients = 1
+		p.AllCustomerGlobalDailyRecipients = 1
+		p.CriticalOperationalDailyRecip = 5
+	}))
+	user := f.user("standard")
+	f.pause(user)
+	eventID := f.pauseNotice(user)
+
+	for _, audience := range []sendingpolicy.Audience{sendingpolicy.AudienceOwner, sendingpolicy.AudienceOperator} {
+		var ref sendingpolicy.OperationRef
+		f.inTx(func(tx pgx.Tx) error {
+			var err error
+			ref, err = g.PrepareProtectionNoticeTx(f.ctx, tx, sendingpolicy.NewProtectionNoticeRef(eventID, audience))
+			return err
+		})
+		_, attempt, err := g.Reserve(f.ctx, ref)
+		if err != nil {
+			t.Fatalf("%s reserve: %v", audience, err)
+		}
+		decision, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+		if err != nil {
+			t.Fatalf("%s consume: %v", audience, err)
+		}
+		if !decision.Allow {
+			t.Fatalf("%s notice held (%q) — a pause notice must survive exhausted customer pools", audience, decision.Reason)
+		}
+		got := auth.AuthorizedRecipients()
+		want := user + "@example.test"
+		if audience == sendingpolicy.AudienceOperator {
+			want = "gate-operator@example.test"
+		}
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("%s recipients = %v, want [%s]", audience, got, want)
+		}
+	}
+	if _, confirmed := f.counter(sendingpolicy.ScopeGlobalCritical, "critical-operational"); confirmed != 2 {
+		t.Errorf("critical pool confirmed = %d, want 2 (one per audience)", confirmed)
+	}
+	if reserved, _ := f.counter(sendingpolicy.ScopeGlobalViolation, "violation-operational"); reserved != 0 {
+		t.Errorf("a pause notice touched the violation pool (%d) — the pools must be independent", reserved)
+	}
+}
+
+// TestEnforcedAccountDenialEnqueuesExactlyOneNoticePerScopePerDay proves the
+// customer hears about its own violation once a day per failed scope, not once
+// per held message.
+func TestEnforcedAccountDenialEnqueuesExactlyOneNoticePerScopePerDay(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.SharedDomainAccountDailyRecip = 1
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	if d := f.send(g, f.message(agent, "relay", 1)); !d.Allow {
+		t.Fatalf("first unit must fit: %q", d.Reason)
+	}
+	for i := 0; i < 3; i++ {
+		if d := f.send(g, f.message(agent, "relay", 1)); d.Allow {
+			t.Fatalf("denial %d unexpectedly allowed", i)
+		}
+	}
+
+	var events int
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT count(*) FROM sending_protection_notice_events
+		 WHERE kind = 'budget_violation' AND account_ref = $1`, user,
+	).Scan(&events); err != nil {
+		t.Fatalf("count violation events: %v", err)
+	}
+	if events != 1 {
+		t.Fatalf("violation events = %d, want exactly 1 for three denials", events)
+	}
+
+	rows, err := f.pool.Query(f.ctx, `
+		SELECT audience FROM sending_protection_notice_deliveries AS d
+		  JOIN sending_protection_notice_events AS e ON e.id = d.event_id
+		 WHERE e.kind = 'budget_violation' ORDER BY audience`)
+	if err != nil {
+		t.Fatalf("read deliveries: %v", err)
+	}
+	defer rows.Close()
+	var audiences []string
+	for rows.Next() {
+		var a string
+		if err := rows.Scan(&a); err != nil {
+			t.Fatalf("scan audience: %v", err)
+		}
+		audiences = append(audiences, a)
+	}
+	if len(audiences) != 2 || audiences[0] != "operator" || audiences[1] != "owner" {
+		t.Errorf("audiences = %v, want [operator owner]", audiences)
+	}
+}
+
+// TestGlobalDenialBlamesNobodyAndCoalesces proves a platform guardrail is
+// reported once per scope and day as an operator incident — never as a
+// violation email to the innocent accounts that happened to collide with it.
+func TestGlobalDenialBlamesNobodyAndCoalesces(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.AllCustomerGlobalDailyRecipients = 1
+		p.DefaultAccountDailyRecipients = 100
+		p.SharedDomainAccountDailyRecip = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+
+	first := f.agent(f.user("standard"))
+	if d := f.send(g, f.message(first, "own_address", 1)); !d.Allow {
+		t.Fatalf("first unit must fit: %q", d.Reason)
+	}
+	for i := 0; i < 2; i++ {
+		agent := f.agent(f.user("standard"))
+		if d := f.send(g, f.message(agent, "own_address", 1)); d.Allow {
+			t.Fatal("global ceiling must hold later accounts")
+		}
+	}
+	// A public-feedback caller hitting the same exhausted pool must coalesce
+	// into the same incident rather than opening a second one.
+	feedback, err := g.PreparePublicFeedback(f.ctx, sendingpolicy.NewPublicFeedbackRef("sub_g", []string{"ops@example.test"}))
+	if err != nil {
+		t.Fatalf("prepare feedback: %v", err)
+	}
+	if d := f.authorize(g, feedback); d.Allow {
+		t.Fatal("public feedback must also be held by the exhausted global pool")
+	}
+
+	var guardrails, violations int
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT count(*) FILTER (WHERE kind = 'global_guardrail'), count(*) FILTER (WHERE kind = 'budget_violation')
+		   FROM sending_protection_notice_events`,
+	).Scan(&guardrails, &violations); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if guardrails != 1 {
+		t.Errorf("guardrail events = %d, want 1", guardrails)
+	}
+	if violations != 0 {
+		t.Errorf("global exhaustion produced %d customer violation notices, want 0", violations)
+	}
+
+	var audiences int
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT count(*) FROM sending_protection_notice_deliveries AS d
+		  JOIN sending_protection_notice_events AS e ON e.id = d.event_id
+		 WHERE e.kind = 'global_guardrail'`).Scan(&audiences); err != nil {
+		t.Fatalf("count guardrail deliveries: %v", err)
+	}
+	if audiences != 1 {
+		t.Errorf("guardrail deliveries = %d, want 1 (operator only)", audiences)
+	}
+}
+
+// TestOperationalDenialDoesNotRecurse proves the notice system cannot feed
+// itself: a notice held by its own exhausted pool must not enqueue a notice
+// about being held.
+func TestOperationalDenialDoesNotRecurse(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.CriticalOperationalDailyRecip = 1
+	}))
+	user := f.user("standard")
+	eventID := f.pauseNotice(user)
+
+	for _, audience := range []sendingpolicy.Audience{sendingpolicy.AudienceOwner, sendingpolicy.AudienceOperator} {
+		var ref sendingpolicy.OperationRef
+		f.inTx(func(tx pgx.Tx) error {
+			var err error
+			ref, err = g.PrepareProtectionNoticeTx(f.ctx, tx, sendingpolicy.NewProtectionNoticeRef(eventID, audience))
+			return err
+		})
+		f.authorize(g, ref)
+	}
+
+	var extra int
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT count(*) FROM sending_protection_notice_events WHERE kind <> 'pause'`,
+	).Scan(&extra); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if extra != 0 {
+		t.Errorf("an exhausted operational pool enqueued %d further notices, want 0", extra)
+	}
+}
+
+// TestGlobalGuardrailHasNoOwnerAudience proves the schema invariant is also an
+// interface invariant: there is nobody to blame for a platform incident.
+func TestGlobalGuardrailHasNoOwnerAudience(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO sending_protection_notice_events
+		    (id, kind, reason_code, budget_scope, ledger_day, expires_at)
+		VALUES ('spn_guard', 'global_guardrail', 'global_budget_exhausted', 'global_all',
+		        CURRENT_DATE, now() + interval '90 days')`); err != nil {
+		t.Fatalf("insert guardrail event: %v", err)
+	}
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO sending_protection_notice_deliveries (event_id, audience) VALUES ('spn_guard', 'owner')`,
+	); err != nil {
+		t.Fatalf("insert owner delivery: %v", err)
+	}
+
+	tx, err := f.pool.Begin(f.ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(f.ctx) }()
+	_, err = g.PrepareProtectionNoticeTx(f.ctx, tx,
+		sendingpolicy.NewProtectionNoticeRef("spn_guard", sendingpolicy.AudienceOwner))
+	if !errors.Is(err, sendingpolicy.ErrAudienceNotAllowed) {
+		t.Fatalf("error = %v, want ErrAudienceNotAllowed", err)
+	}
+}
+
+// --- Modes ----------------------------------------------------------------
+
+// TestShadowModeRecordsDemandWithoutBlockingOrBlaming proves the shadow window
+// produces the number the activation gate has to approve: real demand, past the
+// cap, with no customer effect at all.
+func TestShadowModeRecordsDemandWithoutBlockingOrBlaming(t *testing.T) {
+	f := newFixture(t)
+	policy := sendingpolicy.DisabledPolicy()
+	policy.BudgetMode = sendingpolicy.ModeShadow
+	policy.SharedDomainAccountDailyRecip = 1
+	g := f.gate(policy)
+
+	user := f.user("standard")
+	agent := f.agent(user)
+	for i := 0; i < 3; i++ {
+		if d := f.send(g, f.message(agent, "relay", 1)); !d.Allow {
+			t.Fatalf("shadow mode must never deny (attempt %d held: %q)", i, d.Reason)
+		}
+	}
+	_, confirmed := f.counter(sendingpolicy.ScopeAccountSharedDaily, user)
+	if confirmed != 3 {
+		t.Errorf("shadow confirmed = %d, want 3 — the counter must record demand past the cap", confirmed)
+	}
+	var notices int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM sending_protection_notice_events`).Scan(&notices); err != nil {
+		t.Fatalf("count notices: %v", err)
+	}
+	if notices != 0 {
+		t.Errorf("shadow mode enqueued %d notices, want 0", notices)
+	}
+}
+
+// TestDisabledModeChargesNothingButStillAuthorizes proves the production state
+// this slice actually ships in: the authorization seam is live, the pools are
+// untouched.
+func TestDisabledModeChargesNothingButStillAuthorizes(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	agent := f.agent(f.user("standard"))
+
+	if d := f.send(g, f.message(agent, "relay", 500)); !d.Allow {
+		t.Fatalf("disabled mode must allow, got hold %q", d.Reason)
+	}
+	var counters int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM sending_budget_counters`).Scan(&counters); err != nil {
+		t.Fatalf("count counters: %v", err)
+	}
+	if counters != 0 {
+		t.Errorf("disabled mode wrote %d counter rows, want 0", counters)
+	}
+}
+
+// TestPausedAccountIsRefusedAtBothDoors proves the pause is checked at
+// acceptance (so no unsendable mail is queued) and again at final authorization
+// (so mail queued before the pause never leaves), independently of budget mode.
+func TestPausedAccountIsRefusedAtBothDoors(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	// Queued while active.
+	queued := f.message(agent, "relay", 1)
+	accept, ref := f.prepareMessage(g, queued)
+	if accept != sendingpolicy.AcceptanceAccept {
+		t.Fatalf("acceptance = %q, want accept", accept)
+	}
+
+	f.pause(user)
+
+	if d := f.authorize(g, ref); d.Allow {
+		t.Fatal("a pause must stop mail that was already queued")
+	} else if d.Reason != sendingpolicy.ReasonAccountPaused {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonAccountPaused)
+	}
+
+	if accept, _ := f.prepareMessage(g, f.message(agent, "relay", 1)); accept != sendingpolicy.AcceptanceSendingPaused {
+		t.Errorf("acceptance = %q, want sending_paused", accept)
+	}
+}
+
+// TestLoopbackIsNotProviderBound proves the one exempt path stays exempt: an
+// agent writing to itself never reaches SES, so it gets no operation and
+// consumes nothing.
+func TestLoopbackIsNotProviderBound(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 1
+		p.SharedDomainAccountDailyRecip = 1
+	}))
+	agent := f.agent(f.user("standard"))
+
+	messageSeq++
+	id := fmt.Sprintf("msg_gate_loop_%d", messageSeq)
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO messages (id, agent_id, direction, method, to_recipients, sent_as, status)
+		VALUES ($1, $2, 'outbound', 'loopback', ARRAY['self@example.test'], 'own_address', 'sent')`,
+		id, agent,
+	); err != nil {
+		t.Fatalf("insert loopback message: %v", err)
+	}
+	accept, ref := f.prepareMessage(g, id)
+	if accept != sendingpolicy.AcceptanceAccept {
+		t.Fatalf("acceptance = %q, want accept", accept)
+	}
+	if !ref.IsZero() {
+		t.Error("a loopback message must not get a provider operation")
+	}
+	var ops int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM sending_provider_operations`).Scan(&ops); err != nil {
+		t.Fatalf("count operations: %v", err)
+	}
+	if ops != 0 {
+		t.Errorf("loopback created %d operations, want 0", ops)
+	}
+}

--- a/internal/sendingpolicy/store_integration_test.go
+++ b/internal/sendingpolicy/store_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -139,6 +140,16 @@ var messageSeq int
 
 // message inserts an outbound message with `count` distinct recipients.
 func (f *fixture) message(agentID, sentAs string, count int) string {
+	return f.messageWithStatus(agentID, sentAs, count, "sent")
+}
+
+// pendingMessage inserts one awaiting human approval — the only shape a HITL
+// notification may be derived from.
+func (f *fixture) pendingMessage(agentID, sentAs string) string {
+	return f.messageWithStatus(agentID, sentAs, 1, "pending_review")
+}
+
+func (f *fixture) messageWithStatus(agentID, sentAs string, count int, status string) string {
 	f.t.Helper()
 	messageSeq++
 	id := fmt.Sprintf("msg_gate_%d", messageSeq)
@@ -148,8 +159,8 @@ func (f *fixture) message(agentID, sentAs string, count int) string {
 	}
 	if _, err := f.pool.Exec(f.ctx,
 		`INSERT INTO messages (id, agent_id, direction, to_recipients, sent_as, status)
-		 VALUES ($1, $2, 'outbound', $3, $4, 'sent')`,
-		id, agentID, to, sentAs,
+		 VALUES ($1, $2, 'outbound', $3, $4, $5)`,
+		id, agentID, to, sentAs, status,
 	); err != nil {
 		f.t.Fatalf("insert message: %v", err)
 	}
@@ -211,14 +222,23 @@ func (f *fixture) send(g sendingpolicy.Gate, messageID string) sendingpolicy.Dec
 	return f.authorize(g, ref)
 }
 
-// authorize runs Reserve then ConsumeAttempt, asserting only that the two
-// agree: an early hold must not be followed by a final allow for the same
-// exhausted pool.
+// authorize runs the worker's real sequence: Reserve, and then ConsumeAttempt
+// ONLY if Reserve allowed.
+//
+// This fidelity is load-bearing, and an earlier version of this helper did not
+// have it — it threw Reserve's decision away and always called ConsumeAttempt.
+// That made roughly twenty cap and notice tests pass over three genuine bugs,
+// because the real worker snoozes on an early hold and never reaches the final
+// authorization those tests were actually exercising. A test helper that is
+// more forgiving than production is not a helper.
 func (f *fixture) authorize(g sendingpolicy.Gate, ref sendingpolicy.OperationRef) sendingpolicy.Decision {
 	f.t.Helper()
-	_, attempt, err := g.Reserve(f.ctx, ref)
+	early, attempt, err := g.Reserve(f.ctx, ref)
 	if err != nil {
 		f.t.Fatalf("reserve: %v", err)
+	}
+	if !early.Allow {
+		return early
 	}
 	decision, auth, err := g.ConsumeAttempt(f.ctx, attempt)
 	if err != nil {
@@ -385,7 +405,7 @@ func TestSharedMailboxAndNotificationsShareOneAccountCounter(t *testing.T) {
 	}
 
 	// One HITL notification: same pool, one unit.
-	held := f.message(agent, "relay", 1)
+	held := f.pendingMessage(agent, "relay")
 	var noticeRef sendingpolicy.OperationRef
 	f.inTx(func(tx pgx.Tx) error {
 		var err error
@@ -941,5 +961,168 @@ func TestLoopbackIsNotProviderBound(t *testing.T) {
 	}
 	if ops != 0 {
 		t.Errorf("loopback created %d operations, want 0", ops)
+	}
+}
+
+// TestLoopbackExemptionIsGrantedOnShapeNotLabel proves the one unbudgeted
+// message path cannot be entered by writing a word into a column.
+//
+// `method='loopback'` is one write away from being the whole bypass, so the row
+// must also look like the only thing the spec exempts: exactly one To, no Cc,
+// no Bcc. Anything else is ordinary provider-bound mail.
+func TestLoopbackExemptionIsGrantedOnShapeNotLabel(t *testing.T) {
+	for name, shape := range map[string]struct {
+		to, cc, bcc []string
+		exempt      bool
+	}{
+		"exact self send":   {to: []string{"self@example.test"}, exempt: true},
+		"loopback plus cc":  {to: []string{"self@example.test"}, cc: []string{"out@example.test"}},
+		"loopback plus bcc": {to: []string{"self@example.test"}, bcc: []string{"out@example.test"}},
+		"loopback fan-out":  {to: []string{"self@example.test", "out@example.test"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t)
+			g := f.gate(enforcingPolicy(nil))
+			agent := f.agent(f.user("standard"))
+
+			messageSeq++
+			id := fmt.Sprintf("msg_gate_shape_%d", messageSeq)
+			if _, err := f.pool.Exec(f.ctx, `
+				INSERT INTO messages (id, agent_id, direction, method, to_recipients, cc, bcc, sent_as, status)
+				VALUES ($1, $2, 'outbound', 'loopback', $3, $4, $5, 'own_address', 'sent')`,
+				id, agent, shape.to, shape.cc, shape.bcc,
+			); err != nil {
+				t.Fatalf("insert message: %v", err)
+			}
+
+			accept, ref := f.prepareMessage(g, id)
+			if accept != sendingpolicy.AcceptanceAccept {
+				t.Fatalf("acceptance = %q, want accept", accept)
+			}
+			if ref.IsZero() != shape.exempt {
+				t.Fatalf("exempt = %v, want %v (a %q message)", ref.IsZero(), shape.exempt, name)
+			}
+		})
+	}
+}
+
+// TestHITLNotificationRequiresAMessageAwaitingReview proves a notification is
+// owed only for a message that is actually held. Deriving one from a settled
+// message would let any old row mint customer-attributed provider capacity.
+func TestHITLNotificationRequiresAMessageAwaitingReview(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	user := f.user("standard")
+	agent := f.agent(user)
+
+	settled := f.message(agent, "relay", 1) // status 'sent'
+	tx, err := f.pool.Begin(f.ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	_, err = g.PrepareNotificationTx(f.ctx, tx, sendingpolicy.NewHITLNotificationRef(settled))
+	_ = tx.Rollback(f.ctx)
+	if !errors.Is(err, sendingpolicy.ErrSourceUnavailable) {
+		t.Fatalf("notification from a settled message = %v, want ErrSourceUnavailable", err)
+	}
+
+	held := f.pendingMessage(agent, "relay")
+	var ref sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		ref, err = g.PrepareNotificationTx(f.ctx, tx, sendingpolicy.NewHITLNotificationRef(held))
+		return err
+	})
+	if ref.IsZero() {
+		t.Fatal("a held message must produce a notification operation")
+	}
+}
+
+// TestNonCustomerCorrelationsExpireAtCreation pins the retention split.
+//
+// A customer's correlation must outlive its message for as long as the account
+// exists, so a controlled recipient cannot wait out a fixed timer before
+// complaining; the post-deletion janitor sets that horizon. A non-customer
+// operation has no account to outlive, so it gets the horizon immediately
+// rather than being retained forever.
+func TestNonCustomerCorrelationsExpireAtCreation(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+
+	// Customer message: no expiry yet.
+	agent := f.agent(f.user("standard"))
+	_, customerRef := f.prepareMessage(g, f.message(agent, "own_address", 1))
+	if d := f.authorize(g, customerRef); !d.Allow {
+		t.Fatalf("customer send: %q", d.Reason)
+	}
+
+	// Public feedback: expiry set at creation.
+	feedbackRef, err := g.PreparePublicFeedback(f.ctx,
+		sendingpolicy.NewPublicFeedbackRef("sub_exp", []string{"ops@example.test"}))
+	if err != nil {
+		t.Fatalf("prepare feedback: %v", err)
+	}
+	if d := f.authorize(g, feedbackRef); !d.Allow {
+		t.Fatalf("feedback send: %q", d.Reason)
+	}
+
+	for _, tc := range []struct {
+		operation string
+		wantSet   bool
+	}{
+		{customerRef.ID(), false},
+		{feedbackRef.ID(), true},
+	} {
+		var expires *time.Time
+		if err := f.pool.QueryRow(f.ctx,
+			`SELECT expires_at FROM sending_feedback_correlations WHERE operation_id = $1`, tc.operation,
+		).Scan(&expires); err != nil {
+			t.Fatalf("read correlation for %s: %v", tc.operation, err)
+		}
+		if (expires != nil) != tc.wantSet {
+			t.Errorf("operation %s expires_at set = %v, want %v", tc.operation, expires != nil, tc.wantSet)
+		}
+	}
+}
+
+// TestReputationClassCannotBecomeCheaperAfterPreparation closes the gap between
+// an immutable class and a mutable source column.
+//
+// `shared_reputation` is frozen when the operation is prepared, but
+// `messages.sent_as` is rewritten by the approval path and depends on the
+// domain's live verification state. A message prepared while the customer's own
+// domain was sending-verified, and approved after it was not, would be
+// physically sent over the shared relay while being budgeted as dedicated —
+// escaping both the shared-domain cap and the probation pool.
+func TestReputationClassCannotBecomeCheaperAfterPreparation(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(enforcingPolicy(nil))
+	agent := f.agent(f.user("standard"))
+	messageID := f.message(agent, "own_address", 1)
+	_, ref := f.prepareMessage(g, messageID)
+
+	if _, err := f.pool.Exec(f.ctx,
+		`UPDATE messages SET sent_as = 'relay' WHERE id = $1`, messageID); err != nil {
+		t.Fatalf("downgrade sent_as: %v", err)
+	}
+
+	d := f.authorize(g, ref)
+	if d.Allow {
+		t.Fatal("a message that became shared after preparation must not be sent on a dedicated budget")
+	}
+	if d.Reason != sendingpolicy.ReasonClassChanged {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonClassChanged)
+	}
+
+	// The other direction needs no action: an operation already classed as
+	// shared simply stays shared, which is the stricter reading.
+	shared := f.message(agent, "relay", 1)
+	_, sharedRef := f.prepareMessage(g, shared)
+	if _, err := f.pool.Exec(f.ctx,
+		`UPDATE messages SET sent_as = 'own_address' WHERE id = $1`, shared); err != nil {
+		t.Fatalf("upgrade sent_as: %v", err)
+	}
+	if d := f.authorize(g, sharedRef); !d.Allow {
+		t.Fatalf("tightening in the safe direction must still send: %q", d.Reason)
 	}
 }

--- a/internal/sendingpolicy/types.go
+++ b/internal/sendingpolicy/types.go
@@ -182,6 +182,19 @@ const (
 	ReasonTenantNotReady      = "ses_tenant_not_ready"
 	ReasonRecipientSuperseded = "notice_recipient_superseded"
 	ReasonAccountDeleted      = "account_deleted"
+	// ReasonSourceUnavailable means the durable source row this operation was
+	// derived from is gone, so there is nothing left to send.
+	ReasonSourceUnavailable = "source_unavailable"
+	// ReasonNoticeSettled means the notice delivery already reached a terminal
+	// state; re-sending it would duplicate a logical notice.
+	ReasonNoticeSettled = "notice_already_settled"
+	// ReasonTenantUnnamed means the policy requires a tenant header but the
+	// account has no tenant name to send.
+	ReasonTenantUnnamed = "ses_tenant_unnamed"
+	// ReasonClassChanged means the message's reputation class stopped matching
+	// the immutable class its operation was derived from, so the operation no
+	// longer describes the send.
+	ReasonClassChanged = "reputation_class_changed"
 )
 
 // Decision is allow-or-hold. A hold carries the earliest time a retry could
@@ -315,8 +328,9 @@ type NotificationRef struct {
 }
 
 // NewHITLNotificationRef references a pending outbound message whose approval
-// request is being sent. PrepareNotificationTx validates that the message
-// exists, is outbound, and belongs to a live agent before deriving anything.
+// request is being sent. PrepareNotificationTx locks the owning agent and then
+// the message, and requires the message to still be outbound and still awaiting
+// review before deriving anything from it.
 func NewHITLNotificationRef(messageID string) NotificationRef {
 	return NotificationRef{source: NotificationHITLMessage, id: messageID}
 }
@@ -484,9 +498,20 @@ func (a ProviderAuthorization) ValidateEnvelope(recipients []string) (ProviderHe
 	if a.IsZero() {
 		return ProviderHeaders{}, errors.New("sendingpolicy: authorization is empty")
 	}
-	normalized, err := normalizeEnvelope(recipients)
+	normalized, raw, err := normalizeEnvelopeCounted(recipients)
 	if err != nil {
 		return ProviderHeaders{}, err
+	}
+	// The submission may not contain more entries than it has distinct
+	// mailboxes. Collapsing duplicates here instead would be a 50x reputation
+	// amplifier: one charged unit authorizes one mailbox, but an envelope of
+	// fifty case-variant spellings of that mailbox normalizes down to the same
+	// single authorized address while SES still receives fifty RCPT TO
+	// commands — fifty chances to bounce, against one unit of budget. The
+	// accounting rule that duplicates count once only holds if the thing
+	// submitted is the deduplicated set, so that is what a caller must submit.
+	if raw != len(normalized) {
+		return ProviderHeaders{}, ErrEnvelopeMismatch
 	}
 	if len(normalized) != len(a.recipientSet) {
 		return ProviderHeaders{}, ErrEnvelopeMismatch
@@ -513,16 +538,27 @@ func (a ProviderAuthorization) ValidateEnvelope(recipients []string) (ProviderHe
 // "a@x" as two recipients would let one send be charged twice and, worse, would
 // make ValidateEnvelope reject an envelope the adapter legitimately reassembled.
 func normalizeEnvelope(recipients []string) ([]string, error) {
+	out, _, err := normalizeEnvelopeCounted(recipients)
+	return out, err
+}
+
+// normalizeEnvelopeCounted also reports how many entries the caller actually
+// supplied, so ValidateEnvelope can tell "the same mailbox listed in To and Cc"
+// (which the caller must collapse before submitting) from "one entry per
+// mailbox" (which is what a charged unit buys).
+func normalizeEnvelopeCounted(recipients []string) ([]string, int, error) {
 	if len(recipients) == 0 {
-		return nil, errors.New("sendingpolicy: envelope has no recipients")
+		return nil, 0, errors.New("sendingpolicy: envelope has no recipients")
 	}
 	seen := make(map[string]struct{}, len(recipients))
 	out := make([]string, 0, len(recipients))
-	for _, raw := range recipients {
-		addr, err := normalizeEnvelopeRecipient(raw)
+	raw := 0
+	for _, entry := range recipients {
+		addr, err := normalizeEnvelopeRecipient(entry)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
+		raw++
 		if _, dup := seen[addr]; dup {
 			continue
 		}
@@ -530,10 +566,10 @@ func normalizeEnvelope(recipients []string) ([]string, error) {
 		out = append(out, addr)
 	}
 	if len(out) == 0 {
-		return nil, errors.New("sendingpolicy: envelope has no recipients")
+		return nil, 0, errors.New("sendingpolicy: envelope has no recipients")
 	}
 	sort.Strings(out)
-	return out, nil
+	return out, raw, nil
 }
 
 // maxEnvelopeRecipientLength bounds one address. RFC 5321's path limit is 256

--- a/internal/sendingpolicy/types.go
+++ b/internal/sendingpolicy/types.go
@@ -200,16 +200,30 @@ const (
 // Decision is allow-or-hold. A hold carries the earliest time a retry could
 // plausibly succeed — for a daily budget that is the next UTC midnight, which
 // lets the worker snooze rather than spin.
+//
+// Terminal separates "come back later" from "this can never proceed". Without
+// it every hold reads as retryable, and a worker faced with an operation that
+// is permanently void — its account deleted, its notice already sent, its
+// reputation class no longer the one it was derived from — would snooze on it
+// forever instead of failing the message once. A terminal hold carries no
+// RetryAt because there is no time at which the answer changes.
 type Decision struct {
-	Allow   bool
-	Reason  string
-	RetryAt time.Time
+	Allow    bool
+	Reason   string
+	RetryAt  time.Time
+	Terminal bool
 }
 
 func allowDecision() Decision { return Decision{Allow: true} }
 
 func holdDecision(reason string, retryAt time.Time) Decision {
 	return Decision{Allow: false, Reason: reason, RetryAt: retryAt}
+}
+
+// terminalHold is a hold no retry can clear. The caller must fail the message
+// rather than reschedule it.
+func terminalHold(reason string) Decision {
+	return Decision{Allow: false, Reason: reason, Terminal: true}
 }
 
 // OperationRef names one durable provider operation. Purpose, attribution, and
@@ -490,10 +504,23 @@ var ErrEnvelopeMismatch = errors.New("sendingpolicy: envelope does not match the
 // ValidateEnvelope proves the caller's actual envelope is the authorized one
 // and returns the provider header values derived from the token.
 //
-// The comparison is set equality over normalized addresses, not string
-// equality over the caller's slice: To/Cc/Bcc ordering and duplicate
-// spellings are presentation details, while the set of mailboxes SES will be
-// asked to accept is the thing the budget was charged for.
+// THE CONTRACT: submit exactly AuthorizedRecipients(). Ordering and letter case
+// are free — those are presentation. The COUNT is not: the envelope must carry
+// one entry per distinct mailbox, because the adapter issues one RCPT TO per
+// entry and the budget charged one unit per distinct mailbox.
+//
+// So a caller must collapse its own To/Cc/Bcc overlap before submitting. That
+// is a real constraint on the SMTP adapter — a reply-all naming the same
+// mailbox in To and Cc is an ordinary message, and reassembling the raw header
+// lists would be rejected here. Handing back AuthorizedRecipients() is not a
+// workaround for that; it is the intended call, and it is the only envelope
+// this token was ever priced for.
+//
+// The alternative — silently deduplicating whatever arrives — is what makes an
+// envelope of fifty case-variant spellings of one mailbox pass as "the same
+// recipient" while SES receives fifty RCPT TO commands. That is a 50x
+// reputation amplifier on one unit of budget, which is precisely the quantity
+// this module exists to bound.
 func (a ProviderAuthorization) ValidateEnvelope(recipients []string) (ProviderHeaders, error) {
 	if a.IsZero() {
 		return ProviderHeaders{}, errors.New("sendingpolicy: authorization is empty")
@@ -533,10 +560,13 @@ func (a ProviderAuthorization) ValidateEnvelope(recipients []string) (ProviderHe
 //
 // Lowercasing the whole address — local part included — is a deliberate
 // choice. RFC 5321 permits case-sensitive local parts, but no mail system e2a
-// submits to distinguishes them, and the value must dedupe and hash
-// identically on both sides of the authorization boundary. Treating "A@x" and
-// "a@x" as two recipients would let one send be charged twice and, worse, would
-// make ValidateEnvelope reject an envelope the adapter legitimately reassembled.
+// submits to distinguishes them, and the value must dedupe and hash identically
+// on both sides of the authorization boundary. Treating "A@x" and "a@x" as two
+// mailboxes would charge one send twice.
+//
+// This function is the CHARGING side, where collapsing duplicates is right.
+// ValidateEnvelope is the SUBMISSION side, where it is not: see the contract
+// there.
 func normalizeEnvelope(recipients []string) ([]string, error) {
 	out, _, err := normalizeEnvelopeCounted(recipients)
 	return out, err

--- a/internal/sendingpolicy/types.go
+++ b/internal/sendingpolicy/types.go
@@ -1,0 +1,575 @@
+package sendingpolicy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// This file is the closed vocabulary of provider authorization: who is asking,
+// which pools they consume, and what a caller is allowed to hold in its hand
+// between the decision and the socket.
+//
+// Every type here has unexported fields on purpose. A caller outside this
+// package can hold a reference but cannot forge one, cannot widen one, and
+// cannot read a decision out of one that the module did not put there. That is
+// the whole security argument for the gate: authority is not a string a worker
+// can assemble, it is a durable row this package validated under lock.
+
+// Purpose is the closed set of reasons e2a may hand a message to SES. It is
+// derived by a server-side constructor from a durable source row and persisted
+// on the provider operation; no caller, River argument, or MIME header can
+// select or change it. The values match the CHECK constraint on
+// sending_provider_operations.purpose.
+type Purpose string
+
+const (
+	// PurposeCustomerMessage is mail a customer's agent composed.
+	PurposeCustomerMessage Purpose = "customer_message"
+	// PurposeCustomerNotification is platform mail a customer's own action
+	// triggered — HITL approval requests and webhook-health warnings. It is
+	// attributed to and budgeted against that customer precisely because a
+	// customer can cause an unbounded amount of it.
+	PurposeCustomerNotification Purpose = "customer_notification"
+	// PurposeCriticalOperational is a pause notice. It must survive an abuse
+	// wave that has exhausted every customer pool, so it draws on its own.
+	PurposeCriticalOperational Purpose = "critical_operational"
+	// PurposeViolationOperational is a budget-violation or global-guardrail
+	// notice. Separate from critical so limit-driven mail — which an attacker
+	// can provoke — cannot starve pause notices.
+	PurposeViolationOperational Purpose = "violation_operational"
+	// PurposePublicFeedback is the unauthenticated /api/feedback fan-out to a
+	// fixed configured recipient set. It has no customer to attribute to but
+	// still shares provider reputation, so it consumes the global pools.
+	PurposePublicFeedback Purpose = "public_feedback_notification"
+	// PurposeTrustedSystem is first-party prober/conformance traffic from
+	// system and internal accounts. Unbudgeted by design: it is not
+	// customer-triggerable, so its compromise is a credential incident rather
+	// than an abuse-policy question.
+	PurposeTrustedSystem Purpose = "trusted_system"
+)
+
+func (p Purpose) valid() bool {
+	switch p {
+	case PurposeCustomerMessage, PurposeCustomerNotification,
+		PurposeCriticalOperational, PurposeViolationOperational,
+		PurposePublicFeedback, PurposeTrustedSystem:
+		return true
+	}
+	return false
+}
+
+// isCustomer reports whether this purpose is attributed to, budgeted against,
+// and blocked by a customer account's sending state.
+func (p Purpose) isCustomer() bool {
+	return p == PurposeCustomerMessage || p == PurposeCustomerNotification
+}
+
+// isOperational reports whether this purpose draws on one of the two
+// operational pools rather than any customer pool.
+func (p Purpose) isOperational() bool {
+	return p == PurposeCriticalOperational || p == PurposeViolationOperational
+}
+
+// SystemPolicySubject is the fixed policy subject for operational and
+// public-feedback mail. It is a sentinel reference rather than a real account
+// row: no customer state may authorize or block a pause notice, and there is
+// no users row to pause. Phase 7 binds it to the e2a-system SES tenant.
+const SystemPolicySubject = "e2a-system"
+
+// Scope is a budget counter dimension. The values match the CHECK constraint
+// on sending_budget_counters.scope.
+type Scope string
+
+const (
+	ScopeGlobalAll          Scope = "global_all"
+	ScopeGlobalProbation    Scope = "global_probation"
+	ScopeAccountDaily       Scope = "account_daily"
+	ScopeAccountSharedDaily Scope = "account_shared_daily"
+	ScopeGlobalCritical     Scope = "global_critical"
+	ScopeGlobalViolation    Scope = "global_violation"
+)
+
+// Fixed scope IDs for the pools that are not keyed by an account.
+const (
+	scopeIDAllCustomers = "all-customers"
+	scopeIDProbation    = "probation"
+	scopeIDCritical     = "critical-operational"
+	scopeIDViolation    = "violation-operational"
+)
+
+// scopeLockRank is the normative lock order for budget counters, and the only
+// place that order is written down as data. Every transaction that touches
+// more than one counter sorts by it.
+//
+// Ordering is not a performance detail here. Two workers that acquire
+// global_all and account_daily in opposite orders deadlock under exactly the
+// load this system exists to survive, and Postgres resolves that by killing
+// one transaction — which, on the final authorization path, means a message
+// that should have been held instead errors out. An operation may skip a key
+// it does not need, but it may never reorder the keys it does take.
+var scopeLockRank = map[Scope]int{
+	ScopeGlobalAll:          1,
+	ScopeGlobalProbation:    2,
+	ScopeAccountDaily:       3,
+	ScopeAccountSharedDaily: 4,
+	ScopeGlobalCritical:     5,
+	ScopeGlobalViolation:    6,
+}
+
+// counterKey identifies one row of sending_budget_counters.
+type counterKey struct {
+	Scope   Scope
+	ScopeID string
+}
+
+// sortCounterKeys puts a set of scope keys into the normative lock order. Ties
+// inside one scope (impossible today — every scope has one ID per operation)
+// fall back to the scope ID so the order is total.
+func sortCounterKeys(keys []counterKey) {
+	sort.Slice(keys, func(i, j int) bool {
+		ri, rj := scopeLockRank[keys[i].Scope], scopeLockRank[keys[j].Scope]
+		if ri != rj {
+			return ri < rj
+		}
+		return keys[i].ScopeID < keys[j].ScopeID
+	})
+}
+
+// Audience is the closed recipient class of a protection notice. Owner mail
+// goes to the affected customer; operator mail goes to the version of the
+// operator mailbox map that the runtime policy currently selects.
+type Audience string
+
+const (
+	AudienceOwner    Audience = "owner"
+	AudienceOperator Audience = "operator"
+)
+
+func (a Audience) valid() bool {
+	return a == AudienceOwner || a == AudienceOperator
+}
+
+// AcceptanceDecision is what an API acceptance surface learns from
+// PrepareExternalTx: whether this account may still queue outbound mail at all.
+// It deliberately carries no budget verdict — budgets are decided immediately
+// before the provider call, not at acceptance, so that a queued message is held
+// rather than rejected when the account runs out of daily capacity.
+type AcceptanceDecision string
+
+const (
+	// AcceptanceAccept means the send may be durably queued.
+	AcceptanceAccept AcceptanceDecision = "accept"
+	// AcceptanceSendingPaused means the account is paused; the caller rejects
+	// the request rather than queueing mail that can never leave.
+	AcceptanceSendingPaused AcceptanceDecision = "sending_paused"
+)
+
+// Reason codes for a hold. These are machine-readable and appear in metrics and
+// lifecycle events, so they are part of the operator contract even though no
+// public API surfaces them in this slice.
+const (
+	ReasonAccountPaused       = "account_paused"
+	ReasonAccountDailyBudget  = "account_daily_budget_exhausted"
+	ReasonAccountSharedBudget = "account_shared_daily_budget_exhausted"
+	ReasonGlobalAllBudget     = "global_all_budget_exhausted"
+	ReasonGlobalProbation     = "global_probation_budget_exhausted"
+	ReasonGlobalCritical      = "global_critical_budget_exhausted"
+	ReasonGlobalViolation     = "global_violation_budget_exhausted"
+	ReasonTenantNotReady      = "ses_tenant_not_ready"
+	ReasonRecipientSuperseded = "notice_recipient_superseded"
+	ReasonAccountDeleted      = "account_deleted"
+)
+
+// Decision is allow-or-hold. A hold carries the earliest time a retry could
+// plausibly succeed — for a daily budget that is the next UTC midnight, which
+// lets the worker snooze rather than spin.
+type Decision struct {
+	Allow   bool
+	Reason  string
+	RetryAt time.Time
+}
+
+func allowDecision() Decision { return Decision{Allow: true} }
+
+func holdDecision(reason string, retryAt time.Time) Decision {
+	return Decision{Allow: false, Reason: reason, RetryAt: retryAt}
+}
+
+// OperationRef names one durable provider operation. Purpose, attribution, and
+// shared-reputation class are captured here for the caller's convenience, but
+// they are advisory: every Gate method reloads the row under lock and uses the
+// stored values, so a forged or stale ref grants exactly no authority.
+type OperationRef struct {
+	id            string
+	purpose       Purpose
+	sourceAccount string
+	policySubject string
+	shared        bool
+
+	// recipients is set only by PreparePublicFeedback, whose configured
+	// envelope has nowhere durable to live and never crosses a process
+	// boundary. Every other purpose resolves its envelope from a locked row at
+	// final authorization, and a reference that arrives here by any other
+	// route carries none — which is what makes a deserialized feedback
+	// reference useless rather than dangerous.
+	recipients []string
+}
+
+// ID exposes the opaque operation identifier for logging and for the River
+// argument round-trip. It is not a capability.
+func (r OperationRef) ID() string { return r.id }
+
+// Purpose exposes the derived purpose for metrics. Advisory, as above.
+func (r OperationRef) Purpose() Purpose { return r.purpose }
+
+// IsZero reports an unset reference.
+func (r OperationRef) IsZero() bool { return r.id == "" }
+
+// operationRefJSON is the versioned wire form. Only the ID crosses the
+// boundary: a River job that outlives a process replacement must be able to
+// find its operation again, and nothing more. Migration 113 wrote exactly this
+// shape into legacy job args, so the version and key names are load-bearing.
+type operationRefJSON struct {
+	V  int    `json:"v"`
+	ID string `json:"id"`
+}
+
+const operationRefVersion = 1
+
+// MarshalJSON writes the versioned wire form.
+func (r OperationRef) MarshalJSON() ([]byte, error) {
+	if r.id == "" {
+		return nil, errors.New("sendingpolicy: refusing to marshal an empty operation reference")
+	}
+	return json.Marshal(operationRefJSON{V: operationRefVersion, ID: r.id})
+}
+
+// UnmarshalJSON reads the versioned wire form and yields a reference carrying
+// only an ID. The absent purpose/attribution fields are what force every Gate
+// method to reload from the database instead of trusting deserialized state.
+func (r *OperationRef) UnmarshalJSON(raw []byte) error {
+	var wire operationRefJSON
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&wire); err != nil {
+		return fmt.Errorf("sendingpolicy: decode operation reference: %w", err)
+	}
+	if wire.V != operationRefVersion {
+		return fmt.Errorf("sendingpolicy: unsupported operation reference version %d", wire.V)
+	}
+	if strings.TrimSpace(wire.ID) == "" {
+		return errors.New("sendingpolicy: operation reference has no id")
+	}
+	*r = OperationRef{id: wire.ID}
+	return nil
+}
+
+// AttemptRef names one durable submission attempt: the module-allocated
+// ordinal on a provider operation. River's own job.Attempt is deliberately not
+// used — River retries and provider submissions are different clocks, and
+// conflating them is how one logical message ends up making several
+// unaccounted SES calls.
+type AttemptRef struct {
+	operationID string
+	attempt     int
+
+	// recipients carries PreparePublicFeedback's in-memory envelope from
+	// Reserve to ConsumeAttempt. It is not part of the reference's identity:
+	// the durable row is what every check reads, and a caller that fabricates
+	// this field still cannot make ConsumeAttempt authorize an envelope the
+	// operation's purpose does not permit.
+	recipients []string
+}
+
+// OperationID exposes the operation this attempt belongs to, for logging.
+func (a AttemptRef) OperationID() string { return a.operationID }
+
+// Attempt exposes the durable submission ordinal, for logging.
+func (a AttemptRef) Attempt() int { return a.attempt }
+
+// IsZero reports an unset reference.
+func (a AttemptRef) IsZero() bool { return a.operationID == "" || a.attempt <= 0 }
+
+// NotificationSource is the closed set of durable rows that may produce a
+// customer notification.
+type NotificationSource string
+
+const (
+	// NotificationHITLMessage is a pending message awaiting human approval.
+	NotificationHITLMessage NotificationSource = "hitl_message"
+	// NotificationWebhookHealth is a webhook warning/disabled episode.
+	NotificationWebhookHealth NotificationSource = "webhook_health"
+)
+
+// NotificationRef names one supported notification source row. It has no
+// exported constructor taking a purpose: the two constructors below are the
+// only way to make one, which is what stops a caller from labelling its own
+// mail as operational to escape a budget.
+type NotificationRef struct {
+	source NotificationSource
+	id     string
+}
+
+// NewHITLNotificationRef references a pending outbound message whose approval
+// request is being sent. PrepareNotificationTx validates that the message
+// exists, is outbound, and belongs to a live agent before deriving anything.
+func NewHITLNotificationRef(messageID string) NotificationRef {
+	return NotificationRef{source: NotificationHITLMessage, id: messageID}
+}
+
+// NewWebhookHealthNotificationRef references a webhook whose health episode is
+// being reported to its owner.
+func NewWebhookHealthNotificationRef(webhookID string) NotificationRef {
+	return NotificationRef{source: NotificationWebhookHealth, id: webhookID}
+}
+
+// ProtectionNoticeRef names one already-committed notice event and audience.
+// The event row must exist: notices are enqueued by the transaction that
+// detects the violation, and the drain worker only ever resumes them.
+type ProtectionNoticeRef struct {
+	eventID  string
+	audience Audience
+}
+
+// NewProtectionNoticeRef references one notice event/audience pair.
+func NewProtectionNoticeRef(eventID string, audience Audience) ProtectionNoticeRef {
+	return ProtectionNoticeRef{eventID: eventID, audience: audience}
+}
+
+// PublicFeedbackRef names one server-generated /api/feedback submission and the
+// complete fixed recipient set configured for it. Request data reaches neither
+// field: the ID is minted by the handler and the recipients come from
+// configuration, so a submitter cannot add, replace, or redirect a recipient.
+type PublicFeedbackRef struct {
+	submissionID string
+	recipients   []string
+}
+
+// NewPublicFeedbackRef references one submission and its configured envelope.
+func NewPublicFeedbackRef(submissionID string, recipients []string) PublicFeedbackRef {
+	return PublicFeedbackRef{submissionID: submissionID, recipients: append([]string(nil), recipients...)}
+}
+
+// SettlementOutcome is the closed set of authoritative provider results that
+// move the ramp ledger. Retryable and ambiguous results are deliberately
+// absent: they leave the reservation standing, because a message that might
+// have been delivered must not release ramp capacity.
+type SettlementOutcome string
+
+const (
+	// SettlementProviderAccepted means SES took responsibility for the message.
+	SettlementProviderAccepted SettlementOutcome = "provider_accepted"
+	// SettlementProviderPermanentlyRejected means SES definitively refused it.
+	SettlementProviderPermanentlyRejected SettlementOutcome = "provider_permanently_rejected"
+)
+
+func (o SettlementOutcome) valid() bool {
+	return o == SettlementProviderAccepted || o == SettlementProviderPermanentlyRejected
+}
+
+// ProviderSettlement pairs an attempt with its authoritative outcome.
+type ProviderSettlement struct {
+	Attempt AttemptRef
+	Outcome SettlementOutcome
+}
+
+// TenantMode is the closed tenant-header state carried by an authorization.
+// It is resolved under the final account-control lock, so a job that was
+// enqueued before a tenant flip still submits with the post-flip header.
+type TenantMode string
+
+const (
+	// TenantModeNone means no X-SES-TENANT header. This is every deployment
+	// before phase 7 and every self-host.
+	TenantModeNone TenantMode = "none"
+	// TenantModeRequired means the exact named tenant must be sent.
+	TenantModeRequired TenantMode = "required"
+)
+
+// ProviderHeaders is what the SMTP adapter is allowed to learn from a token.
+// The adapter derives its provider-owned headers only from these values and
+// never accepts them as separate parameters, which is what makes header
+// smuggling a compile-time impossibility rather than a review question.
+type ProviderHeaders struct {
+	AttemptCorrelationID string
+	TenantRequired       bool
+	TenantName           string
+}
+
+// ProviderAuthorization is the single-use permission to make exactly one SES
+// call for exactly one durable attempt. It cannot be constructed outside this
+// package, cannot be widened, and is worthless without the durable nonce that
+// RedeemProviderCall consumes.
+type ProviderAuthorization struct {
+	attempt       AttemptRef
+	correlationID string
+	purpose       Purpose
+	nonce         string
+
+	// recipients is the exact final authorized envelope, normalized and
+	// deduplicated, in stable order; recipientSet is the same value as a
+	// membership test. The durable provenance rows store keyed HMACs of these
+	// addresses, never the addresses themselves, but the in-memory comparison
+	// is over plaintext: the token already holds the envelope it authorized,
+	// so hashing it again to compare it with itself would add ceremony, not
+	// safety.
+	recipients   []string
+	recipientSet map[string]struct{}
+
+	tenantMode TenantMode
+	tenantName string
+
+	// notice is set only for a protection notice, whose recipient is resolved
+	// at final authorization rather than supplied by the caller.
+	notice *noticeBinding
+}
+
+// noticeBinding carries the protection-notice identity a redemption must
+// re-prove immediately before the socket opens.
+//
+// One version/commitment pair covers both audiences because both answer the
+// same question — "is this still the right recipient?" — with different
+// evidence. For an operator delivery the version is the logical mailbox-map
+// version and the commitment is its keyed commitment, so rotating the map
+// retires the attempt. For an owner delivery the version is the feedback HMAC
+// key version and the commitment is the HMAC of the address itself, so an owner
+// who edits their email retires it. Neither form stores an address.
+type noticeBinding struct {
+	eventID             string
+	audience            Audience
+	deliveryAttempt     int
+	recipientVersion    int
+	recipientCommitment []byte
+}
+
+// IsZero reports an unset authorization.
+func (a ProviderAuthorization) IsZero() bool { return a.attempt.IsZero() }
+
+// Attempt exposes the durable attempt this token authorizes, for logging.
+func (a ProviderAuthorization) Attempt() AttemptRef { return a.attempt }
+
+// Purpose exposes the derived purpose, for metrics.
+func (a ProviderAuthorization) Purpose() Purpose { return a.purpose }
+
+// AuthorizedRecipients returns a defensive copy of the exact final envelope.
+//
+// Only the protection notifier uses it: that path is the one caller that does
+// not already know its recipient, because the address is resolved under lock at
+// final authorization and deliberately never persisted in plaintext. Every
+// other caller composed its own envelope and must not re-derive one here.
+func (a ProviderAuthorization) AuthorizedRecipients() []string {
+	out := make([]string, len(a.recipients))
+	copy(out, a.recipients)
+	return out
+}
+
+// ErrEnvelopeMismatch means the envelope a caller is about to submit is not the
+// envelope that was authorized. It is returned before any redemption or network
+// I/O, because a mismatch here is either a bug or an attempt to reuse one
+// authorization for different recipients.
+var ErrEnvelopeMismatch = errors.New("sendingpolicy: envelope does not match the authorized recipients")
+
+// ValidateEnvelope proves the caller's actual envelope is the authorized one
+// and returns the provider header values derived from the token.
+//
+// The comparison is set equality over normalized addresses, not string
+// equality over the caller's slice: To/Cc/Bcc ordering and duplicate
+// spellings are presentation details, while the set of mailboxes SES will be
+// asked to accept is the thing the budget was charged for.
+func (a ProviderAuthorization) ValidateEnvelope(recipients []string) (ProviderHeaders, error) {
+	if a.IsZero() {
+		return ProviderHeaders{}, errors.New("sendingpolicy: authorization is empty")
+	}
+	normalized, err := normalizeEnvelope(recipients)
+	if err != nil {
+		return ProviderHeaders{}, err
+	}
+	if len(normalized) != len(a.recipientSet) {
+		return ProviderHeaders{}, ErrEnvelopeMismatch
+	}
+	for _, addr := range normalized {
+		if _, ok := a.recipientSet[addr]; !ok {
+			return ProviderHeaders{}, ErrEnvelopeMismatch
+		}
+	}
+	return ProviderHeaders{
+		AttemptCorrelationID: a.correlationID,
+		TenantRequired:       a.tenantMode == TenantModeRequired,
+		TenantName:           a.tenantName,
+	}, nil
+}
+
+// normalizeEnvelope lowercases, deduplicates, and sorts an envelope recipient
+// list, rejecting anything that is not a bare addr-spec.
+//
+// Lowercasing the whole address — local part included — is a deliberate
+// choice. RFC 5321 permits case-sensitive local parts, but no mail system e2a
+// submits to distinguishes them, and the value must dedupe and hash
+// identically on both sides of the authorization boundary. Treating "A@x" and
+// "a@x" as two recipients would let one send be charged twice and, worse, would
+// make ValidateEnvelope reject an envelope the adapter legitimately reassembled.
+func normalizeEnvelope(recipients []string) ([]string, error) {
+	if len(recipients) == 0 {
+		return nil, errors.New("sendingpolicy: envelope has no recipients")
+	}
+	seen := make(map[string]struct{}, len(recipients))
+	out := make([]string, 0, len(recipients))
+	for _, raw := range recipients {
+		addr, err := normalizeEnvelopeRecipient(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := seen[addr]; dup {
+			continue
+		}
+		seen[addr] = struct{}{}
+		out = append(out, addr)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("sendingpolicy: envelope has no recipients")
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// maxEnvelopeRecipientLength bounds one address. RFC 5321's path limit is 256
+// including angle brackets; this is the bare addr-spec.
+const maxEnvelopeRecipientLength = 254
+
+// normalizeEnvelopeRecipient validates one customer-facing envelope recipient.
+//
+// This is deliberately laxer than the operator-mailbox rules in keyring.go.
+// An operator address is one value we chose and can constrain to ASCII atext;
+// a customer envelope recipient is whatever the world's mail systems accept,
+// and rejecting a valid destination here would be an outage, not a control.
+// What it still refuses is anything that could act as a separator in an SMTP
+// or MIME grammar, because those are how one recipient becomes two.
+func normalizeEnvelopeRecipient(raw string) (string, error) {
+	addr := strings.TrimSpace(raw)
+	if addr == "" {
+		return "", errors.New("sendingpolicy: envelope recipient is empty")
+	}
+	if len(addr) > maxEnvelopeRecipientLength {
+		return "", fmt.Errorf("sendingpolicy: envelope recipient is longer than %d bytes", maxEnvelopeRecipientLength)
+	}
+	for i := 0; i < len(addr); i++ {
+		if c := addr[i]; c < 0x21 || c == 0x7f {
+			return "", errors.New("sendingpolicy: envelope recipient contains a control or space byte")
+		}
+	}
+	if strings.ContainsAny(addr, "<>,;\"\\()[]") {
+		return "", errors.New("sendingpolicy: envelope recipient must be a bare address without display name or route syntax")
+	}
+	at := strings.LastIndexByte(addr, '@')
+	if at <= 0 || at == len(addr)-1 {
+		return "", errors.New("sendingpolicy: envelope recipient must be local@domain")
+	}
+	if strings.IndexByte(addr, '@') != at {
+		return "", errors.New("sendingpolicy: envelope recipient must contain exactly one @")
+	}
+	return strings.ToLower(addr), nil
+}


### PR DESCRIPTION
## Summary

B3 of the sending-protection plan (`docs/superpowers/plans/2026-08-21-sending-abuse-prevention.md`, Task 3): the budget ledger, the durable submission attempt, and the final pre-I/O authorization.

- **types.go** — the closed vocabulary. Every ref has unexported fields; the only serialization is `OperationRef`'s versioned `{v,id}` form, which survives a River process replacement while granting no authority, because every `Gate` method reloads the durable row.
- **budget.go** — which pools an operation charges, today's limit per pool, and one ordered locking pass over every counter row a transaction may touch, with the arithmetic applied afterwards so an all-or-nothing decision needs no savepoint and no second lock pass.
- **operations.go** — purpose, attribution, and the shared-reputation class derived once from a locked source row and persisted immutable. `sent_as` decides the reputation class and an unknown value reads as shared, so an unexpected write tightens the cap rather than buying an exemption.
- **gate.go** — the approved `Gate` interface verbatim. `Reserve` allocates the durable ordinal, `ConsumeAttempt` re-derives everything under the normative lock order and confirms, `RedeemProviderCall` re-proves the whole chain immediately before the socket.

## Operational risk

**Enforcement is off and nothing calls the Gate yet.** The shipped generation-zero policy has `budget_mode: disabled`, which charges nothing and writes no counter rows while still exercising the authorization seam. The compiled contract stays at 0. The ramp composition (B4), the SMTP adapter (B5), and the workers (B6/B7) are the next slices; rollback is the ordinary code rollback.

## Defects found and fixed while testing

- A non-customer purpose left `tenant_mode` empty, which the provenance table's closed enum rejects.
- The token could carry a correlation ID no row held — that would have left the detector silently blind rather than visibly broken, since the ID is the header SES echoes back on every delivery event.
- `Reserve` judged the account cap with an empty plan code, so a **paid** account's message could be deferred to midnight by an optimization that has no authority to deny. It now denies only what no plan could fit: a false allow costs nothing (final authorization re-evaluates), a false deny is a customer-visible outage.

## Test plan

- [x] `go test -p 1 -race -count=1 ./internal/sendingpolicy ./internal/config ./cmd/e2a`
- [x] `go test -p 1 -race ./internal/identity -run 'Budget|Attempt|Consume|Rollover|Downgrade|PolicyGeneration|AccountClass|Deletion|Purge|Refund'`
- [x] 229 tests in the package, red before each behavior and green after: duplicate-worker race, adjacent-day physical submission bound, plan downgrade and policy change between `Reserve` and `ConsumeAttempt`, deletion vs confirmed exposure, envelope mismatch, owner/operator recipient supersession
- [x] Every "zero provider calls" claim is asserted against a fake socket counter, not against the absence of an error
- [x] `make fmt-check`, `git diff --check`, synthetic-data scan of the diff (every address is `.test`)

Client surface checklist omitted: this adds internal provider-authorization mechanism only and changes no HTTP API, OpenAPI operation, SDK, CLI package, or MCP tool.

## Merge gate

Per the plan's build-slice train, **do not merge before the B2 gate is closed** — the audited initial v1 operator-recipient registry insert/readback on the promoted binary (prod runs 1.8.7, which contains B2). This PR is ready for review now; promotion waits on that evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjfGxvXW6fNKWGFHuo68yX