### PR TITLE
feat(sending): compose ramp with protection gate

### DIFF
--- a/internal/sendingpolicy/gate.go
+++ b/internal/sendingpolicy/gate.go
@@ -467,6 +467,7 @@ type authState struct {
 
 	envelope []string
 	notice   *noticeState
+	ramp     rampSubject
 }
 
 // noticeState is the protection-notice half of a final authorization.
@@ -673,7 +674,17 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 	if err != nil {
 		return st, Decision{}, err
 	}
-	st.probation = op.Shared
+	// Probation is the ramp's answer, read before the budget counters are
+	// locked because it decides WHICH counters this transaction must take. The
+	// read is unlocked and that is sound: ramp progress is monotonic, so a
+	// stale answer can only be stale in the strict direction.
+	st.probation, err = m.rampProbation(ctx, tx, policy, op)
+	if err != nil {
+		if errors.Is(err, ErrSourceUnavailable) {
+			return st, holdDecision(ReasonSourceUnavailable, time.Time{}), nil
+		}
+		return st, Decision{}, err
+	}
 
 	// Verdicts, now that every key is held.
 	//
@@ -755,6 +766,14 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 	}
 	st.envelope = envelope
 	st.units = len(st.envelope)
+
+	st.ramp, err = m.rampSubjectFor(ctx, tx, policy, op, st.units)
+	if err != nil {
+		if errors.Is(err, ErrSourceUnavailable) {
+			return st, holdDecision(ReasonSourceUnavailable, time.Time{}), nil
+		}
+		return st, Decision{}, err
+	}
 	return st, allowDecision(), nil
 }
 
@@ -969,7 +988,23 @@ func (m *Module) reauthorizeBudget(ctx context.Context, tx pgx.Tx, st authState)
 	// under a different policy is given back.
 	exempt := accountClassExempt(st.class) && st.op.Purpose.isCustomer()
 	if st.policy.BudgetMode == ModeDisabled || exempt || st.op.Purpose == PurposeTrustedSystem {
-		return allowDecision(), m.releaseStoredUnits(ctx, tx, st)
+		if err := m.releaseStoredUnits(ctx, tx, st); err != nil {
+			return Decision{}, err
+		}
+		// The ramp is a separate control with its own mode. A deployment can
+		// run the ramp with budgets disabled — that is exactly what production
+		// does today — so the budget being off is not a reason to skip it.
+		// A trusted account is exempt from both.
+		if exempt || st.op.Purpose == PurposeTrustedSystem {
+			return allowDecision(), nil
+		}
+		if err := m.rampAuthorize(ctx, tx, st.policy, st.ramp, st.day); err != nil {
+			if errors.Is(err, errRampCapacity) {
+				return holdDecision(ReasonRampCapacity, nextUTCMidnight(st.day)), nil
+			}
+			return Decision{}, err
+		}
+		return allowDecision(), nil
 	}
 
 	currentKeys, err := scopeKeys(st.op.Purpose, st.op.accountRef(), st.op.Shared, st.probation)
@@ -1044,7 +1079,56 @@ func (m *Module) reauthorizeBudget(ctx context.Context, tx pgx.Tx, st authState)
 	if err := plan.flush(ctx, tx); err != nil {
 		return Decision{}, err
 	}
+
+	// The ramp is last in the lock order and decided last. The budget said yes;
+	// if the ramp says no, the most restrictive answer wins and the budget
+	// units this transaction just took are given straight back — holding them
+	// would charge an account for a send its own domain was not allowed to
+	// make.
+	if err := m.rampAuthorize(ctx, tx, st.policy, st.ramp, st.day); err != nil {
+		if !errors.Is(err, errRampCapacity) {
+			return Decision{}, err
+		}
+		if err := m.releaseReacquiredUnits(ctx, tx, st); err != nil {
+			return Decision{}, err
+		}
+		return holdDecision(ReasonRampCapacity, nextUTCMidnight(st.day)), nil
+	}
 	return allowDecision(), nil
+}
+
+// releaseReacquiredUnits gives back the units reauthorizeBudget just took, for
+// the one case where a later control overrules it.
+//
+// The rows are already locked by this transaction, so this re-locks nothing and
+// cannot deadlock; it is the same ordered set, walked again to apply the
+// inverse delta.
+func (m *Module) releaseReacquiredUnits(ctx context.Context, tx pgx.Tx, st authState) error {
+	keys, err := scopeKeys(st.op.Purpose, st.op.accountRef(), st.op.Shared, st.probation)
+	if err != nil {
+		return err
+	}
+	refs := refsFor(keys, st.day)
+	plan, err := lockLedger(ctx, tx, nil, refs)
+	if err != nil {
+		return err
+	}
+	for _, ref := range refs {
+		plan.release(ref, st.units)
+	}
+	if err := plan.flush(ctx, tx); err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		UPDATE sending_budget_reservations
+		   SET state = 'released', call_state = 'none', authorization_nonce = NULL,
+		       provider_call_started_at = NULL, updated_at = now()
+		 WHERE operation_id = $1 AND submission_attempt = $2`,
+		st.op.OperationID, st.stored.Attempt)
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: release ramp-held reservation: %w", err)
+	}
+	return nil
 }
 
 // authorize confirms the capacity, mints the single-use nonce, records the
@@ -1503,10 +1587,6 @@ func (m *Module) DeferAttempt(ctx context.Context, ref AttemptRef) error {
 // CancelAttempt gives back both ledgers for a terminal local cancellation such
 // as a suppression match.
 func (m *Module) CancelAttempt(ctx context.Context, ref AttemptRef) error {
-	// The ramp half arrives with Task 4's adapter; until the ramp is composed
-	// into final authorization there is no ramp reservation for this module
-	// to release, and the existing message-keyed ledger stays with its
-	// current owner.
 	return m.releaseAttempt(ctx, ref, "cancel")
 }
 
@@ -1582,6 +1662,15 @@ func (m *Module) releaseAttempt(ctx context.Context, ref AttemptRef, what string
 	); err != nil {
 		return fmt.Errorf("sendingpolicy: %s reservation: %w", what, err)
 	}
+	// A terminal local cancellation — a suppression match, say — gives back
+	// both ledgers. A rate deferral gives back only the budget: the message was
+	// not rejected by anyone, and releasing its ramp claim would let it
+	// re-qualify a stage it has already qualified.
+	if what == "cancel" && op.Purpose == PurposeCustomerMessage {
+		if err := m.rampRelease(ctx, tx, op.OperationID); err != nil {
+			return err
+		}
+	}
 	return m.commit(ctx, tx, what)
 }
 
@@ -1606,7 +1695,8 @@ func (m *Module) SettleProvider(ctx context.Context, settlement ProviderSettleme
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if _, err := lockOperation(ctx, tx, settlement.Attempt.operationID); err != nil {
+	op, err := lockOperation(ctx, tx, settlement.Attempt.operationID)
+	if err != nil {
 		return err
 	}
 	stored, err := lockReservation(ctx, tx, settlement.Attempt.operationID, settlement.Attempt.attempt)
@@ -1618,15 +1708,16 @@ func (m *Module) SettleProvider(ctx context.Context, settlement ProviderSettleme
 	}
 	// Settlement reports what the PROVIDER did, so it is only meaningful for an
 	// attempt that was authorized to reach the provider. Accepting a reserved
-	// or released attempt would let a caller advance ramp progress for a send
-	// that never happened once Task 4 hangs the ramp mutation off this call.
+	// or released attempt would advance ramp progress for a send that never
+	// happened.
 	if stored.State != "confirmed" {
 		return ErrAttemptStale
 	}
 
-	// The ramp ledger is Task 4's to move. Validating the attempt here — and
-	// taking its locks in the normative order — is what makes that composition
-	// a body change rather than a reshaping of the interface every caller
-	// already uses.
+	if op.Purpose == PurposeCustomerMessage {
+		if err := m.rampSettle(ctx, tx, op.OperationID, settlement.Outcome); err != nil {
+			return err
+		}
+	}
 	return m.commit(ctx, tx, "settle")
 }

--- a/internal/sendingpolicy/gate.go
+++ b/internal/sendingpolicy/gate.go
@@ -303,13 +303,22 @@ func (m *Module) Reserve(ctx context.Context, ref OperationRef) (Decision, Attem
 		return Decision{}, AttemptRef{}, err
 	}
 
-	// Probation classification. Shared-domain traffic is probationary at every
-	// plan level and never graduates by age or payment — higher-volume
-	// initiated sending requires a customer-controlled domain. Custom-domain
-	// probation is the custom-domain ramp's answer, composed into this
-	// decision by Task 4; until then a dedicated domain is not probationary,
-	// which is correct while the ramp itself is pass-through.
-	probation := op.Shared
+	// Probation classification, from the same source final authorization uses.
+	//
+	// Shared-domain traffic is probationary at every plan level and never
+	// graduates by age or payment — higher-volume initiated sending requires a
+	// customer-controlled domain. Custom-domain probation is the ramp's answer,
+	// and reading it HERE rather than only at final authorization is what makes
+	// the early hold bound the probation pool at all: a worker that is going to
+	// be stopped by the platform's Sybil guardrail must learn it before it
+	// composes and signs a message. It also keeps the stored `probation` column
+	// equal to the class the release path will target, and saves every
+	// authorization a needless release-and-reacquire on the platform's hottest
+	// counter rows.
+	probation, err := m.rampProbation(ctx, tx, policy, op)
+	if err != nil {
+		return Decision{}, AttemptRef{}, err
+	}
 
 	// Trusted first-party accounts charge nothing, and that has to be true
 	// HERE and not only at final authorization. The exemption exists so
@@ -680,8 +689,12 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 	// stale answer can only be stale in the strict direction.
 	st.probation, err = m.rampProbation(ctx, tx, policy, op)
 	if err != nil {
+		// TERMINAL, exactly as the envelope resolution below answers the same
+		// loss. This read runs FIRST, so a retryable answer here would pre-empt
+		// the correct one whenever the ramp is armed, and the worker would
+		// snooze forever on an operation whose message no longer exists.
 		if errors.Is(err, ErrSourceUnavailable) {
-			return st, holdDecision(ReasonSourceUnavailable, time.Time{}), nil
+			return st, terminalHold(ReasonSourceUnavailable), nil
 		}
 		return st, Decision{}, err
 	}
@@ -769,8 +782,11 @@ func (m *Module) readAuthState(ctx context.Context, tx pgx.Tx, ref AttemptRef) (
 
 	st.ramp, err = m.rampSubjectFor(ctx, tx, policy, op, st.units)
 	if err != nil {
+		// Defensive: rampProbation resolves the same rows earlier and would
+		// already have answered. Terminal for the same reason it is above — a
+		// vanished source is not something a retry can restore.
 		if errors.Is(err, ErrSourceUnavailable) {
-			return st, holdDecision(ReasonSourceUnavailable, time.Time{}), nil
+			return st, terminalHold(ReasonSourceUnavailable), nil
 		}
 		return st, Decision{}, err
 	}
@@ -999,8 +1015,10 @@ func (m *Module) reauthorizeBudget(ctx context.Context, tx pgx.Tx, st authState)
 			return allowDecision(), nil
 		}
 		if err := m.rampAuthorize(ctx, tx, st.policy, st.ramp, st.day); err != nil {
-			if errors.Is(err, errRampCapacity) {
-				return holdDecision(ReasonRampCapacity, nextUTCMidnight(st.day)), nil
+			// releaseStoredUnits above already gave back whatever an earlier
+			// Reserve was holding, so every hold here leaves the ledger clean.
+			if hold, ok := rampHoldFor(err, st.day); ok {
+				return hold, nil
 			}
 			return Decision{}, err
 		}
@@ -1086,13 +1104,20 @@ func (m *Module) reauthorizeBudget(ctx context.Context, tx pgx.Tx, st authState)
 	// would charge an account for a send its own domain was not allowed to
 	// make.
 	if err := m.rampAuthorize(ctx, tx, st.policy, st.ramp, st.day); err != nil {
-		if !errors.Is(err, errRampCapacity) {
+		hold, ok := rampHoldFor(err, st.day)
+		if !ok {
 			return Decision{}, err
 		}
+		// Every ramp refusal — capacity, identity, or permanent — gives the
+		// budget units this transaction just took straight back. A permanent
+		// one especially: returning it as an error would roll back with the
+		// attempt still `reserved`, and since every later execution fails at
+		// the same point, those units would sit on the SHARED pools until
+		// midnight with nothing able to release them.
 		if err := m.releaseReacquiredUnits(ctx, tx, st); err != nil {
 			return Decision{}, err
 		}
-		return holdDecision(ReasonRampCapacity, nextUTCMidnight(st.day)), nil
+		return hold, nil
 	}
 	return allowDecision(), nil
 }
@@ -1585,9 +1610,55 @@ func (m *Module) DeferAttempt(ctx context.Context, ref AttemptRef) error {
 }
 
 // CancelAttempt gives back both ledgers for a terminal local cancellation such
-// as a suppression match.
+// as a suppression match — the ramp half only while nothing has been authorized
+// to send this message. See cancelRamp.
 func (m *Module) CancelAttempt(ctx context.Context, ref AttemptRef) error {
 	return m.releaseAttempt(ctx, ref, "cancel")
+}
+
+// cancelRamp gives the message-keyed ramp reservation back for a terminal local
+// cancellation, but only when no attempt of this operation has ever been
+// authorized to reach the provider.
+//
+// The two ledgers are keyed differently, and that asymmetry is the hazard. A
+// sending-budget reservation belongs to ONE submission attempt and refuses to
+// refund a confirmed one, so a cancel can never hand back capacity a socket may
+// have used. The ramp reservation is keyed by MESSAGE and has no ordinal at
+// all: cancelling attempt N+1 releases exactly the units attempt N handed to
+// SES. An unsettled attempt is the ordinary state after an ambiguous SMTP
+// result — settlement deliberately leaves the reservation standing, because a
+// message that might have been delivered must not release capacity — so the
+// refund repeats on every retry, and a repeatable refund makes the stage cap
+// advisory rather than binding.
+//
+// The question is therefore about the OPERATION, not the ordinal: if any
+// attempt was ever authorized, the ramp units are spent whichever attempt is
+// being cancelled, and only SettleProvider — holding a definite provider
+// outcome — may give them back. A reservation that no attempt has authorized is
+// still refundable, which is the shape the outbound worker produces today when
+// it reserves ramp capacity before this module is involved.
+//
+// The read needs no lock: the caller holds the operation row FOR UPDATE and
+// every authorization takes that same row, so no attempt can become confirmed
+// underneath it.
+func (m *Module) cancelRamp(ctx context.Context, tx pgx.Tx, op operationRow, what string) error {
+	if what != "cancel" || op.Purpose != PurposeCustomerMessage {
+		return nil
+	}
+	var authorized bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		    SELECT 1 FROM sending_budget_reservations
+		     WHERE operation_id = $1
+		       AND (state = 'confirmed' OR call_state <> 'none')
+		)`, op.OperationID,
+	).Scan(&authorized); err != nil {
+		return fmt.Errorf("sendingpolicy: read authorized attempts: %w", err)
+	}
+	if authorized {
+		return nil
+	}
+	return m.rampRelease(ctx, tx, op.OperationID)
 }
 
 // releaseAttempt is the shared release path. Both callers are valid only while
@@ -1633,8 +1704,17 @@ func (m *Module) releaseAttempt(ctx context.Context, ref AttemptRef, what string
 		return ErrAttemptStale
 	}
 	if stored.State == "released" {
-		// Already given back. Releases run on retry-prone paths, so repeating
-		// one must be a no-op rather than an error or a double refund.
+		// The BUDGET half is already given back, and repeating it must be a
+		// no-op rather than an error or a double refund — releases run on
+		// retry-prone paths. The RAMP half may still be outstanding: a
+		// deferral releases the budget and deliberately keeps the ramp, so a
+		// suppression discovered immediately afterwards arrives here holding
+		// the terminal answer the ramp was waiting for. Returning early would
+		// leave a message that will never send holding its domain's allowance
+		// until midnight.
+		if err := m.cancelRamp(ctx, tx, op, what); err != nil {
+			return err
+		}
 		return m.commit(ctx, tx, what)
 	}
 
@@ -1666,10 +1746,8 @@ func (m *Module) releaseAttempt(ctx context.Context, ref AttemptRef, what string
 	// both ledgers. A rate deferral gives back only the budget: the message was
 	// not rejected by anyone, and releasing its ramp claim would let it
 	// re-qualify a stage it has already qualified.
-	if what == "cancel" && op.Purpose == PurposeCustomerMessage {
-		if err := m.rampRelease(ctx, tx, op.OperationID); err != nil {
-			return err
-		}
+	if err := m.cancelRamp(ctx, tx, op, what); err != nil {
+		return err
 	}
 	return m.commit(ctx, tx, what)
 }

--- a/internal/sendingpolicy/ramp.go
+++ b/internal/sendingpolicy/ramp.go
@@ -31,6 +31,23 @@ import (
 // holds until midnight and the second must not be allowed to look like a hold.
 var errRampCapacity = errors.New("sendingpolicy: ramp capacity exhausted")
 
+// errRampIdentityUnverified is the internal marker for the ramp's other
+// refusal: the domain this message would send as has no verified sending
+// identity. It is not a volume answer and must not wait for midnight — the
+// thing that clears it is the customer finishing DNS verification.
+var errRampIdentityUnverified = errors.New("sendingpolicy: sending identity is not verified")
+
+// errRampUnavailable marks a PERMANENT ramp refusal — a domain that changed
+// hands, a reservation already settled, a persisted schedule that no longer
+// validates.
+//
+// Keeping it distinct from a transport error is the whole point. Both arrive as
+// `error` from the ramp store, but a permanent one will be repeated identically
+// by every later execution, so returning it as an error rolls the transaction
+// back with the attempt still `reserved` and its units stranded on the SHARED
+// pools with nothing able to release them. A caller can farm that.
+var errRampUnavailable = errors.New("sendingpolicy: ramp permanently refused this message")
+
 // ReasonRampCapacity is the machine-readable hold reason for a domain that has
 // used its ramp allowance for the day.
 const ReasonRampCapacity = "sending_ramp_capacity_exhausted"
@@ -141,20 +158,54 @@ func (m *Module) rampAuthorize(ctx context.Context, tx pgx.Tx, policy RuntimePol
 		},
 	})
 	if err != nil {
+		var permanent *sendramp.PermanentError
+		if errors.As(err, &permanent) {
+			return fmt.Errorf("%w: %v", errRampUnavailable, err)
+		}
 		return fmt.Errorf("sendingpolicy: reserve ramp capacity: %w", err)
 	}
 	if !decision.Allowed {
+		if decision.IdentityUnverified {
+			return errRampIdentityUnverified
+		}
 		return errRampCapacity
 	}
 	return nil
 }
 
+// rampHoldFor turns a ramp refusal into the decision it deserves, and reports
+// whether it was a refusal at all.
+//
+// The distinction it draws is the one the caller cannot afford to get wrong. A
+// capacity answer waits for midnight; an unverified identity waits for the
+// customer, with no clock to advise; a permanent refusal waits for nothing and
+// must be terminal, so the worker fails the message once instead of snoozing on
+// it forever. Anything unrecognized stays an error — a transport failure that
+// looked like a hold would silently un-ramp the send.
+//
+// Every branch here is a HOLD, and every hold must be reached on a path that
+// gives the budget units back. That is why this returns a decision rather than
+// writing one: the two call sites have released their units at different
+// points, and only they know which.
+func rampHoldFor(err error, day time.Time) (Decision, bool) {
+	switch {
+	case errors.Is(err, errRampCapacity):
+		return holdDecision(ReasonRampCapacity, nextUTCMidnight(day)), true
+	case errors.Is(err, errRampIdentityUnverified):
+		return holdDecision(ReasonSendingIdentityUnverified, time.Time{}), true
+	case errors.Is(err, errRampUnavailable):
+		return terminalHold(ReasonRampUnavailable), true
+	}
+	return Decision{}, false
+}
+
 // rampRelease returns a message's ramp units for a terminal local cancellation.
 //
-// Only Cancel does this. A rate deferral deliberately retains the ramp
-// reservation: the message was not rejected by anyone, it was merely slowed
-// down, and releasing its ramp claim would let the same message re-qualify a
-// stage it has already qualified.
+// Only Cancel does this, and only through cancelRamp, which decides WHETHER the
+// units are still this caller's to give back. A rate deferral deliberately
+// retains the reservation: the message was not rejected by anyone, it was
+// merely slowed down, and releasing its ramp claim would let the same message
+// re-qualify a stage it has already qualified.
 func (m *Module) rampRelease(ctx context.Context, tx pgx.Tx, messageID string) error {
 	if err := sendramp.ReleaseTx(ctx, tx, messageID); err != nil {
 		return fmt.Errorf("sendingpolicy: release ramp capacity: %w", err)

--- a/internal/sendingpolicy/ramp.go
+++ b/internal/sendingpolicy/ramp.go
@@ -1,0 +1,185 @@
+package sendingpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/tokencanopy/e2a/internal/sendramp"
+)
+
+// This file composes the custom-domain ramp into final authorization.
+//
+// The ramp and the sending budget answer different questions. The budget asks
+// "has this account, or the platform, already exposed SES enough today?" The
+// ramp asks "has this particular domain earned the right to send this much
+// yet?" A new custom domain can be well inside its account's daily allowance
+// and still be limited to 150 recipients because it has no reputation history;
+// an established domain can be far into its ramp and still be held because the
+// platform pool is exhausted. Both apply, and the most restrictive wins.
+//
+// Composition is one-directional: the ramp is private to this package and is
+// reached only through Gate. Nothing outside can reserve ramp capacity without
+// also passing the budget, which is what stops the two ledgers from being
+// satisfied by different callers at different times.
+
+// ErrRampCapacity is the internal marker for a ramp hold. It never escapes to a
+// caller — Gate turns it into a Decision — but it keeps "this domain has sent
+// enough today" distinct from "the database is unhappy", because the first
+// holds until midnight and the second must not be allowed to look like a hold.
+var errRampCapacity = errors.New("sendingpolicy: ramp capacity exhausted")
+
+// ReasonRampCapacity is the machine-readable hold reason for a domain that has
+// used its ramp allowance for the day.
+const ReasonRampCapacity = "sending_ramp_capacity_exhausted"
+
+// rampSubject is everything the ramp needs about one customer message, read
+// from the locked source rows.
+type rampSubject struct {
+	messageID string
+	userID    string
+	domain    string
+	units     int
+	// applies is false for every message the ramp does not govern: shared-relay
+	// mail, platform test mail, non-message purposes, and every deployment
+	// whose policy has the ramp disabled.
+	applies bool
+}
+
+// rampSubjectFor derives the ramp's view of an operation.
+//
+// The eligibility rule matches the existing worker's exactly — own-address mail
+// that is not platform test mail — because the ramp ledger is message-keyed and
+// shared with that worker during the migration. Two different notions of
+// "eligible" would let one path reserve capacity the other never released.
+func (m *Module) rampSubjectFor(ctx context.Context, tx pgx.Tx, policy RuntimePolicy, op operationRow, units int) (rampSubject, error) {
+	if !policy.RampEnabled || op.Purpose != PurposeCustomerMessage || op.Shared {
+		return rampSubject{}, nil
+	}
+
+	var domain, messageType string
+	err := tx.QueryRow(ctx, `
+		SELECT agent.registered_domain, COALESCE(message.message_type, '')
+		  FROM messages AS message
+		  JOIN agent_identities AS agent ON agent.id = message.agent_id
+		 WHERE message.id = $1`, op.OperationID,
+	).Scan(&domain, &messageType)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return rampSubject{}, ErrSourceUnavailable
+	}
+	if err != nil {
+		return rampSubject{}, fmt.Errorf("sendingpolicy: read ramp subject: %w", err)
+	}
+	if messageType == "test" {
+		return rampSubject{}, nil
+	}
+
+	return rampSubject{
+		messageID: op.OperationID,
+		userID:    op.accountRef(),
+		domain:    domain,
+		units:     units,
+		applies:   true,
+	}, nil
+}
+
+// rampProbation reports whether this operation still draws on the shared
+// probation pool.
+//
+// Shared-relay traffic is probationary at every plan level and never graduates
+// — it borrows platform reputation, so no amount of age or payment earns it
+// higher volume; the way out is a customer-controlled domain. A custom domain
+// is probationary until its scope has one qualified day behind it.
+//
+// When the ramp is disabled the answer is "not probationary", and that is
+// correct rather than permissive: with the ramp pass-through there is no
+// probation concept for custom domains at all, and the account and platform
+// pools still bound the traffic.
+func (m *Module) rampProbation(ctx context.Context, tx pgx.Tx, policy RuntimePolicy, op operationRow) (bool, error) {
+	if op.Shared {
+		return true, nil
+	}
+	subject, err := m.rampSubjectFor(ctx, tx, policy, op, 1)
+	if err != nil {
+		return false, err
+	}
+	if !subject.applies {
+		return false, nil
+	}
+	state, err := sendramp.InspectScopeTx(ctx, tx, subject.userID, subject.domain)
+	if err != nil {
+		return false, fmt.Errorf("sendingpolicy: inspect ramp scope: %w", err)
+	}
+	return !state.Established, nil
+}
+
+// rampAuthorize acquires the message's ramp capacity, last in the normative
+// lock order.
+//
+// It runs after the budget has been reacquired, so a ramp hold arrives with the
+// budget already taken; the caller releases that reservation before returning.
+// The order is not negotiable — the budget counters are global and highly
+// contended, the ramp keys are per-domain, and taking the narrow keys first
+// would let two accounts sharing a registrable domain deadlock against the
+// platform pool.
+func (m *Module) rampAuthorize(ctx context.Context, tx pgx.Tx, policy RuntimePolicy, subject rampSubject, day time.Time) error {
+	if !subject.applies {
+		return nil
+	}
+	decision, err := sendramp.ReserveTx(ctx, tx, sendramp.ReserveRequest{
+		MessageID: subject.messageID,
+		UserID:    subject.userID,
+		Domain:    subject.domain,
+		Units:     subject.units,
+		Day:       day,
+		Schedule: sendramp.Schedule{
+			StartDaily:  policy.RampStartDaily,
+			TargetDaily: policy.RampTargetDaily,
+			RampDays:    policy.RampDays,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: reserve ramp capacity: %w", err)
+	}
+	if !decision.Allowed {
+		return errRampCapacity
+	}
+	return nil
+}
+
+// rampRelease returns a message's ramp units for a terminal local cancellation.
+//
+// Only Cancel does this. A rate deferral deliberately retains the ramp
+// reservation: the message was not rejected by anyone, it was merely slowed
+// down, and releasing its ramp claim would let the same message re-qualify a
+// stage it has already qualified.
+func (m *Module) rampRelease(ctx context.Context, tx pgx.Tx, messageID string) error {
+	if err := sendramp.ReleaseTx(ctx, tx, messageID); err != nil {
+		return fmt.Errorf("sendingpolicy: release ramp capacity: %w", err)
+	}
+	return nil
+}
+
+// rampSettle applies an authoritative provider outcome to the ramp ledger.
+//
+// Acceptance is the only thing that advances a ramp day, because progress has
+// to measure delivered volume rather than attempts — otherwise a domain could
+// age into full allowance by failing repeatedly. A definite permanent rejection
+// gives the units back. Retryable and ambiguous results are deliberately absent
+// from the closed outcome set and leave the reservation standing: a message
+// that might have been delivered must not release ramp capacity.
+func (m *Module) rampSettle(ctx context.Context, tx pgx.Tx, messageID string, outcome SettlementOutcome) error {
+	switch outcome {
+	case SettlementProviderAccepted:
+		if err := sendramp.ConfirmTx(ctx, tx, messageID); err != nil {
+			return fmt.Errorf("sendingpolicy: confirm ramp capacity: %w", err)
+		}
+	case SettlementProviderPermanentlyRejected:
+		if err := sendramp.ReleaseTx(ctx, tx, messageID); err != nil {
+			return fmt.Errorf("sendingpolicy: release ramp capacity: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/sendingpolicy/ramp_integration_test.go
+++ b/internal/sendingpolicy/ramp_integration_test.go
@@ -407,9 +407,7 @@ func TestSettlementIsTheOnlyThingThatAdvancesTheRamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
-	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
-		t.Fatalf("authorize: auth=%v err=%v", auth, err)
-	}
+	f.consumeAndRedeem(g, attempt)
 
 	// Authorized but unsettled: the day has not qualified.
 	if _, days, ok := f.rampScope(user, domain); !ok || days != 0 {
@@ -454,9 +452,7 @@ func TestPermanentRejectionReleasesRampCapacity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
-	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
-		t.Fatalf("authorize: auth=%v err=%v", auth, err)
-	}
+	f.consumeAndRedeem(g, attempt)
 	if reserved, _, _ := f.domainCounter(user, domain); reserved != 10 {
 		t.Fatalf("ramp reserved = %d, want 10", reserved)
 	}
@@ -636,9 +632,7 @@ func TestFreePlanCanQualifyStageOneButNotStageTwo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
-	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
-		t.Fatalf("authorize: auth=%v err=%v", auth, err)
-	}
+	f.consumeAndRedeem(g, attempt)
 	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
 		Attempt: attempt, Outcome: sendingpolicy.SettlementProviderAccepted,
 	}); err != nil {
@@ -689,9 +683,7 @@ func TestFreePlanCanQualifyStageOneButNotStageTwo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stage two reserve: %v", err)
 	}
-	if d, auth, err := g.ConsumeAttempt(f.ctx, stageTwo); err != nil || auth == nil {
-		t.Fatalf("stage two authorize: decision=%+v auth=%v err=%v", d, auth, err)
-	}
+	f.consumeAndRedeem(g, stageTwo)
 	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
 		Attempt: stageTwo, Outcome: sendingpolicy.SettlementProviderAccepted,
 	}); err != nil {
@@ -824,9 +816,7 @@ func TestCancelCannotRefundRampUnitsAnEarlierAttemptSpent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
-	if _, auth, err := g.ConsumeAttempt(f.ctx, first); err != nil || auth == nil {
-		t.Fatalf("authorize attempt one: auth=%v err=%v", auth, err)
-	}
+	f.consumeAndRedeem(g, first)
 	if reserved, _, _ := f.domainCounter(user, domain); reserved != 100 {
 		t.Fatalf("ramp reserved = %d after authorization, want 100", reserved)
 	}
@@ -1311,9 +1301,7 @@ func TestDelayedAcceptanceCreditsTheAttemptsOwnDay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reserve: %v", err)
 	}
-	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
-		t.Fatalf("authorize: auth=%v err=%v", auth, err)
-	}
+	f.consumeAndRedeem(g, attempt)
 	// Age the ramp ledger so the attempt reads as three days old.
 	for _, stmt := range []string{
 		`UPDATE domain_send_counters SET day = day - 3`,
@@ -1531,4 +1519,19 @@ func probeRowLock(t *testing.T, f *fixture, query string, args []any) error {
 	defer func() { _ = tx.Rollback(f.ctx) }()
 	_, err = tx.Exec(f.ctx, query, args...)
 	return err
+}
+
+// consumeAndRedeem runs final authorization and then redeems the token, the
+// way the SMTP adapter does immediately before it dials. Settlement reports
+// what the provider did, so it is only meaningful for an attempt that opened
+// the socket; every test that settles must have redeemed first.
+func (f *fixture) consumeAndRedeem(g sendingpolicy.Gate, attempt sendingpolicy.AttemptRef) {
+	f.t.Helper()
+	_, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		f.t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	if err := g.RedeemProviderCall(f.ctx, *auth); err != nil {
+		f.t.Fatalf("redeem: %v", err)
+	}
 }

--- a/internal/sendingpolicy/ramp_integration_test.go
+++ b/internal/sendingpolicy/ramp_integration_test.go
@@ -2,7 +2,9 @@ package sendingpolicy_test
 
 import (
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/tokencanopy/e2a/internal/sendingpolicy"
 	"github.com/tokencanopy/e2a/internal/sendramp"
@@ -170,6 +172,27 @@ func TestProbationClassification(t *testing.T) {
 			},
 			probation: false,
 		},
+		// A scope's history cannot vouch for an identity it no longer sends
+		// under. A rebind onto an unverified child subdomain leaves the
+		// qualified days behind while the mail goes out on an unproven
+		// identity, so classification has to follow the identity.
+		"one qualified day, sending identity unverified": {
+			setup: func(f *fixture, userID, domain string) {
+				f.armScope(userID, domain, 1)
+				f.setDomainSendingStatus(domain, "pending")
+			},
+			probation: true,
+		},
+		// The two legacy states mean "this domain already earned its volume",
+		// and they say so about the domain rather than about today's SES
+		// verification record. They must stay established.
+		"legacy exempt, sending identity unverified": {
+			setup: func(f *fixture, _, domain string) {
+				f.setDomainRampStatus(domain, sendramp.StatusExempt)
+				f.setDomainSendingStatus(domain, "pending")
+			},
+			probation: false,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			f := newFixture(t)
@@ -194,10 +217,19 @@ func TestProbationClassification(t *testing.T) {
 			}
 
 			d := f.send(g, f.message(agent, "own_address", 1))
-			if tc.probation && d.Allow {
-				t.Fatal("a probationary domain must be bounded by the exhausted probation pool")
+			if tc.probation {
+				if d.Allow {
+					t.Fatal("a probationary domain must be bounded by the exhausted probation pool")
+				}
+				// The reason matters as much as the verdict: any other hold
+				// would mean the send was stopped by something that is not the
+				// Sybil guardrail, and the classification would be untested.
+				if d.Reason != sendingpolicy.ReasonGlobalProbation {
+					t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonGlobalProbation)
+				}
+				return
 			}
-			if !tc.probation && !d.Allow {
+			if !d.Allow {
 				t.Fatalf("an established domain must not draw on the probation pool (held: %q)", d.Reason)
 			}
 		})
@@ -250,8 +282,13 @@ func TestSharedTrafficNeverGraduates(t *testing.T) {
 	if d := f.send(g, f.message(relayAgent, "relay", 1)); !d.Allow {
 		t.Fatalf("first shared unit: %q", d.Reason)
 	}
-	if d := f.send(g, f.message(relayAgent, "relay", 1)); d.Allow {
+	d := f.send(g, f.message(relayAgent, "relay", 1))
+	if d.Allow {
 		t.Fatal("shared traffic must remain bounded by the probation pool regardless of plan or sibling domains")
+	}
+	if d.Reason != sendingpolicy.ReasonGlobalProbation {
+		t.Errorf("reason = %q, want %q — any other hold would leave the classification untested",
+			d.Reason, sendingpolicy.ReasonGlobalProbation)
 	}
 }
 
@@ -284,7 +321,24 @@ func TestRampHoldReturnsTheBudgetUnits(t *testing.T) {
 	if reserved, _, limit := f.domainCounter(user, domain); reserved != 150 || limit != 150 {
 		t.Fatalf("domain counter reserved=%d limit=%d, want 150/150", reserved, limit)
 	}
-	budgetBefore, _ := f.counter(sendingpolicy.ScopeAccountDaily, user)
+	// Every pool the transaction charges has to be given back, not just the
+	// account's: the two global pools are the ones an abusive account would
+	// otherwise pin for the whole platform by farming ramp holds.
+	pools := []struct {
+		scope sendingpolicy.Scope
+		id    string
+	}{
+		{sendingpolicy.ScopeGlobalAll, "all-customers"},
+		{sendingpolicy.ScopeGlobalProbation, "probation"},
+		{sendingpolicy.ScopeAccountDaily, user},
+	}
+	before := make([]int, len(pools))
+	for i, pool := range pools {
+		before[i], _ = f.counter(pool.scope, pool.id)
+		if before[i] == 0 {
+			t.Fatalf("%s was never charged, so its release proves nothing", pool.scope)
+		}
+	}
 
 	d := f.send(g, f.message(agent, "own_address", 1))
 	if d.Allow {
@@ -294,9 +348,11 @@ func TestRampHoldReturnsTheBudgetUnits(t *testing.T) {
 		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonRampCapacity)
 	}
 
-	budgetAfter, _ := f.counter(sendingpolicy.ScopeAccountDaily, user)
-	if budgetAfter != budgetBefore {
-		t.Errorf("a ramp hold left %d extra budget units charged (was %d)", budgetAfter-budgetBefore, budgetBefore)
+	for i, pool := range pools {
+		after, _ := f.counter(pool.scope, pool.id)
+		if after != before[i] {
+			t.Errorf("a ramp hold left %d extra units charged on %s (was %d)", after-before[i], pool.scope, before[i])
+		}
 	}
 }
 
@@ -423,7 +479,9 @@ func TestPermanentRejectionReleasesRampCapacity(t *testing.T) {
 //
 // A rate deferral has not been rejected by anyone, so releasing its ramp claim
 // would let the same message re-qualify a stage it already qualified. A
-// suppression match is terminal and gives both ledgers back.
+// suppression match is terminal and gives both ledgers back — but only while
+// the ramp units are still provably pre-provider, which is why the reservation
+// here is taken before any attempt is authorized.
 func TestDeferRetainsTheRampWhileCancelReleasesIt(t *testing.T) {
 	for name, tc := range map[string]struct {
 		release   func(*fixture, sendingpolicy.Gate, sendingpolicy.AttemptRef) error
@@ -453,27 +511,18 @@ func TestDeferRetainsTheRampWhileCancelReleasesIt(t *testing.T) {
 			user := f.user("standard")
 			agent, domain := f.customDomainAgent(user)
 
-			_, ref := f.prepareMessage(g, f.message(agent, "own_address", 7))
-			_, attempt, err := g.Reserve(f.ctx, ref)
-			if err != nil {
-				t.Fatalf("reserve: %v", err)
-			}
-			// The ramp reservation is created at final authorization, so drive
-			// one and then step back to a pre-provider state.
-			if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
-				t.Fatalf("authorize: auth=%v err=%v", auth, err)
-			}
+			messageID := f.message(agent, "own_address", 7)
+			f.legacyRampReserve(user, domain, messageID, 7, time.Time{})
 			if reserved, _, _ := f.domainCounter(user, domain); reserved != 7 {
 				t.Fatalf("ramp reserved = %d, want 7", reserved)
 			}
 
-			// Re-arm a fresh pre-provider ordinal, which is what a worker that
-			// hits its rate limiter or a suppression actually holds.
-			_, next, err := g.Reserve(f.ctx, ref)
+			_, ref := f.prepareMessage(g, messageID)
+			_, attempt, err := g.Reserve(f.ctx, ref)
 			if err != nil {
-				t.Fatalf("second reserve: %v", err)
+				t.Fatalf("reserve: %v", err)
 			}
-			if err := tc.release(f, g, next); err != nil {
+			if err := tc.release(f, g, attempt); err != nil {
 				t.Fatalf("%s: %v", name, err)
 			}
 			if reserved, _, _ := f.domainCounter(user, domain); reserved != tc.rampAfter {
@@ -611,9 +660,875 @@ func TestFreePlanCanQualifyStageOneButNotStageTwo(t *testing.T) {
 		t.Errorf("active days = %d, want progress retained at 1", days)
 	}
 
-	// After an upgrade, progression resumes from where it stopped.
+	// After an upgrade, progression RESUMES from where it stopped. That the
+	// plan write left the scope alone is the weaker half; what the design
+	// promises is that the next stage can now be qualified without a reset.
 	f.plan(user, "scale")
 	if _, days, _ := f.rampScope(user, domain); days != 1 {
 		t.Errorf("an upgrade reset ramp progress to %d", days)
 	}
+
+	// Roll both ledgers to the next UTC day, which is what midnight does.
+	for _, stmt := range []string{
+		`UPDATE sending_budget_counters SET day = day - 1`,
+		`UPDATE domain_send_counters SET day = day - 1`,
+		`UPDATE sending_ramp_reservations SET day = day - 1`,
+		// The qualified-day marker moves with them, or the scope would refuse
+		// to count a second day it believes it already counted.
+		`UPDATE sending_ramp_scopes SET last_qualified_day = last_qualified_day - 1`,
+	} {
+		if _, err := f.pool.Exec(f.ctx, stmt); err != nil {
+			t.Fatalf("advance day (%s): %v", stmt, err)
+		}
+	}
+
+	// Stage two allows 213 recipients and qualifies at 107 — the bar the Free
+	// ceiling forbade and the upgraded plan can now afford.
+	_, second := f.prepareMessage(g, f.message(agent, "own_address", 107))
+	_, stageTwo, err := g.Reserve(f.ctx, second)
+	if err != nil {
+		t.Fatalf("stage two reserve: %v", err)
+	}
+	if d, auth, err := g.ConsumeAttempt(f.ctx, stageTwo); err != nil || auth == nil {
+		t.Fatalf("stage two authorize: decision=%+v auth=%v err=%v", d, auth, err)
+	}
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: stageTwo, Outcome: sendingpolicy.SettlementProviderAccepted,
+	}); err != nil {
+		t.Fatalf("stage two settle: %v", err)
+	}
+	if _, days, _ := f.rampScope(user, domain); days != 2 {
+		t.Errorf("active days = %d after the upgraded account cleared stage two, want 2", days)
+	}
+	if _, _, limit := f.domainCounter(user, domain); limit != 213 {
+		t.Errorf("stage two daily limit = %d, want 213", limit)
+	}
+}
+
+// --- Helpers for the composition tests -----------------------------------
+
+// legacyRampReserve takes ramp capacity the way today's outbound worker does:
+// straight through the pool-owning store, BEFORE any provider authorization
+// exists.
+//
+// That shape matters for more than migration compatibility. It is the only way
+// a ramp reservation can exist for a message no attempt has been authorized to
+// send, and therefore the only state in which a local cancellation is still
+// allowed to give those units back.
+func (f *fixture) legacyRampReserve(userID, domain, messageID string, units int, day time.Time) sendramp.Decision {
+	f.t.Helper()
+	d, err := sendramp.NewStore(f.pool).Reserve(f.ctx, sendramp.ReserveRequest{
+		MessageID: messageID,
+		UserID:    userID,
+		Domain:    domain,
+		Units:     units,
+		Day:       day,
+		Schedule:  sendramp.NewSchedule(150, 2000, 30),
+	})
+	if err != nil {
+		f.t.Fatalf("legacy ramp reserve: %v", err)
+	}
+	return d
+}
+
+// setDomainSendingStatus rewrites the domain's SENDING identity state, which is
+// what SES verification drives and what a subdomain rebind can move under a
+// message that was already accepted.
+func (f *fixture) setDomainSendingStatus(domain, status string) {
+	f.t.Helper()
+	if _, err := f.pool.Exec(f.ctx,
+		`UPDATE domains SET sending_status = $2 WHERE domain = $1`, domain, status,
+	); err != nil {
+		f.t.Fatalf("set sending status: %v", err)
+	}
+}
+
+// reservationProbation reads the probation class Reserve actually stored, which
+// is the value every later release targets.
+func (f *fixture) reservationProbation(operationID string, attempt int) bool {
+	f.t.Helper()
+	var probation bool
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT probation FROM sending_budget_reservations
+		 WHERE operation_id = $1 AND submission_attempt = $2`, operationID, attempt,
+	).Scan(&probation); err != nil {
+		f.t.Fatalf("read reservation probation: %v", err)
+	}
+	return probation
+}
+
+// ledgerToday is the UTC date the module's own clock read would produce.
+func (f *fixture) ledgerToday() time.Time {
+	f.t.Helper()
+	var day time.Time
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT (clock_timestamp() AT TIME ZONE 'UTC')::date`).Scan(&day); err != nil {
+		f.t.Fatalf("read ledger day: %v", err)
+	}
+	return day.UTC()
+}
+
+func (f *fixture) counterOn(scope sendingpolicy.Scope, scopeID string, day time.Time) (reserved, confirmed int) {
+	f.t.Helper()
+	err := f.pool.QueryRow(f.ctx, `
+		SELECT COALESCE(SUM(reserved_count), 0), COALESCE(SUM(confirmed_count), 0)
+		  FROM sending_budget_counters
+		 WHERE scope = $1 AND scope_id = $2 AND day = $3`, string(scope), scopeID, day,
+	).Scan(&reserved, &confirmed)
+	if err != nil {
+		f.t.Fatalf("read counter for %s: %v", day.Format("2006-01-02"), err)
+	}
+	return reserved, confirmed
+}
+
+func (f *fixture) domainCounterOn(userID, domain string, day time.Time) (reserved, confirmed int) {
+	f.t.Helper()
+	err := f.pool.QueryRow(f.ctx, `
+		SELECT COALESCE(SUM(reserved_count), 0), COALESCE(SUM(confirmed_count), 0)
+		  FROM domain_send_counters WHERE user_id = $1 AND domain = $2 AND day = $3`,
+		userID, registrable(f.t, domain), day,
+	).Scan(&reserved, &confirmed)
+	if err != nil {
+		f.t.Fatalf("read domain counter for %s: %v", day.Format("2006-01-02"), err)
+	}
+	return reserved, confirmed
+}
+
+// --- Cancellation versus provider exposure --------------------------------
+
+// TestCancelCannotRefundRampUnitsAnEarlierAttemptSpent is the difference
+// between the two ledgers' keys, and it is the whole reason the stage cap is
+// not advisory.
+//
+// The sending budget is reserved per ATTEMPT and refuses to refund a confirmed
+// one. The ramp reservation is keyed by MESSAGE, so it has no ordinal of its
+// own: the units attempt one handed to the provider are the same units attempt
+// two would be giving back. An ambiguous provider result deliberately leaves
+// attempt one unsettled, River allocates attempt two, and a suppression added
+// in between cancels it — at which point a refund would hand back capacity for
+// mail that may already be in flight, repeatably.
+func TestCancelCannotRefundRampUnitsAnEarlierAttemptSpent(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.DefaultAccountDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+		p.ProbationGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	f.plan(user, "scale")
+	agent, domain := f.customDomainAgent(user)
+
+	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 100))
+	_, first, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, auth, err := g.ConsumeAttempt(f.ctx, first); err != nil || auth == nil {
+		t.Fatalf("authorize attempt one: auth=%v err=%v", auth, err)
+	}
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 100 {
+		t.Fatalf("ramp reserved = %d after authorization, want 100", reserved)
+	}
+
+	// The provider result was ambiguous, so nothing settled and the reservation
+	// stands. The retry allocates a strictly greater ordinal.
+	_, second, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("second reserve: %v", err)
+	}
+	if got := f.currentAttempt(ref.ID()); got != 2 {
+		t.Fatalf("current attempt = %d, want a fresh ordinal 2", got)
+	}
+	if err := g.CancelAttempt(f.ctx, second); err != nil {
+		t.Fatalf("cancel attempt two: %v", err)
+	}
+
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 100 {
+		t.Errorf("cancelling attempt two refunded %d ramp units attempt one already handed to the provider",
+			100-reserved)
+	}
+
+	// Repeatability is what turns the leak into an unlimited allowance, so
+	// prove the second cycle refunds nothing either.
+	_, third, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("third reserve: %v", err)
+	}
+	if err := g.CancelAttempt(f.ctx, third); err != nil {
+		t.Fatalf("cancel attempt three: %v", err)
+	}
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 100 {
+		t.Errorf("a repeated cancel drained the ramp to %d, want it pinned at 100", reserved)
+	}
+}
+
+// TestCancelAfterADeferStillReleasesTheRamp closes the mirror gap.
+//
+// DeferAttempt gives the budget back and marks the attempt released; a
+// suppression discovered immediately afterwards cancels the same ordinal. The
+// budget half is correctly a no-op the second time, but the ramp half had never
+// run at all, so a message that will never be sent kept its domain's allowance
+// until midnight.
+func TestCancelAfterADeferStillReleasesTheRamp(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.DefaultAccountDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+		p.ProbationGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+
+	messageID := f.message(agent, "own_address", 7)
+	f.legacyRampReserve(user, domain, messageID, 7, time.Time{})
+	_, ref := f.prepareMessage(g, messageID)
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+
+	// Rate deferral first: the budget comes back, the ramp deliberately does
+	// not.
+	if err := g.DeferAttempt(f.ctx, attempt); err != nil {
+		t.Fatalf("defer: %v", err)
+	}
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 7 {
+		t.Fatalf("ramp reserved = %d after a deferral, want it retained at 7", reserved)
+	}
+
+	// Then the suppression match, on the same ordinal the worker still holds.
+	if err := g.CancelAttempt(f.ctx, attempt); err != nil {
+		t.Fatalf("cancel after defer: %v", err)
+	}
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 0 {
+		t.Errorf("a cancel following a deferral left %d ramp units held for a message that will never send", reserved)
+	}
+}
+
+// --- Permanent ramp failure ------------------------------------------------
+
+// TestAPermanentRampRefusalReleasesTheBudgetUnits is the stranding case.
+//
+// A permanent ramp error is not "the database is unhappy" — it is a definite
+// refusal that every later execution will repeat. Returning it as an error
+// rolls the transaction back with the attempt still `reserved`, so the units it
+// holds on the SHARED pools can never be released by anything: not by the
+// retry, which fails at the same point, and not by a cancel, which the worker
+// never reaches. A handful of those exhausts the probation pool for the day.
+func TestAPermanentRampRefusalReleasesTheBudgetUnits(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+
+	messageID := f.message(agent, "own_address", 50)
+	f.legacyRampReserve(user, domain, messageID, 50, time.Time{})
+	// A local failure released those units. The ramp treats a released
+	// reservation as terminal and permanently refuses to reserve it again.
+	if err := sendramp.NewStore(f.pool).Release(f.ctx, messageID); err != nil {
+		t.Fatalf("release ramp reservation: %v", err)
+	}
+
+	_, ref := f.prepareMessage(g, messageID)
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		t.Fatalf("a permanent ramp refusal must be a hold, not an error: %v", err)
+	}
+	if auth != nil {
+		t.Fatal("a hold must never return a token")
+	}
+	assertTerminal(t, d, sendingpolicy.ReasonRampUnavailable)
+
+	for _, pool := range []struct {
+		scope sendingpolicy.Scope
+		id    string
+	}{
+		{sendingpolicy.ScopeGlobalAll, "all-customers"},
+		{sendingpolicy.ScopeGlobalProbation, "probation"},
+		{sendingpolicy.ScopeAccountDaily, user},
+	} {
+		if reserved, _ := f.counter(pool.scope, pool.id); reserved != 0 {
+			t.Errorf("%s left %d units stranded with nothing able to release them", pool.scope, reserved)
+		}
+	}
+	if state, callState := f.reservationState(ref.ID(), 1); state != "released" || callState != "none" {
+		t.Errorf("attempt left as %s/%s, want released/none", state, callState)
+	}
+}
+
+// --- Sending identity ------------------------------------------------------
+
+// TestAnUnverifiedSendingIdentityHoldsInsteadOfPassingThrough closes the
+// rebind bypass.
+//
+// The message's reputation class and its composed From are frozen at
+// acceptance, but the agent's registered domain is not: verifying a child
+// subdomain rebinds the account's agents onto it, and that child's SES identity
+// stays unverified while its DKIM records are never published. The ramp reads
+// the registered domain live, so an unverified identity that passes through
+// hands an accepted backlog an uncapped day — and, because a scope with a
+// qualified day behind it also reports established, it does not even pay the
+// probation pool on the way out.
+func TestAnUnverifiedSendingIdentityHoldsInsteadOfPassingThrough(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.DefaultAccountDailyRecipients = 5000
+		p.AllCustomerGlobalDailyRecipients = 5000
+		p.ProbationGlobalDailyRecipients = 5000
+	}))
+	user := f.user("standard")
+	f.plan(user, "scale")
+	agent, domain := f.customDomainAgent(user)
+	// A qualified day behind it, so nothing about this scope's history explains
+	// the refusal — only its identity does.
+	f.armScope(user, domain, 1)
+	f.setDomainSendingStatus(domain, "pending")
+
+	d := f.send(g, f.message(agent, "own_address", 5000))
+	if d.Allow {
+		t.Fatal("an unverified sending identity must not be ramp pass-through")
+	}
+	if d.Reason != sendingpolicy.ReasonSendingIdentityUnverified {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonSendingIdentityUnverified)
+	}
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 0 {
+		t.Errorf("the ramp counter moved by %d for a send it never governed", reserved)
+	}
+}
+
+// --- Reserve's probation classification ------------------------------------
+
+// TestReserveClassifiesProbationFromTheRamp pins the early half of the
+// composition.
+//
+// Reserve writes the probation column every later release targets and charges
+// the pools it names. A stand-in answer there is wrong three ways: the stored
+// class disagrees with the one final authorization computes, the early hold
+// never bounds the probation pool at all, and every authorization pays a
+// needless release-and-reacquire on the platform's hottest counter rows.
+func TestReserveClassifiesProbationFromTheRamp(t *testing.T) {
+	for name, tc := range map[string]struct {
+		setup     func(f *fixture, userID, domain string)
+		probation bool
+	}{
+		"day zero": {
+			setup:     func(f *fixture, u, d string) { f.armScope(u, d, 0) },
+			probation: true,
+		},
+		"one qualified day": {
+			setup:     func(f *fixture, u, d string) { f.armScope(u, d, 1) },
+			probation: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t)
+			g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+				p.BudgetMode = sendingpolicy.ModeEnforce
+				p.DefaultAccountDailyRecipients = 1000
+				p.AllCustomerGlobalDailyRecipients = 1000
+				p.ProbationGlobalDailyRecipients = 1000
+			}))
+			user := f.user("standard")
+			f.plan(user, "scale")
+			agent, domain := f.customDomainAgent(user)
+			tc.setup(f, user, domain)
+
+			_, ref := f.prepareMessage(g, f.message(agent, "own_address", 3))
+			if _, _, err := g.Reserve(f.ctx, ref); err != nil {
+				t.Fatalf("reserve: %v", err)
+			}
+			if got := f.reservationProbation(ref.ID(), 1); got != tc.probation {
+				t.Errorf("Reserve stored probation = %v, want %v", got, tc.probation)
+			}
+			reserved, _ := f.counter(sendingpolicy.ScopeGlobalProbation, "probation")
+			if (reserved > 0) != tc.probation {
+				t.Errorf("Reserve charged %d probation units, want charged=%v", reserved, tc.probation)
+			}
+		})
+	}
+}
+
+// TestReserveHoldsAnUnprovenDomainOnTheProbationPool proves the early hold
+// actually bounds the pool it classifies into. Without it a worker composes and
+// signs a message before learning the platform's Sybil guardrail is exhausted.
+func TestReserveHoldsAnUnprovenDomainOnTheProbationPool(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.ProbationGlobalDailyRecipients = 1
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent, _ := f.customDomainAgent(user)
+
+	// Burn the single probation unit with unrelated shared traffic.
+	other := f.agent(f.user("standard"))
+	if d := f.send(g, f.message(other, "relay", 1)); !d.Allow {
+		t.Fatalf("priming shared send: %q", d.Reason)
+	}
+
+	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 1))
+	d, _, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if d.Allow {
+		t.Fatal("Reserve must bound an unproven custom domain by the probation pool")
+	}
+	if d.Reason != sendingpolicy.ReasonGlobalProbation {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonGlobalProbation)
+	}
+}
+
+// --- Terminal source loss --------------------------------------------------
+
+// TestARampSourceThatVanishedIsTerminal is a regression on hold shape rather
+// than on accounting.
+//
+// The ramp's own source read runs before the envelope resolution that already
+// answers this correctly, so a retryable answer here pre-empts the terminal one
+// whenever the ramp is armed. A non-terminal hold makes the worker snooze
+// forever on an operation whose message no longer exists.
+func TestARampSourceThatVanishedIsTerminal(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+		p.ProbationGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent, _ := f.customDomainAgent(user)
+
+	messageID := f.message(agent, "own_address", 2)
+	_, ref := f.prepareMessage(g, messageID)
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `DELETE FROM messages WHERE id = $1`, messageID); err != nil {
+		t.Fatalf("delete message: %v", err)
+	}
+
+	d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if auth != nil {
+		t.Fatal("a hold must never return a token")
+	}
+	assertTerminal(t, d, sendingpolicy.ReasonSourceUnavailable)
+}
+
+// --- Concurrency -----------------------------------------------------------
+
+// TestConcurrentAuthorizationsCannotExceedOneStageCapOrDeadlock is the reason
+// the ramp store was collapsed onto a single lock order.
+//
+// Every one of these transactions holds the platform's hottest budget counters
+// before it reaches the ramp's per-domain keys, so any disagreement about
+// suborder closes a cycle across two subsystems — and Postgres resolves a cycle
+// by killing a transaction, which on this path is a message that errors instead
+// of being held. The assertion is therefore both halves at once: exactly one
+// stage cap admitted, and not one deadlock.
+func TestConcurrentAuthorizationsCannotExceedOneStageCapOrDeadlock(t *testing.T) {
+	const (
+		workers = 8
+		units   = 30 // 8 x 30 = 240 against a 150-recipient first stage
+	)
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.RampStartDaily = 150
+		p.DefaultAccountDailyRecipients = 5000
+		p.AllCustomerGlobalDailyRecipients = 5000
+		p.ProbationGlobalDailyRecipients = 5000
+	}))
+	user := f.user("standard")
+	f.plan(user, "scale")
+	agent, domain := f.customDomainAgent(user)
+
+	refs := make([]sendingpolicy.OperationRef, workers)
+	for i := range refs {
+		_, refs[i] = f.prepareMessage(g, f.message(agent, "own_address", units))
+	}
+
+	var wg sync.WaitGroup
+	granted := make([]bool, workers)
+	errs := make([]error, workers)
+	for i := range refs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			early, attempt, err := g.Reserve(f.ctx, refs[i])
+			if err != nil {
+				errs[i] = fmt.Errorf("reserve: %w", err)
+				return
+			}
+			if !early.Allow {
+				return
+			}
+			d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+			if err != nil {
+				errs[i] = fmt.Errorf("consume: %w", err)
+				return
+			}
+			granted[i] = d.Allow && auth != nil
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			// A deadlock arrives here as SQLSTATE 40P01.
+			t.Fatalf("worker %d failed instead of being held: %v", i, err)
+		}
+	}
+	admitted := 0
+	for _, ok := range granted {
+		if ok {
+			admitted++
+		}
+	}
+	if admitted != 5 {
+		t.Errorf("%d of %d workers were admitted, want exactly the 150/%d that fit one stage", admitted, workers, units)
+	}
+	reserved, _, limit := f.domainCounter(user, domain)
+	if reserved != 150 || limit != 150 {
+		t.Errorf("domain counter reserved=%d limit=%d, want the stage filled exactly once (150/150)", reserved, limit)
+	}
+}
+
+// --- Midnight --------------------------------------------------------------
+
+// TestOneAuthorizationReAgesBothLedgersAcrossMidnight proves the two ledgers
+// roll over together.
+//
+// Final authorization re-derives the UTC day after taking its locks, so an
+// attempt reserved before midnight must give yesterday's units back on BOTH
+// ledgers and take today's on both. Rolling only one leaves the other holding a
+// dead day's capacity until a janitor notices.
+func TestOneAuthorizationReAgesBothLedgersAcrossMidnight(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.DefaultAccountDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+		p.ProbationGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+	today := f.ledgerToday()
+	yesterday := today.AddDate(0, 0, -1)
+
+	// The ramp reservation was taken yesterday, before the rollover.
+	messageID := f.message(agent, "own_address", 5)
+	f.legacyRampReserve(user, domain, messageID, 5, yesterday)
+	if reserved, _ := f.domainCounterOn(user, domain, yesterday); reserved != 5 {
+		t.Fatalf("yesterday's ramp counter = %d, want 5", reserved)
+	}
+
+	// So was the budget reservation. Ageing the rows is exactly what midnight
+	// does from the ledger's point of view.
+	_, ref := f.prepareMessage(g, messageID)
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	for _, stmt := range []string{
+		`UPDATE sending_budget_counters SET day = day - 1`,
+		`UPDATE sending_budget_reservations SET day = day - 1`,
+	} {
+		if _, err := f.pool.Exec(f.ctx, stmt); err != nil {
+			t.Fatalf("advance day (%s): %v", stmt, err)
+		}
+	}
+
+	d, auth, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || auth == nil {
+		t.Fatalf("authorize across midnight: auth=%v err=%v decision=%+v", auth, err, d)
+	}
+
+	for _, pool := range []struct {
+		scope sendingpolicy.Scope
+		id    string
+	}{
+		{sendingpolicy.ScopeGlobalAll, "all-customers"},
+		{sendingpolicy.ScopeGlobalProbation, "probation"},
+		{sendingpolicy.ScopeAccountDaily, user},
+	} {
+		if reserved, _ := f.counterOn(pool.scope, pool.id, yesterday); reserved != 0 {
+			t.Errorf("%s still holds %d units on yesterday", pool.scope, reserved)
+		}
+		if reserved, confirmed := f.counterOn(pool.scope, pool.id, today); reserved != 5 || confirmed != 5 {
+			t.Errorf("%s today reserved=%d confirmed=%d, want 5/5", pool.scope, reserved, confirmed)
+		}
+	}
+	if reserved, _ := f.domainCounterOn(user, domain, yesterday); reserved != 0 {
+		t.Errorf("the ramp still holds %d units on yesterday", reserved)
+	}
+	if reserved, _ := f.domainCounterOn(user, domain, today); reserved != 5 {
+		t.Errorf("today's ramp counter = %d, want the re-aged 5", reserved)
+	}
+}
+
+// --- Delayed provider acceptance -------------------------------------------
+
+// TestDelayedAcceptanceCreditsTheAttemptsOwnDay proves settlement is bound to
+// the attempt, not to the clock that happens to be running when the evidence
+// arrives.
+//
+// SES delivery evidence can land days after submission, and the finalizer that
+// replays it calls the same SettleProvider. Crediting "today" would let a
+// domain qualify a day it never sent on, and would leave the real day's counter
+// reserved-but-never-confirmed forever.
+func TestDelayedAcceptanceCreditsTheAttemptsOwnDay(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+	sendDay := f.ledgerToday().AddDate(0, 0, -3)
+
+	// 80 recipients clears the first stage's 75-recipient qualification bar.
+	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 80))
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	// Age the ramp ledger so the attempt reads as three days old.
+	for _, stmt := range []string{
+		`UPDATE domain_send_counters SET day = day - 3`,
+		`UPDATE sending_ramp_reservations SET day = day - 3`,
+	} {
+		if _, err := f.pool.Exec(f.ctx, stmt); err != nil {
+			t.Fatalf("age ramp ledger (%s): %v", stmt, err)
+		}
+	}
+
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: attempt, Outcome: sendingpolicy.SettlementProviderAccepted,
+	}); err != nil {
+		t.Fatalf("delayed settle: %v", err)
+	}
+
+	if _, confirmed := f.domainCounterOn(user, domain, sendDay); confirmed != 80 {
+		t.Errorf("the send day's confirmed volume = %d, want 80", confirmed)
+	}
+	if reserved, _ := f.domainCounterOn(user, domain, f.ledgerToday()); reserved != 0 {
+		t.Errorf("a delayed settlement created %d units on today's counter", reserved)
+	}
+	_, days, _ := f.rampScope(user, domain)
+	if days != 1 {
+		t.Errorf("active days = %d, want the send day credited once", days)
+	}
+	var qualified *time.Time
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT last_qualified_day FROM sending_ramp_scopes WHERE user_id = $1 AND domain = $2`,
+		user, registrable(t, domain),
+	).Scan(&qualified); err != nil {
+		t.Fatalf("read last qualified day: %v", err)
+	}
+	if qualified == nil || !qualified.UTC().Equal(sendDay) {
+		t.Errorf("last qualified day = %v, want the attempt's own day %s", qualified, sendDay.Format("2006-01-02"))
+	}
+}
+
+// --- Lock order ------------------------------------------------------------
+
+// TestTheRampTakesItsKeysInTheNamedSuborder makes the deadlock argument
+// checkable instead of merely documented.
+//
+// The order is domain identity → registrable-domain scope → message
+// reservation → UTC day counter, and prose cannot keep it. Each phase parks a
+// competing session on one key, waits until the authorization is provably
+// blocked on exactly that key, and then probes the rest with FOR UPDATE NOWAIT:
+// every key EARLIER in the order must already be held, and every LATER one must
+// still be free.
+func TestTheRampTakesItsKeysInTheNamedSuborder(t *testing.T) {
+	type probe struct {
+		name  string
+		query string
+		args  func(user, domain, scope string, day time.Time) []any
+		held  bool
+	}
+	domainProbe := probe{
+		name:  "domain identity",
+		query: `SELECT 1 FROM domains WHERE domain = $1 FOR UPDATE NOWAIT`,
+		args:  func(_, domain, _ string, _ time.Time) []any { return []any{domain} },
+		held:  true,
+	}
+	scopeProbe := probe{
+		name:  "registrable-domain scope",
+		query: `SELECT 1 FROM sending_ramp_scopes WHERE user_id = $1 AND domain = $2 FOR UPDATE NOWAIT`,
+		args:  func(user, _, scope string, _ time.Time) []any { return []any{user, scope} },
+	}
+	counterProbe := probe{
+		name:  "UTC day counter",
+		query: `SELECT 1 FROM domain_send_counters WHERE user_id = $1 AND domain = $2 AND day = $3 FOR UPDATE NOWAIT`,
+		args:  func(user, _, scope string, day time.Time) []any { return []any{user, scope, day} },
+	}
+
+	for _, phase := range []struct {
+		name string
+		// block is the key a competing session holds, which the authorization
+		// must stop at.
+		block  func(user, domain, scope string, day time.Time) (string, []any)
+		probes []probe
+		// preReserve pre-creates the message's ramp reservation, which is the
+		// only way a competitor can hold that key before the gate does.
+		preReserve bool
+	}{
+		{
+			name: "blocked on the scope",
+			block: func(user, _, scope string, _ time.Time) (string, []any) {
+				return `SELECT 1 FROM sending_ramp_scopes WHERE user_id = $1 AND domain = $2 FOR UPDATE`,
+					[]any{user, scope}
+			},
+			probes: []probe{domainProbe, counterProbe},
+		},
+		{
+			name:       "blocked on the message reservation",
+			preReserve: true,
+			block: func(_, _, _ string, _ time.Time) (string, []any) {
+				return `SELECT 1 FROM sending_ramp_reservations WHERE message_id = $1 FOR UPDATE`, nil
+			},
+			probes: []probe{domainProbe, func() probe { p := scopeProbe; p.held = true; return p }(), counterProbe},
+		},
+	} {
+		t.Run(phase.name, func(t *testing.T) {
+			f := newFixture(t)
+			g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+				p.BudgetMode = sendingpolicy.ModeEnforce
+				p.DefaultAccountDailyRecipients = 1000
+				p.AllCustomerGlobalDailyRecipients = 1000
+				p.ProbationGlobalDailyRecipients = 1000
+			}))
+			user := f.user("standard")
+			agent, domain := f.customDomainAgent(user)
+			scope := registrable(t, domain)
+			day := f.ledgerToday()
+
+			// One completed send so every key in the order exists and can be
+			// probed rather than trivially returning no rows.
+			if d := f.send(g, f.message(agent, "own_address", 1)); !d.Allow {
+				t.Fatalf("priming send: %q", d.Reason)
+			}
+
+			messageID := f.message(agent, "own_address", 1)
+			if phase.preReserve {
+				f.legacyRampReserve(user, domain, messageID, 1, day)
+			}
+			_, ref := f.prepareMessage(g, messageID)
+			_, attempt, err := g.Reserve(f.ctx, ref)
+			if err != nil {
+				t.Fatalf("reserve: %v", err)
+			}
+
+			blockerConn, err := f.pool.Acquire(f.ctx)
+			if err != nil {
+				t.Fatalf("acquire blocker connection: %v", err)
+			}
+			defer blockerConn.Release()
+			blocker, err := blockerConn.Begin(f.ctx)
+			if err != nil {
+				t.Fatalf("begin blocker: %v", err)
+			}
+			defer func() { _ = blocker.Rollback(f.ctx) }()
+			query, args := phase.block(user, domain, scope, day)
+			if args == nil {
+				args = []any{messageID}
+			}
+			if _, err := blocker.Exec(f.ctx, query, args...); err != nil {
+				t.Fatalf("hold the blocking key: %v", err)
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				_, _, err := g.ConsumeAttempt(f.ctx, attempt)
+				done <- err
+			}()
+			waitForLockWaiter(t, f)
+
+			for _, p := range phase.probes {
+				err := probeRowLock(t, f, p.query, p.args(user, domain, scope, day))
+				switch {
+				case p.held && err == nil:
+					t.Errorf("%s is free, but it comes BEFORE the blocking key and must already be held", p.name)
+				case !p.held && err != nil:
+					t.Errorf("%s is already held, but it comes AFTER the blocking key: %v", p.name, err)
+				}
+			}
+
+			if err := blocker.Rollback(f.ctx); err != nil {
+				t.Fatalf("release the blocking key: %v", err)
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("authorization failed once the key was released: %v", err)
+				}
+			case <-time.After(30 * time.Second):
+				t.Fatal("authorization never completed after the blocking key was released")
+			}
+		})
+	}
+}
+
+// waitForLockWaiter blocks until some backend on this database is waiting on a
+// row lock, which is how the test knows the authorization has reached — and
+// stopped at — the parked key rather than racing past it.
+func waitForLockWaiter(t *testing.T, f *fixture) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var waiting int
+		if err := f.pool.QueryRow(f.ctx, `
+			SELECT count(*) FROM pg_stat_activity
+			 WHERE datname = current_database() AND wait_event_type = 'Lock'`).Scan(&waiting); err != nil {
+			t.Fatalf("read lock waiters: %v", err)
+		}
+		if waiting > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("the authorization never blocked on the parked key")
+}
+
+// probeRowLock reports whether a row lock is currently held by someone else,
+// without ever waiting for it. Its own transaction is always rolled back, so
+// the probe cannot become the next blocker.
+func probeRowLock(t *testing.T, f *fixture, query string, args []any) error {
+	t.Helper()
+	conn, err := f.pool.Acquire(f.ctx)
+	if err != nil {
+		t.Fatalf("acquire probe connection: %v", err)
+	}
+	defer conn.Release()
+	tx, err := conn.Begin(f.ctx)
+	if err != nil {
+		t.Fatalf("begin probe: %v", err)
+	}
+	defer func() { _ = tx.Rollback(f.ctx) }()
+	_, err = tx.Exec(f.ctx, query, args...)
+	return err
 }

--- a/internal/sendingpolicy/ramp_integration_test.go
+++ b/internal/sendingpolicy/ramp_integration_test.go
@@ -1,0 +1,619 @@
+package sendingpolicy_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/sendingpolicy"
+	"github.com/tokencanopy/e2a/internal/sendramp"
+	"golang.org/x/net/publicsuffix"
+)
+
+// registrable mirrors the ramp ledger's own key derivation. The ledger is keyed
+// by registrable domain, not hostname, so a test that asserts against the
+// hostname silently reads an empty row and passes for the wrong reason.
+//
+// It also constrains the fixtures: `ramp-1.example.test` and
+// `ramp-2.example.test` share the registrable domain `example.test`, so every
+// fixture built that way would share one scope. Each fixture domain is
+// therefore its own eTLD+1 (`ramp-N.test`) unless a test is specifically about
+// sharing.
+func registrable(t *testing.T, domain string) string {
+	t.Helper()
+	d, err := publicsuffix.EffectiveTLDPlusOne(domain)
+	if err != nil {
+		t.Fatalf("registrable domain for %q: %v", domain, err)
+	}
+	return d
+}
+
+// These tests cover the composition of two independent ledgers. The budget asks
+// whether the account and the platform have exposed SES enough today; the ramp
+// asks whether this particular domain has earned this volume yet. Both apply,
+// and the tests below are mostly about which one wins and what happens to the
+// other one's units when it loses.
+
+// rampPolicy returns a policy with the ramp armed at the hosted generation-zero
+// schedule (150 → 2000 over 30 days) and budgets wide enough not to interfere.
+func rampPolicy(mutate func(*sendingpolicy.RuntimePolicy)) sendingpolicy.RuntimePolicy {
+	p := sendingpolicy.DisabledPolicy()
+	p.RampEnabled = true
+	p.RampStartDaily = 150
+	p.RampTargetDaily = 2000
+	p.RampDays = 30
+	if mutate != nil {
+		mutate(&p)
+	}
+	return p
+}
+
+var rampSeq int
+
+// customDomainAgent creates a user with a verified custom domain and an agent
+// on it, which is the only shape the ramp governs.
+func (f *fixture) customDomainAgent(userID string) (agentID, domain string) {
+	f.t.Helper()
+	rampSeq++
+	// Its own registrable domain, so one fixture's ramp cannot advance another's.
+	domain = fmt.Sprintf("ramp-%d.test", rampSeq)
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO domains (domain, user_id, verified, verified_at, sending_status, sending_ramp_status)
+		VALUES ($1, $2, true, now(), 'verified', 'inactive')`, domain, userID,
+	); err != nil {
+		f.t.Fatalf("insert domain: %v", err)
+	}
+	agentID = fmt.Sprintf("agt_ramp_%d", rampSeq)
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO agent_identities (id, user_id, registered_domain, name) VALUES ($1, $2, $3, $4)`,
+		agentID, userID, domain, agentID,
+	); err != nil {
+		f.t.Fatalf("insert agent: %v", err)
+	}
+	return agentID, domain
+}
+
+// rampScope reads the account/registrable-domain scope's progress.
+func (f *fixture) rampScope(userID, domain string) (status string, activeDays int, found bool) {
+	f.t.Helper()
+	err := f.pool.QueryRow(f.ctx,
+		`SELECT status, active_days FROM sending_ramp_scopes WHERE user_id = $1 AND domain = $2`,
+		userID, registrable(f.t, domain),
+	).Scan(&status, &activeDays)
+	if err != nil {
+		return "", 0, false
+	}
+	return status, activeDays, true
+}
+
+func (f *fixture) domainCounter(userID, domain string) (reserved, confirmed, limit int) {
+	f.t.Helper()
+	err := f.pool.QueryRow(f.ctx, `
+		SELECT COALESCE(SUM(reserved_count), 0), COALESCE(SUM(confirmed_count), 0), COALESCE(MAX(daily_limit), 0)
+		  FROM domain_send_counters WHERE user_id = $1 AND domain = $2`, userID, registrable(f.t, domain),
+	).Scan(&reserved, &confirmed, &limit)
+	if err != nil {
+		f.t.Fatalf("read domain counter: %v", err)
+	}
+	return reserved, confirmed, limit
+}
+
+// --- Schedule progression ------------------------------------------------
+
+// TestRampStageCapsAndQualificationThresholds pins the numbers the rollout
+// record approves: a new custom domain starts at 150 recipients/day and reaches
+// 2,000 over 30 qualified days, qualifying each stage at half its allowance.
+//
+// These are the hosted values. The OSS/self-host default deliberately starts at
+// 50, so this asserts the schedule arithmetic against the hosted schedule
+// rather than against whatever `DefaultSchedule` happens to be.
+func TestRampStageCapsAndQualificationThresholds(t *testing.T) {
+	schedule := sendramp.NewSchedule(150, 2000, 30)
+	for _, tc := range []struct {
+		activeDay int
+		cap       int
+		qualifyAt int
+	}{
+		{0, 150, 75},
+		{1, 213, 107},
+		{2, 277, 139},
+		{29, 2000, 1000},
+	} {
+		got := schedule.CapForActiveDay(tc.activeDay)
+		if got != tc.cap {
+			t.Errorf("active day %d cap = %d, want %d", tc.activeDay, got, tc.cap)
+		}
+		if !sendramp.Qualifies(tc.qualifyAt, got) {
+			t.Errorf("active day %d: %d accepted must qualify against %d", tc.activeDay, tc.qualifyAt, got)
+		}
+		if sendramp.Qualifies(tc.qualifyAt-1, got) {
+			t.Errorf("active day %d: %d accepted must NOT qualify against %d", tc.activeDay, tc.qualifyAt-1, got)
+		}
+	}
+}
+
+// --- Probation classification --------------------------------------------
+
+// TestProbationClassification is the rule that decides whether an operation
+// draws on the shared probation pool, which is the pool that bounds Sybil
+// growth. Getting it wrong in the permissive direction is how "more accounts"
+// starts multiplying allowance again.
+func TestProbationClassification(t *testing.T) {
+	for name, tc := range map[string]struct {
+		setup     func(f *fixture, userID, domain string)
+		probation bool
+	}{
+		"inactive domain": {
+			setup:     func(*fixture, string, string) {},
+			probation: true,
+		},
+		"ramping, day zero": {
+			setup: func(f *fixture, userID, domain string) {
+				f.armScope(userID, domain, 0)
+			},
+			probation: true,
+		},
+		"ramping, one qualified day": {
+			setup: func(f *fixture, userID, domain string) {
+				f.armScope(userID, domain, 1)
+			},
+			probation: false,
+		},
+		"legacy exempt": {
+			setup: func(f *fixture, _, domain string) {
+				f.setDomainRampStatus(domain, sendramp.StatusExempt)
+			},
+			probation: false,
+		},
+		"completed ramp": {
+			setup: func(f *fixture, _, domain string) {
+				f.setDomainRampStatus(domain, sendramp.StatusComplete)
+			},
+			probation: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t)
+			policy := rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+				p.BudgetMode = sendingpolicy.ModeEnforce
+				// A probation pool of exactly one unit turns the
+				// classification into an observable allow/deny.
+				p.ProbationGlobalDailyRecipients = 1
+				p.DefaultAccountDailyRecipients = 100
+				p.AllCustomerGlobalDailyRecipients = 100
+			})
+			g := f.gate(policy)
+			user := f.user("standard")
+			agent, domain := f.customDomainAgent(user)
+			tc.setup(f, user, domain)
+
+			// Burn the single probation unit with unrelated shared traffic,
+			// which is probationary by definition.
+			other := f.agent(f.user("standard"))
+			if d := f.send(g, f.message(other, "relay", 1)); !d.Allow {
+				t.Fatalf("priming shared send: %q", d.Reason)
+			}
+
+			d := f.send(g, f.message(agent, "own_address", 1))
+			if tc.probation && d.Allow {
+				t.Fatal("a probationary domain must be bounded by the exhausted probation pool")
+			}
+			if !tc.probation && !d.Allow {
+				t.Fatalf("an established domain must not draw on the probation pool (held: %q)", d.Reason)
+			}
+		})
+	}
+}
+
+// armScope creates the registrable-domain scope at a given qualified-day count.
+func (f *fixture) armScope(userID, domain string, activeDays int) {
+	f.t.Helper()
+	f.setDomainRampStatus(domain, sendramp.StatusRamping)
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO sending_ramp_scopes (user_id, domain, start_daily, target_daily, ramp_days, active_days)
+		VALUES ($1, $2, 150, 2000, 30, $3)
+		ON CONFLICT (user_id, domain) DO UPDATE SET active_days = EXCLUDED.active_days`,
+		userID, registrable(f.t, domain), activeDays,
+	); err != nil {
+		f.t.Fatalf("arm ramp scope: %v", err)
+	}
+}
+
+func (f *fixture) setDomainRampStatus(domain, status string) {
+	f.t.Helper()
+	if _, err := f.pool.Exec(f.ctx,
+		`UPDATE domains SET sending_ramp_status = $2 WHERE domain = $1`, domain, status,
+	); err != nil {
+		f.t.Fatalf("set ramp status: %v", err)
+	}
+}
+
+// TestSharedTrafficNeverGraduates proves the one asymmetry that makes the whole
+// scheme hold: shared-relay mail is probationary at every plan level and cannot
+// age or pay its way out. The only exit is a customer-controlled domain.
+func TestSharedTrafficNeverGraduates(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.ProbationGlobalDailyRecipients = 1
+		p.DefaultAccountDailyRecipients = 100
+		p.SharedDomainAccountDailyRecip = 100
+		p.AllCustomerGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	f.plan(user, "scale")
+	// Even with a fully established custom domain on the same account, the
+	// account's SHARED traffic stays probationary.
+	_, domain := f.customDomainAgent(user)
+	f.armScope(user, domain, 5)
+
+	relayAgent := f.agent(user)
+	if d := f.send(g, f.message(relayAgent, "relay", 1)); !d.Allow {
+		t.Fatalf("first shared unit: %q", d.Reason)
+	}
+	if d := f.send(g, f.message(relayAgent, "relay", 1)); d.Allow {
+		t.Fatal("shared traffic must remain bounded by the probation pool regardless of plan or sibling domains")
+	}
+}
+
+// --- Composition ----------------------------------------------------------
+
+// TestRampHoldReturnsTheBudgetUnits is the most-restrictive-wins case that
+// matters for correctness.
+//
+// The budget is decided first and the ramp last, so a ramp hold arrives with
+// budget units already taken. Keeping them would charge an account for a send
+// its own domain was not allowed to make, and that charge would persist until
+// midnight.
+func TestRampHoldReturnsTheBudgetUnits(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.RampStartDaily = 150
+		p.DefaultAccountDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+		p.ProbationGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	f.plan(user, "scale")
+	agent, domain := f.customDomainAgent(user)
+
+	// Fill the first ramp stage exactly.
+	if d := f.send(g, f.message(agent, "own_address", 150)); !d.Allow {
+		t.Fatalf("first stage must fit: %q", d.Reason)
+	}
+	if reserved, _, limit := f.domainCounter(user, domain); reserved != 150 || limit != 150 {
+		t.Fatalf("domain counter reserved=%d limit=%d, want 150/150", reserved, limit)
+	}
+	budgetBefore, _ := f.counter(sendingpolicy.ScopeAccountDaily, user)
+
+	d := f.send(g, f.message(agent, "own_address", 1))
+	if d.Allow {
+		t.Fatal("the 151st recipient must be held by the ramp")
+	}
+	if d.Reason != sendingpolicy.ReasonRampCapacity {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonRampCapacity)
+	}
+
+	budgetAfter, _ := f.counter(sendingpolicy.ScopeAccountDaily, user)
+	if budgetAfter != budgetBefore {
+		t.Errorf("a ramp hold left %d extra budget units charged (was %d)", budgetAfter-budgetBefore, budgetBefore)
+	}
+}
+
+// TestBudgetHoldLeavesTheRampUntouched is the mirror. The budget is decided
+// first, so a budget hold must never have reached the ramp at all — otherwise a
+// message held for the platform's reasons would silently consume the customer
+// domain's daily allowance.
+func TestBudgetHoldLeavesTheRampUntouched(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.DefaultAccountDailyRecipients = 2
+		p.AllCustomerGlobalDailyRecipients = 100
+	}))
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+
+	if d := f.send(g, f.message(agent, "own_address", 2)); !d.Allow {
+		t.Fatalf("first send: %q", d.Reason)
+	}
+	reservedBefore, _, _ := f.domainCounter(user, domain)
+
+	d := f.send(g, f.message(agent, "own_address", 1))
+	if d.Allow {
+		t.Fatal("the third recipient must be held by the account budget")
+	}
+	if d.Reason != sendingpolicy.ReasonAccountDailyBudget {
+		t.Errorf("reason = %q, want the account budget", d.Reason)
+	}
+	reservedAfter, _, _ := f.domainCounter(user, domain)
+	if reservedAfter != reservedBefore {
+		t.Errorf("a budget hold consumed %d ramp units", reservedAfter-reservedBefore)
+	}
+}
+
+// TestSettlementIsTheOnlyThingThatAdvancesTheRamp proves progress measures
+// delivered volume, not attempts. Without this, a domain could age into full
+// allowance by failing repeatedly.
+func TestSettlementIsTheOnlyThingThatAdvancesTheRamp(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.RampStartDaily = 150
+		p.DefaultAccountDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+
+	// 75 recipients is exactly the first stage's qualification bar.
+	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 75))
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+
+	// Authorized but unsettled: the day has not qualified.
+	if _, days, ok := f.rampScope(user, domain); !ok || days != 0 {
+		t.Fatalf("active days before settlement = %d (found=%v), want 0", days, ok)
+	}
+
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: attempt, Outcome: sendingpolicy.SettlementProviderAccepted,
+	}); err != nil {
+		t.Fatalf("settle accepted: %v", err)
+	}
+	if _, days, _ := f.rampScope(user, domain); days != 1 {
+		t.Fatalf("active days after acceptance = %d, want 1", days)
+	}
+
+	// Settlement is idempotent — both the synchronous success branch and the
+	// delayed delivery-feedback finalizer call it for the same attempt.
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: attempt, Outcome: sendingpolicy.SettlementProviderAccepted,
+	}); err != nil {
+		t.Fatalf("repeat settle: %v", err)
+	}
+	if _, days, _ := f.rampScope(user, domain); days != 1 {
+		t.Fatalf("active days after a repeated settlement = %d, want 1", days)
+	}
+}
+
+// TestPermanentRejectionReleasesRampCapacity proves a definitively refused
+// message gives its ramp units back, while an unsettled one does not: a message
+// that might have been delivered must not release capacity.
+func TestPermanentRejectionReleasesRampCapacity(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.DefaultAccountDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+
+	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 10))
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 10 {
+		t.Fatalf("ramp reserved = %d, want 10", reserved)
+	}
+
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: attempt, Outcome: sendingpolicy.SettlementProviderPermanentlyRejected,
+	}); err != nil {
+		t.Fatalf("settle rejected: %v", err)
+	}
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 0 {
+		t.Errorf("ramp reserved = %d after a permanent rejection, want 0", reserved)
+	}
+	if _, days, _ := f.rampScope(user, domain); days != 0 {
+		t.Errorf("a rejected message advanced the ramp to day %d", days)
+	}
+}
+
+// TestDeferRetainsTheRampWhileCancelReleasesIt is the difference between "slow
+// down" and "never mind".
+//
+// A rate deferral has not been rejected by anyone, so releasing its ramp claim
+// would let the same message re-qualify a stage it already qualified. A
+// suppression match is terminal and gives both ledgers back.
+func TestDeferRetainsTheRampWhileCancelReleasesIt(t *testing.T) {
+	for name, tc := range map[string]struct {
+		release   func(*fixture, sendingpolicy.Gate, sendingpolicy.AttemptRef) error
+		rampAfter int
+	}{
+		"defer keeps the ramp": {
+			release: func(f *fixture, g sendingpolicy.Gate, a sendingpolicy.AttemptRef) error {
+				return g.DeferAttempt(f.ctx, a)
+			},
+			rampAfter: 7,
+		},
+		"cancel releases the ramp": {
+			release: func(f *fixture, g sendingpolicy.Gate, a sendingpolicy.AttemptRef) error {
+				return g.CancelAttempt(f.ctx, a)
+			},
+			rampAfter: 0,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t)
+			g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+				p.BudgetMode = sendingpolicy.ModeEnforce
+				p.DefaultAccountDailyRecipients = 1000
+				p.AllCustomerGlobalDailyRecipients = 1000
+				p.ProbationGlobalDailyRecipients = 1000
+			}))
+			user := f.user("standard")
+			agent, domain := f.customDomainAgent(user)
+
+			_, ref := f.prepareMessage(g, f.message(agent, "own_address", 7))
+			_, attempt, err := g.Reserve(f.ctx, ref)
+			if err != nil {
+				t.Fatalf("reserve: %v", err)
+			}
+			// The ramp reservation is created at final authorization, so drive
+			// one and then step back to a pre-provider state.
+			if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+				t.Fatalf("authorize: auth=%v err=%v", auth, err)
+			}
+			if reserved, _, _ := f.domainCounter(user, domain); reserved != 7 {
+				t.Fatalf("ramp reserved = %d, want 7", reserved)
+			}
+
+			// Re-arm a fresh pre-provider ordinal, which is what a worker that
+			// hits its rate limiter or a suppression actually holds.
+			_, next, err := g.Reserve(f.ctx, ref)
+			if err != nil {
+				t.Fatalf("second reserve: %v", err)
+			}
+			if err := tc.release(f, g, next); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if reserved, _, _ := f.domainCounter(user, domain); reserved != tc.rampAfter {
+				t.Errorf("ramp reserved = %d after %s, want %d", reserved, name, tc.rampAfter)
+			}
+		})
+	}
+}
+
+// TestDisabledRampIsPassThroughAndWritesNoExemption proves the production state
+// this slice ships in.
+//
+// Pass-through has to mean pass-through: writing `exempt` while the ramp is off
+// would permanently grandfather every domain that happened to send during the
+// disabled window, and the phase-3 activation would then find nothing left to
+// ramp.
+func TestDisabledRampIsPassThroughAndWritesNoExemption(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy()) // ramp_enabled: false
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+
+	if d := f.send(g, f.message(agent, "own_address", 500)); !d.Allow {
+		t.Fatalf("a disabled ramp must pass through: %q", d.Reason)
+	}
+
+	var status string
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT sending_ramp_status FROM domains WHERE domain = $1`, domain,
+	).Scan(&status); err != nil {
+		t.Fatalf("read ramp status: %v", err)
+	}
+	if status != sendramp.StatusInactive {
+		t.Errorf("ramp status = %q, want it left inactive", status)
+	}
+	if _, _, found := f.rampScope(user, domain); found {
+		t.Error("a disabled ramp created a scope row")
+	}
+	if reserved, _, _ := f.domainCounter(user, domain); reserved != 0 {
+		t.Errorf("a disabled ramp reserved %d units", reserved)
+	}
+}
+
+// TestRampSharesOneScopeAcrossAnAccountsSubdomains proves the ledger is keyed by
+// registrable domain, not by hostname — otherwise a customer could mint fresh
+// 150-recipient allowances by inventing subdomains.
+func TestRampSharesOneScopeAcrossAnAccountsSubdomains(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.RampStartDaily = 150
+		p.DefaultAccountDailyRecipients = 1000
+		p.AllCustomerGlobalDailyRecipients = 1000
+		p.ProbationGlobalDailyRecipients = 1000
+	}))
+	user := f.user("standard")
+	f.plan(user, "scale")
+
+	// Two hostnames under one registrable domain.
+	rampSeq++
+	// One registrable domain, two hostnames under it.
+	base := fmt.Sprintf("shared-%d.test", rampSeq)
+	agents := make([]string, 2)
+	for i, host := range []string{"a." + base, "b." + base} {
+		if _, err := f.pool.Exec(f.ctx, `
+			INSERT INTO domains (domain, user_id, verified, verified_at, sending_status, sending_ramp_status)
+			VALUES ($1, $2, true, now(), 'verified', 'inactive')`, host, user,
+		); err != nil {
+			t.Fatalf("insert domain %s: %v", host, err)
+		}
+		agents[i] = fmt.Sprintf("agt_sub_%d_%d", rampSeq, i)
+		if _, err := f.pool.Exec(f.ctx,
+			`INSERT INTO agent_identities (id, user_id, registered_domain, name) VALUES ($1, $2, $3, $4)`,
+			agents[i], user, host, agents[i],
+		); err != nil {
+			t.Fatalf("insert agent: %v", err)
+		}
+	}
+
+	if d := f.send(g, f.message(agents[0], "own_address", 150)); !d.Allow {
+		t.Fatalf("first subdomain must fill the stage: %q", d.Reason)
+	}
+	d := f.send(g, f.message(agents[1], "own_address", 1))
+	if d.Allow {
+		t.Fatal("a sibling subdomain must not find a fresh ramp allowance")
+	}
+	if d.Reason != sendingpolicy.ReasonRampCapacity {
+		t.Errorf("reason = %q, want %q", d.Reason, sendingpolicy.ReasonRampCapacity)
+	}
+}
+
+// TestFreePlanCanQualifyStageOneButNotStageTwo is the interaction the design
+// calls out explicitly: a Free account's 100/day ceiling lets it clear the
+// 75-recipient stage-one bar but not the 107-recipient stage-two bar, and the
+// progress it already made survives the upgrade rather than resetting.
+func TestFreePlanCanQualifyStageOneButNotStageTwo(t *testing.T) {
+	f := newFixture(t)
+	policy := rampPolicy(func(p *sendingpolicy.RuntimePolicy) {
+		p.BudgetMode = sendingpolicy.ModeEnforce
+		p.DefaultAccountDailyRecipients = 100
+		p.AllCustomerGlobalDailyRecipients = 5000
+		p.ProbationGlobalDailyRecipients = 5000
+	})
+	g := f.gate(policy)
+	user := f.user("standard")
+	agent, domain := f.customDomainAgent(user)
+
+	// Stage one qualifies at 75, inside the Free ceiling of 100.
+	_, ref := f.prepareMessage(g, f.message(agent, "own_address", 75))
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, auth, err := g.ConsumeAttempt(f.ctx, attempt); err != nil || auth == nil {
+		t.Fatalf("authorize: auth=%v err=%v", auth, err)
+	}
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{
+		Attempt: attempt, Outcome: sendingpolicy.SettlementProviderAccepted,
+	}); err != nil {
+		t.Fatalf("settle: %v", err)
+	}
+	if _, days, _ := f.rampScope(user, domain); days != 1 {
+		t.Fatalf("stage one did not qualify (active days = %d)", days)
+	}
+
+	// Stage two needs 107 accepted recipients in one day, which the Free
+	// ceiling forbids. The account is stuck at day one — but not reset.
+	if d := f.send(g, f.message(agent, "own_address", 25)); !d.Allow {
+		t.Fatalf("the rest of the Free allowance must still send: %q", d.Reason)
+	}
+	if d := f.send(g, f.message(agent, "own_address", 1)); d.Allow {
+		t.Fatal("a Free account must stop at its own daily ceiling")
+	}
+	if _, days, _ := f.rampScope(user, domain); days != 1 {
+		t.Errorf("active days = %d, want progress retained at 1", days)
+	}
+
+	// After an upgrade, progression resumes from where it stopped.
+	f.plan(user, "scale")
+	if _, days, _ := f.rampScope(user, domain); days != 1 {
+		t.Errorf("an upgrade reset ramp progress to %d", days)
+	}
+}

--- a/internal/sendingpolicy/types.go
+++ b/internal/sendingpolicy/types.go
@@ -195,6 +195,15 @@ const (
 	// the immutable class its operation was derived from, so the operation no
 	// longer describes the send.
 	ReasonClassChanged = "reputation_class_changed"
+	// ReasonSendingIdentityUnverified means the domain this message would send
+	// as no longer has a verified sending identity, so the ramp has no proven
+	// scope to charge and the send waits for the customer to finish verifying.
+	ReasonSendingIdentityUnverified = "sending_identity_unverified"
+	// ReasonRampUnavailable means the ramp ledger permanently refused this
+	// message — a domain that changed hands, a reservation already settled, a
+	// stored schedule that no longer validates. No retry of this operation can
+	// change the answer.
+	ReasonRampUnavailable = "sending_ramp_unavailable"
 )
 
 // Decision is allow-or-hold. A hold carries the earliest time a retry could

--- a/internal/sendramp/store.go
+++ b/internal/sendramp/store.go
@@ -111,20 +111,34 @@ func (s *Store) Snapshot(ctx context.Context, userID, domain string, now time.Ti
 	return snap, err
 }
 
+// Reserve is the pool-owning wrapper. The logic lives in ReserveTx so the
+// sending-protection gate can compose the ramp into its own transaction
+// without a second implementation drifting from this one.
 func (s *Store) Reserve(ctx context.Context, req ReserveRequest) (Decision, error) {
-	if req.MessageID == "" || req.UserID == "" || req.Domain == "" || req.Units < 1 {
-		return Decision{}, permanentf("sendramp: invalid reservation request")
-	}
-	day := utcDay(req.Day)
-	schedule := NewSchedule(req.Schedule.StartDaily, req.Schedule.TargetDaily, req.Schedule.RampDays)
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return Decision{}, err
 	}
 	defer tx.Rollback(ctx)
+	d, err := ReserveTx(ctx, tx, req)
+	if err != nil {
+		return Decision{}, err
+	}
+	return commitDecision(ctx, tx, d)
+}
+
+// ReserveTx acquires ramp capacity for one message inside a caller's
+// transaction, in the normative suborder: domain identity, registrable-domain
+// scope, message reservation, UTC day counter.
+func ReserveTx(ctx context.Context, tx pgx.Tx, req ReserveRequest) (Decision, error) {
+	if req.MessageID == "" || req.UserID == "" || req.Domain == "" || req.Units < 1 {
+		return Decision{}, permanentf("sendramp: invalid reservation request")
+	}
+	day := utcDay(req.Day)
+	schedule := NewSchedule(req.Schedule.StartDaily, req.Schedule.TargetDaily, req.Schedule.RampDays)
 
 	var owner, sendingStatus, domainStatus string
-	err = tx.QueryRow(ctx, `SELECT COALESCE(user_id,''), sending_status, sending_ramp_status FROM domains WHERE domain=$1 FOR UPDATE`, req.Domain).Scan(&owner, &sendingStatus, &domainStatus)
+	err := tx.QueryRow(ctx, `SELECT COALESCE(user_id,''), sending_status, sending_ramp_status FROM domains WHERE domain=$1 FOR UPDATE`, req.Domain).Scan(&owner, &sendingStatus, &domainStatus)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Decision{}, permanentf("sendramp: domain not found")
 	}
@@ -135,7 +149,7 @@ func (s *Store) Reserve(ctx context.Context, req ReserveRequest) (Decision, erro
 		return Decision{}, permanentf("sendramp: domain owner mismatch")
 	}
 	if domainStatus == StatusExempt || domainStatus == StatusComplete || sendingStatus != "verified" {
-		return commitDecision(ctx, tx, Decision{Allowed: true, Status: domainStatus})
+		return decisionOnly(Decision{Allowed: true, Status: domainStatus})
 	}
 
 	scope := registrableDomain(req.Domain)
@@ -161,7 +175,7 @@ func (s *Store) Reserve(ctx context.Context, req ReserveRequest) (Decision, erro
 		if _, err := tx.Exec(ctx, `UPDATE domains SET sending_ramp_status='complete' WHERE domain=$1`, req.Domain); err != nil {
 			return Decision{}, err
 		}
-		return commitDecision(ctx, tx, Decision{Allowed: true, Status: StatusComplete})
+		return decisionOnly(Decision{Allowed: true, Status: StatusComplete})
 	}
 	if activeDays >= schedule.RampDays && lastQualifiedDay != nil && utcDay(*lastQualifiedDay).Before(day) {
 		if _, err := tx.Exec(ctx, `UPDATE sending_ramp_scopes SET status='complete',completed_at=now() WHERE user_id=$1 AND domain=$2`, req.UserID, scope); err != nil {
@@ -170,7 +184,7 @@ func (s *Store) Reserve(ctx context.Context, req ReserveRequest) (Decision, erro
 		if _, err := tx.Exec(ctx, `UPDATE domains SET sending_ramp_status='complete' WHERE user_id=$1 AND domain=$2`, req.UserID, req.Domain); err != nil {
 			return Decision{}, err
 		}
-		return commitDecision(ctx, tx, Decision{Allowed: true, Status: StatusComplete})
+		return decisionOnly(Decision{Allowed: true, Status: StatusComplete})
 	}
 
 	var priorDay time.Time
@@ -179,7 +193,7 @@ func (s *Store) Reserve(ctx context.Context, req ReserveRequest) (Decision, erro
 	err = tx.QueryRow(ctx, `SELECT day,units,state FROM sending_ramp_reservations WHERE message_id=$1 FOR UPDATE`, req.MessageID).Scan(&priorDay, &priorUnits, &priorState)
 	if err == nil {
 		if priorState == "confirmed" {
-			return commitDecision(ctx, tx, Decision{Allowed: true, Status: StatusRamping})
+			return decisionOnly(Decision{Allowed: true, Status: StatusRamping})
 		}
 		if priorState == "released" {
 			return Decision{}, permanentf("sendramp: reservation already released")
@@ -192,7 +206,7 @@ func (s *Store) Reserve(ctx context.Context, req ReserveRequest) (Decision, erro
 			if err := tx.QueryRow(ctx, `SELECT reserved_count,daily_limit FROM domain_send_counters WHERE user_id=$1 AND domain=$2 AND day=$3`, req.UserID, scope, day).Scan(&used, &limit); err != nil {
 				return Decision{}, err
 			}
-			return commitDecision(ctx, tx, Decision{Allowed: true, Status: StatusRamping, DailyLimit: limit, UsedToday: used})
+			return decisionOnly(Decision{Allowed: true, Status: StatusRamping, DailyLimit: limit, UsedToday: used})
 		}
 		if _, err := tx.Exec(ctx, `UPDATE domain_send_counters SET reserved_count=reserved_count-$4 WHERE user_id=$1 AND domain=$2 AND day=$3 AND reserved_count >= $4`, req.UserID, scope, utcDay(priorDay), priorUnits); err != nil {
 			return Decision{}, err
@@ -219,7 +233,7 @@ func (s *Store) Reserve(ctx context.Context, req ReserveRequest) (Decision, erro
 		} else if err != nil {
 			return Decision{}, err
 		}
-		return commitDecision(ctx, tx, Decision{Allowed: false, Status: StatusRamping, DailyLimit: appliedLimit, UsedToday: used, RetryAt: day.Add(24 * time.Hour)})
+		return decisionOnly(Decision{Allowed: false, Status: StatusRamping, DailyLimit: appliedLimit, UsedToday: used, RetryAt: day.Add(24 * time.Hour)})
 	}
 	if err != nil {
 		return Decision{}, err
@@ -227,92 +241,25 @@ func (s *Store) Reserve(ctx context.Context, req ReserveRequest) (Decision, erro
 	if _, err := tx.Exec(ctx, `INSERT INTO sending_ramp_reservations (message_id,day,user_id,domain,units) VALUES ($1,$2,$3,$4,$5)`, req.MessageID, day, req.UserID, scope, req.Units); err != nil {
 		return Decision{}, err
 	}
-	return commitDecision(ctx, tx, Decision{Allowed: true, Status: StatusRamping, DailyLimit: appliedLimit, UsedToday: used})
+	return decisionOnly(Decision{Allowed: true, Status: StatusRamping, DailyLimit: appliedLimit, UsedToday: used})
 }
 
 func (s *Store) Confirm(ctx context.Context, messageID string) error {
-	if messageID == "" {
-		return permanentf("sendramp: empty message id")
-	}
-	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback(ctx)
-	var day time.Time
-	var userID, domain, state string
-	var units int
-	err = tx.QueryRow(ctx, `SELECT day,user_id,domain,units,state FROM sending_ramp_reservations WHERE message_id=$1 FOR UPDATE`, messageID).Scan(&day, &userID, &domain, &units, &state)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return tx.Commit(ctx)
-	}
-	if err != nil {
-		return err
-	}
-	if state == "confirmed" {
-		return tx.Commit(ctx)
-	}
-	var confirmed, limit int
-	var query string
-	switch state {
-	case "reserved":
-		query = `UPDATE domain_send_counters
-		            SET confirmed_count=confirmed_count+$4
-		          WHERE user_id=$1 AND domain=$2 AND day=$3
-		      RETURNING confirmed_count,daily_limit`
-	case "released":
-		// A locally inferred failure can be corrected by later authoritative
-		// provider feedback. Release returned its units to the daily counter, so
-		// confirming that real send must restore consumed as well as accepted
-		// volume. The reservation row lock makes this transition idempotent.
-		query = `UPDATE domain_send_counters
-		            SET reserved_count=reserved_count+$4,
-		                confirmed_count=confirmed_count+$4
-		          WHERE user_id=$1 AND domain=$2 AND day=$3
-		      RETURNING confirmed_count,daily_limit`
-	default:
-		return permanentf("sendramp: invalid reservation state %q", state)
-	}
-	if err := tx.QueryRow(ctx, query, userID, domain, utcDay(day), units).Scan(&confirmed, &limit); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx, `UPDATE sending_ramp_reservations SET state='confirmed',updated_at=now() WHERE message_id=$1`, messageID); err != nil {
-		return err
-	}
-	if Qualifies(confirmed, limit) {
-		if _, err := tx.Exec(ctx, `UPDATE sending_ramp_scopes SET active_days=active_days+1,last_qualified_day=$3 WHERE user_id=$1 AND domain=$2 AND (last_qualified_day IS NULL OR last_qualified_day < $3)`, userID, domain, utcDay(day)); err != nil {
-			return err
-		}
-	}
-	return tx.Commit(ctx)
+	return s.inTx(ctx, func(tx pgx.Tx) error { return ConfirmTx(ctx, tx, messageID) })
 }
 
 func (s *Store) Release(ctx context.Context, messageID string) error {
-	if messageID == "" {
-		return permanentf("sendramp: empty message id")
-	}
+	return s.inTx(ctx, func(tx pgx.Tx) error { return ReleaseTx(ctx, tx, messageID) })
+}
+
+// inTx runs one of the tx-aware helpers in its own transaction.
+func (s *Store) inTx(ctx context.Context, fn func(pgx.Tx) error) error {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback(ctx)
-	var day time.Time
-	var userID, domain, state string
-	var units int
-	err = tx.QueryRow(ctx, `SELECT day,user_id,domain,units,state FROM sending_ramp_reservations WHERE message_id=$1 FOR UPDATE`, messageID).Scan(&day, &userID, &domain, &units, &state)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return tx.Commit(ctx)
-	}
-	if err != nil {
-		return err
-	}
-	if state != "reserved" {
-		return tx.Commit(ctx)
-	}
-	if _, err := tx.Exec(ctx, `UPDATE domain_send_counters SET reserved_count=reserved_count-$4 WHERE user_id=$1 AND domain=$2 AND day=$3 AND reserved_count >= $4`, userID, domain, utcDay(day), units); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx, `UPDATE sending_ramp_reservations SET state='released',updated_at=now() WHERE message_id=$1`, messageID); err != nil {
+	if err := fn(tx); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)
@@ -345,6 +292,10 @@ func commitDecision(ctx context.Context, tx pgx.Tx, d Decision) (Decision, error
 	}
 	return d, nil
 }
+
+// decisionOnly is the in-transaction counterpart of commitDecision: the caller
+// owns the transaction, so returning is all there is to do.
+func decisionOnly(d Decision) (Decision, error) { return d, nil }
 
 func utcDay(t time.Time) time.Time {
 	if t.IsZero() {

--- a/internal/sendramp/store.go
+++ b/internal/sendramp/store.go
@@ -43,6 +43,14 @@ type Decision struct {
 	DailyLimit int
 	UsedToday  int
 	RetryAt    time.Time
+	// IdentityUnverified reports the one refusal that is not about volume: the
+	// domain has no verified SENDING identity, so there is no proven scope for
+	// the ramp to charge and no daily allowance the caller could wait out. It
+	// rides the decision rather than an error because it is an ordinary answer
+	// about this send, and because the retry advice it deserves differs from a
+	// capacity hold's: what clears it is the customer finishing verification,
+	// not the next UTC midnight.
+	IdentityUnverified bool
 }
 
 type Snapshot struct {
@@ -148,8 +156,31 @@ func ReserveTx(ctx context.Context, tx pgx.Tx, req ReserveRequest) (Decision, er
 	if owner != req.UserID {
 		return Decision{}, permanentf("sendramp: domain owner mismatch")
 	}
-	if domainStatus == StatusExempt || domainStatus == StatusComplete || sendingStatus != "verified" {
+	// The two legacy states mean "this domain already earned its volume", and
+	// they say so about the DOMAIN rather than about today's SES verification
+	// record — a grandfathered or completed sender is not re-throttled because
+	// its identity is being re-verified.
+	if domainStatus == StatusExempt || domainStatus == StatusComplete {
 		return decisionOnly(Decision{Allowed: true, Status: domainStatus})
+	}
+	// Everything else with an unverified sending identity is REFUSED, not
+	// passed through.
+	//
+	// Pass-through looks harmless — no verified identity, no custom-domain
+	// sending, nothing to ramp — but the two facts it joins are read at
+	// different times. A message's composed From and its reputation class are
+	// frozen when it is accepted; the agent's registered domain is not.
+	// Verifying a child subdomain rebinds an account's agents onto it, that
+	// child's SES identity stays unverified while its DKIM records are never
+	// published, and the ramp resolves the registered domain live. An accepted
+	// backlog then goes out under the frozen custom-domain identity with no
+	// daily cap at all, and the same unverified state makes the scope look
+	// established, so it does not even draw on the probation pool on the way
+	// out. Holding is the only answer that is safe in both readings: if the
+	// identity is genuinely gone the mail should not claim it, and if it is
+	// merely mid-verification the customer finishing DNS clears the hold.
+	if sendingStatus != "verified" {
+		return decisionOnly(Decision{Allowed: false, Status: domainStatus, IdentityUnverified: true})
 	}
 
 	scope := registrableDomain(req.Domain)

--- a/internal/sendramp/store_extra_test.go
+++ b/internal/sendramp/store_extra_test.go
@@ -150,7 +150,17 @@ func TestSnapshotReportsCompleteWhenScopeCompleted(t *testing.T) {
 	}
 }
 
-func TestReserveAllowsUnverifiedDomainWithoutAccounting(t *testing.T) {
+// TestReserveHoldsAnUnverifiedDomainWithoutAccounting pins the refusal that
+// replaced the old pass-through.
+//
+// A message's composed From and its reputation class are frozen at acceptance;
+// the agent's registered domain is not. Verifying a child subdomain rebinds an
+// account's agents onto it, that child's SES identity stays unverified while
+// its DKIM records are never published, and this reserve resolves the domain
+// live — so passing through handed an accepted backlog an uncapped day under a
+// frozen custom-domain identity. The refusal must still write NOTHING: an
+// unverified identity has no scope to arm and no counter to charge.
+func TestReserveHoldsAnUnverifiedDomainWithoutAccounting(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := sendramp.NewStore(pool)
 	ids := identity.NewStore(pool)
@@ -176,8 +186,8 @@ func TestReserveAllowsUnverifiedDomainWithoutAccounting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Reserve: %v", err)
 	}
-	if !d.Allowed || d.Status != sendramp.StatusInactive || d.DailyLimit != 0 {
-		t.Fatalf("decision = %+v, want allowed passthrough with inactive status", d)
+	if d.Allowed || !d.IdentityUnverified || d.Status != sendramp.StatusInactive {
+		t.Fatalf("decision = %+v, want a hold flagged as an unverified identity", d)
 	}
 	var counters, reservations int
 	if err := pool.QueryRow(ctx, `SELECT count(*) FROM domain_send_counters WHERE user_id=$1`, user.ID).Scan(&counters); err != nil {
@@ -434,5 +444,75 @@ func TestResolveIgnoresNonTerminalDeliveryStatus(t *testing.T) {
 	}
 	if state != "reserved" {
 		t.Fatalf("state=%q, want reserved (non-terminal outcome must not settle)", state)
+	}
+}
+
+// TestConfirmAfterTheDaysCounterWasReapedIsANoOp covers the one legitimate way
+// a reservation can outlive its own day counter.
+//
+// Maintenance deletes counter rows older than 35 days once nothing `reserved`
+// still points at them, while a reservation gets its own seven-day window from
+// the moment it settles — so a message released long after its send day leaves
+// a released reservation whose counter row is already gone. Late authoritative
+// acceptance still arrives for it, and the restoration it would perform has
+// nothing left to restore: no capacity to give back and no day left to qualify.
+// Reporting that as an error makes the finalizer retry a correction that can
+// never apply.
+func TestConfirmAfterTheDaysCounterWasReapedIsANoOp(t *testing.T) {
+	store, pool, userID, domain, messageID := seedRampMessage(t, "confirm-reaped")
+	ctx := context.Background()
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	if got := reserve(t, store, userID, domain, messageID, 5, day, sendramp.DefaultSchedule); !got.Allowed {
+		t.Fatalf("seed reservation = %+v, want allowed", got)
+	}
+	if err := store.Release(ctx, messageID); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM domain_send_counters WHERE user_id=$1`, userID); err != nil {
+		t.Fatalf("reap the day counter: %v", err)
+	}
+
+	if err := store.Confirm(ctx, messageID); err != nil {
+		t.Fatalf("a correction for a reaped day must be a no-op, not an error: %v", err)
+	}
+}
+
+// TestReleaseRefusesToRecordAGiveBackThatNeverHappened is the mirror of the
+// restoration above.
+//
+// The decrement is deliberately guarded, so it can match nothing — and when it
+// does, no units came back. Writing `released` anyway makes the reservation
+// claim a give-back that never happened, and ConfirmTx's released→confirmed
+// restoration believes it: a later authoritative acceptance adds those units
+// back to a counter that never returned them, minting daily allowance out of an
+// inconsistency.
+func TestReleaseRefusesToRecordAGiveBackThatNeverHappened(t *testing.T) {
+	store, pool, userID, domain, messageID := seedRampMessage(t, "release-short")
+	ctx := context.Background()
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	if got := reserve(t, store, userID, domain, messageID, 10, day, sendramp.DefaultSchedule); !got.Allowed {
+		t.Fatalf("seed reservation = %+v, want allowed", got)
+	}
+	// The counter now holds fewer reserved units than the reservation claims,
+	// which is the only shape in which the guarded decrement matches nothing
+	// while the row is still there.
+	if _, err := pool.Exec(ctx,
+		`UPDATE domain_send_counters SET reserved_count = 4 WHERE user_id=$1`, userID); err != nil {
+		t.Fatalf("short the counter: %v", err)
+	}
+
+	err := store.Release(ctx, messageID)
+	var permanent permanentMarker
+	if !errors.As(err, &permanent) || !permanent.Permanent() {
+		t.Fatalf("Release err = %v, want a permanent error — the counter never returned the units", err)
+	}
+	var state string
+	if err := pool.QueryRow(ctx,
+		`SELECT state FROM sending_ramp_reservations WHERE message_id=$1`, messageID).Scan(&state); err != nil {
+		t.Fatalf("read reservation: %v", err)
+	}
+	if state != "reserved" {
+		t.Errorf("reservation state = %q: it claims a give-back of 10 units the counter never returned, "+
+			"which a later restoration would add back out of nothing", state)
 	}
 }

--- a/internal/sendramp/tx.go
+++ b/internal/sendramp/tx.go
@@ -1,0 +1,263 @@
+package sendramp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// This file is the ramp's single lock order.
+//
+// The store originally used three different ones: Reserve took the domain, then
+// the scope, then the reservation, then the day counter; Confirm took the
+// reservation, then the counter, then the scope; Release took the reservation
+// and the counter. Three orders over four keys is a deadlock waiting for
+// traffic, and it becomes unavoidable the moment the sending-protection gate
+// composes both ledgers into one transaction — that transaction already holds
+// budget counters when it reaches the ramp, so any disagreement here closes a
+// cycle across two subsystems.
+//
+// Every mutation now acquires, in exactly this suborder:
+//
+//	ramp domain identity → registrable-domain scope → message reservation → UTC day counter
+//
+// An operation may SKIP a key it does not need. It may never take one it does
+// need out of order. The exported Store methods are thin wrappers so there is
+// no second implementation to drift.
+
+// probeReservation reads a reservation's owning scope WITHOUT locking, so a
+// caller that only knows a message ID can still take the scope lock first.
+//
+// Reading before locking is safe because the values it recovers — the owning
+// account and registrable domain — are immutable for the life of the row: the
+// reservation is keyed by message, and a message never changes hands. Every
+// value the decision actually rests on is re-read under the lock below.
+func probeReservation(ctx context.Context, tx pgx.Tx, messageID string) (userID, scope string, found bool, err error) {
+	err = tx.QueryRow(ctx,
+		`SELECT user_id, domain FROM sending_ramp_reservations WHERE message_id = $1`, messageID,
+	).Scan(&userID, &scope)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, err
+	}
+	return userID, scope, true, nil
+}
+
+// lockScope takes the registrable-domain scope row, creating nothing.
+func lockScope(ctx context.Context, tx pgx.Tx, userID, scope string) error {
+	var exists bool
+	err := tx.QueryRow(ctx,
+		`SELECT true FROM sending_ramp_scopes WHERE user_id = $1 AND domain = $2 FOR UPDATE`,
+		userID, scope,
+	).Scan(&exists)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	return err
+}
+
+// ConfirmTx records authoritative provider acceptance inside a caller's
+// transaction, in the normative suborder.
+//
+// Confirmation is the only thing that advances the ramp. That is deliberate:
+// progress must measure delivered volume, not attempts, or a domain could age
+// into full allowance by repeatedly failing.
+func ConfirmTx(ctx context.Context, tx pgx.Tx, messageID string) error {
+	if messageID == "" {
+		return permanentf("sendramp: empty message id")
+	}
+	userID, scope, found, err := probeReservation(ctx, tx, messageID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+	// Scope before reservation. Confirmation may advance active_days on this
+	// row, and taking it after the reservation is what made the old Confirm
+	// disagree with Reserve.
+	if err := lockScope(ctx, tx, userID, scope); err != nil {
+		return err
+	}
+
+	var day time.Time
+	var lockedUser, lockedScope, state string
+	var units int
+	err = tx.QueryRow(ctx, `
+		SELECT day, user_id, domain, units, state
+		  FROM sending_ramp_reservations WHERE message_id = $1 FOR UPDATE`, messageID,
+	).Scan(&day, &lockedUser, &lockedScope, &units, &state)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if lockedUser != userID || lockedScope != scope {
+		return permanentf("sendramp: reservation ownership changed under lock")
+	}
+	if state == "confirmed" {
+		return nil
+	}
+
+	var query string
+	switch state {
+	case "reserved":
+		query = `UPDATE domain_send_counters
+		            SET confirmed_count = confirmed_count + $4
+		          WHERE user_id=$1 AND domain=$2 AND day=$3
+		      RETURNING confirmed_count, daily_limit`
+	case "released":
+		// A locally inferred failure can be corrected by later authoritative
+		// provider evidence. Release returned the units to the daily counter,
+		// so confirming that real send must restore consumed as well as
+		// accepted volume. The reservation row lock makes this idempotent.
+		query = `UPDATE domain_send_counters
+		            SET reserved_count = reserved_count + $4,
+		                confirmed_count = confirmed_count + $4
+		          WHERE user_id=$1 AND domain=$2 AND day=$3
+		      RETURNING confirmed_count, daily_limit`
+	default:
+		return permanentf("sendramp: invalid reservation state %q", state)
+	}
+
+	var confirmed, limit int
+	if err := tx.QueryRow(ctx, query, userID, scope, utcDay(day), units).Scan(&confirmed, &limit); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE sending_ramp_reservations SET state='confirmed', updated_at=now() WHERE message_id=$1`,
+		messageID,
+	); err != nil {
+		return err
+	}
+	if Qualifies(confirmed, limit) {
+		if _, err := tx.Exec(ctx, `
+			UPDATE sending_ramp_scopes
+			   SET active_days = active_days + 1, last_qualified_day = $3
+			 WHERE user_id=$1 AND domain=$2
+			   AND (last_qualified_day IS NULL OR last_qualified_day < $3)`,
+			userID, scope, utcDay(day),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReleaseTx returns a still-reserved message's ramp units inside a caller's
+// transaction.
+//
+// It skips the scope key, which it never writes. Skipping is permitted; what is
+// not permitted is taking the reservation before a key that comes earlier, and
+// this takes only the reservation and then the counter — a suffix of the
+// normative order.
+func ReleaseTx(ctx context.Context, tx pgx.Tx, messageID string) error {
+	if messageID == "" {
+		return permanentf("sendramp: empty message id")
+	}
+	var day time.Time
+	var userID, scope, state string
+	var units int
+	err := tx.QueryRow(ctx, `
+		SELECT day, user_id, domain, units, state
+		  FROM sending_ramp_reservations WHERE message_id = $1 FOR UPDATE`, messageID,
+	).Scan(&day, &userID, &scope, &units, &state)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if state != "reserved" {
+		return nil
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE domain_send_counters SET reserved_count = reserved_count - $4
+		 WHERE user_id=$1 AND domain=$2 AND day=$3 AND reserved_count >= $4`,
+		userID, scope, utcDay(day), units,
+	); err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx,
+		`UPDATE sending_ramp_reservations SET state='released', updated_at=now() WHERE message_id=$1`,
+		messageID)
+	return err
+}
+
+// ScopeState is the ramp's answer to "has this domain proved itself yet".
+type ScopeState struct {
+	// Status is the domain's ramp status: inactive, ramping, complete, exempt.
+	Status string
+	// ActiveDays is how many UTC days reached the qualifying accepted volume.
+	ActiveDays int
+	// Established reports whether the scope has left probation.
+	Established bool
+}
+
+// InspectScopeTx classifies a domain without locking or writing anything.
+//
+// The unlocked read is deliberate and safe in the only direction that matters.
+// Ramp progress is monotonic — a scope goes inactive → ramping → qualified →
+// complete and never regresses — so a stale read can only be stale in the
+// STRICT direction, reporting probation for a scope that has just graduated.
+// Charging the probation pool for one extra send is harmless; the reverse
+// would not be, and cannot happen.
+//
+// This matters because the probation classification decides which budget
+// counters a transaction must lock, and the budget counters come BEFORE the
+// ramp keys in the normative order. Something has to be read before the ramp
+// lock is taken, and monotonicity is what makes that sound.
+func InspectScopeTx(ctx context.Context, tx pgx.Tx, userID, domain string) (ScopeState, error) {
+	var state ScopeState
+	err := tx.QueryRow(ctx,
+		`SELECT sending_ramp_status FROM domains WHERE domain = $1 AND user_id = $2`,
+		domain, userID,
+	).Scan(&state.Status)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// No domain row means no customer-controlled identity, so nothing here
+		// has been proven. Probation is the answer.
+		state.Status = StatusInactive
+		return state, nil
+	}
+	if err != nil {
+		return ScopeState{}, err
+	}
+
+	// Legacy exemption and completed ramps are established from the start —
+	// they are the two states that mean "this domain already earned its
+	// volume".
+	if state.Status == StatusExempt || state.Status == StatusComplete {
+		state.Established = true
+		return state, nil
+	}
+
+	var scopeStatus string
+	err = tx.QueryRow(ctx,
+		`SELECT status, active_days FROM sending_ramp_scopes WHERE user_id = $1 AND domain = $2`,
+		userID, registrableDomain(domain),
+	).Scan(&scopeStatus, &state.ActiveDays)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Ramping was stamped on the domain but the scope has not armed yet:
+		// day zero, still probationary.
+		return state, nil
+	}
+	if err != nil {
+		return ScopeState{}, err
+	}
+	if scopeStatus == StatusComplete {
+		state.Status = StatusComplete
+		state.Established = true
+		return state, nil
+	}
+	// One qualified day is the bar. Day zero is the first 150-recipient stage
+	// and has proved nothing yet; from day one the account/registrable-domain
+	// scope is established for classification even though its ramp keeps
+	// enforcing 213, 277, and onward.
+	state.Established = state.ActiveDays >= 1
+	return state, nil
+}

--- a/internal/sendramp/tx.go
+++ b/internal/sendramp/tx.go
@@ -126,7 +126,20 @@ func ConfirmTx(ctx context.Context, tx pgx.Tx, messageID string) error {
 	}
 
 	var confirmed, limit int
-	if err := tx.QueryRow(ctx, query, userID, scope, utcDay(day), units).Scan(&confirmed, &limit); err != nil {
+	err = tx.QueryRow(ctx, query, userID, scope, utcDay(day), units).Scan(&confirmed, &limit)
+	if errors.Is(err, pgx.ErrNoRows) && state == "released" {
+		// The day's counter row is gone. Maintenance deletes counters older
+		// than 35 days whose reservation is no longer `reserved`, and a
+		// reservation released long after its own day outlives its counter by
+		// exactly that window. There is nothing left to restore and nothing
+		// left to qualify, so a late correction for that day is a no-op rather
+		// than an error that would retry forever. The `reserved` branch is
+		// deliberately NOT forgiven the same way: maintenance never reaps a
+		// counter that still has a reserved reservation, so a missing row there
+		// is a real inconsistency.
+		return nil
+	}
+	if err != nil {
 		return err
 	}
 	if _, err := tx.Exec(ctx,
@@ -176,12 +189,39 @@ func ReleaseTx(ctx context.Context, tx pgx.Tx, messageID string) error {
 	if state != "reserved" {
 		return nil
 	}
-	if _, err := tx.Exec(ctx, `
+	tag, err := tx.Exec(ctx, `
 		UPDATE domain_send_counters SET reserved_count = reserved_count - $4
 		 WHERE user_id=$1 AND domain=$2 AND day=$3 AND reserved_count >= $4`,
-		userID, scope, utcDay(day), units,
-	); err != nil {
+		userID, scope, utcDay(day), units)
+	if err != nil {
 		return err
+	}
+	if tag.RowsAffected() == 0 {
+		// The guarded decrement matched nothing, so no units came back — and
+		// the reservation must not claim they did. ConfirmTx's
+		// released→confirmed restoration adds `units` BACK to this counter when
+		// late provider evidence corrects a locally inferred failure, so a
+		// reservation that says "released" without having returned anything
+		// lets that correction mint capacity out of nothing.
+		//
+		// Two shapes reach here and they are not the same. If the counter row
+		// is gone the release is honest — there is nothing to give back and
+		// nothing to restore either, because the restoration targets the same
+		// missing row. If the row is present but holds fewer reserved units
+		// than this reservation claims, the ledger and the reservation already
+		// disagree; papering over that with a state write is what turns one
+		// inconsistency into free capacity, so it fails permanently instead.
+		var exists bool
+		err := tx.QueryRow(ctx,
+			`SELECT true FROM domain_send_counters WHERE user_id=$1 AND domain=$2 AND day=$3`,
+			userID, scope, utcDay(day),
+		).Scan(&exists)
+		switch {
+		case err == nil:
+			return permanentf("sendramp: counter holds fewer than the %d reserved units of message %s", units, messageID)
+		case !errors.Is(err, pgx.ErrNoRows):
+			return err
+		}
 	}
 	_, err = tx.Exec(ctx,
 		`UPDATE sending_ramp_reservations SET state='released', updated_at=now() WHERE message_id=$1`,
@@ -212,12 +252,20 @@ type ScopeState struct {
 // counters a transaction must lock, and the budget counters come BEFORE the
 // ramp keys in the normative order. Something has to be read before the ramp
 // lock is taken, and monotonicity is what makes that sound.
+//
+// The sending identity below is the one input that is NOT monotonic — a domain
+// can lose verification as well as gain it — so a stale read there could report
+// established for an identity that has just gone unverified. That costs nothing
+// this argument needs: ReserveTx re-reads the same column under the domain row
+// lock and refuses the send outright, so the only consequence of the stale
+// classification is which pool the refused attempt briefly charged.
 func InspectScopeTx(ctx context.Context, tx pgx.Tx, userID, domain string) (ScopeState, error) {
 	var state ScopeState
+	var sendingStatus string
 	err := tx.QueryRow(ctx,
-		`SELECT sending_ramp_status FROM domains WHERE domain = $1 AND user_id = $2`,
+		`SELECT sending_ramp_status, sending_status FROM domains WHERE domain = $1 AND user_id = $2`,
 		domain, userID,
-	).Scan(&state.Status)
+	).Scan(&state.Status, &sendingStatus)
 	if errors.Is(err, pgx.ErrNoRows) {
 		// No domain row means no customer-controlled identity, so nothing here
 		// has been proven. Probation is the answer.
@@ -233,6 +281,17 @@ func InspectScopeTx(ctx context.Context, tx pgx.Tx, userID, domain string) (Scop
 	// volume".
 	if state.Status == StatusExempt || state.Status == StatusComplete {
 		state.Established = true
+		return state, nil
+	}
+
+	// Qualified days belong to the scope, but they vouch for the identity that
+	// earned them. A rebind onto a child subdomain whose SES identity was never
+	// verified inherits the parent's progress without inheriting anything that
+	// proved it, so an unverified identity is probationary however old its
+	// scope is. Reserve refuses that send outright; this keeps the class honest
+	// for the early hold, which is decided before the ramp is consulted and is
+	// the only thing bounding the probation pool at that point.
+	if sendingStatus != "verified" {
 		return state, nil
 	}
 

--- a/internal/sendramp/tx_test.go
+++ b/internal/sendramp/tx_test.go
@@ -1,0 +1,173 @@
+package sendramp_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/sendramp"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// InspectScopeTx decides which budget pool a send charges BEFORE the ramp lock
+// is taken, so every branch below is a classification the sending-protection
+// gate relies on without a second check. The tests pin each branch in
+// isolation against the store's own tables rather than through the gate, so a
+// regression here fails in this package instead of surfacing as a mysterious
+// pool charge two packages away.
+
+// inspectDomain seeds one user owning one domain in the given sending and ramp
+// states and returns the classifier's answer for it.
+func inspectDomain(t *testing.T, pool *pgxpool.Pool, suffix, domain, sendingStatus, rampStatus string, seedScope func(userID string)) sendramp.ScopeState {
+	t.Helper()
+	ctx := context.Background()
+	ids := identity.NewStore(pool)
+	user, err := ids.CreateOrGetUser(ctx, "inspect-"+suffix+"@example.com", "Inspect", "inspect-"+suffix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if domain != "" {
+		if _, err := ids.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+			t.Fatalf("ClaimOrCreateDomain: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`UPDATE domains SET sending_status=$2, sending_ramp_status=$3 WHERE domain=$1`,
+			domain, sendingStatus, rampStatus,
+		); err != nil {
+			t.Fatalf("stamp domain state: %v", err)
+		}
+	}
+	if seedScope != nil {
+		seedScope(user.ID)
+	}
+	return inspect(t, pool, user.ID, domain)
+}
+
+func inspect(t *testing.T, pool *pgxpool.Pool, userID, domain string) sendramp.ScopeState {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	state, err := sendramp.InspectScopeTx(ctx, tx, userID, domain)
+	if err != nil {
+		t.Fatalf("InspectScopeTx: %v", err)
+	}
+	return state
+}
+
+func insertScope(t *testing.T, pool *pgxpool.Pool, userID, scope, status string, activeDays int) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO sending_ramp_scopes (user_id,domain,status,active_days,start_daily,target_daily,ramp_days)
+		VALUES ($1,$2,$3,$4,50,200,4)`, userID, scope, status, activeDays,
+	); err != nil {
+		t.Fatalf("insert scope: %v", err)
+	}
+}
+
+func TestInspectScopeTxTreatsAMissingDomainAsProbation(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// The user exists; the domain was never registered. Nothing has been
+	// proven, so the answer is inactive and not established — never an error,
+	// because the gate must classify shared-relay-shaped sends without a row.
+	got := inspectDomain(t, pool, "missing", "", "", "", nil)
+	if got.Status != sendramp.StatusInactive || got.Established || got.ActiveDays != 0 {
+		t.Fatalf("state=%+v, want inactive probation", got)
+	}
+}
+
+func TestInspectScopeTxEstablishesLegacyExemptDomainsWithoutAScope(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// Exempt is the grandfather stamp: verified before the ramp existed. It is
+	// established on its own say-so and no scope row is consulted or required.
+	got := inspectDomain(t, pool, "exempt", "inspect-exempt.example.com", "verified", sendramp.StatusExempt, nil)
+	if got.Status != sendramp.StatusExempt || !got.Established {
+		t.Fatalf("state=%+v, want established exempt", got)
+	}
+}
+
+func TestInspectScopeTxEstablishesADomainStampedComplete(t *testing.T) {
+	pool := testutil.TestDB(t)
+	got := inspectDomain(t, pool, "complete", "inspect-complete.example.com", "verified", sendramp.StatusComplete, nil)
+	if got.Status != sendramp.StatusComplete || !got.Established {
+		t.Fatalf("state=%+v, want established complete", got)
+	}
+}
+
+func TestInspectScopeTxKeepsAnUnverifiedIdentityInProbationHoweverOldItsScope(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// The scope has four qualified days, which would normally establish it.
+	// But qualified days vouch for the identity that earned them, and this
+	// domain's own SES identity is not verified — a child subdomain rebound
+	// onto a parent's progress. The classifier must not read the scope at
+	// all: it stays probationary with zero reported days.
+	got := inspectDomain(t, pool, "unverified", "inspect-unverified.example.com", "pending", sendramp.StatusRamping,
+		func(userID string) { insertScope(t, pool, userID, "example.com", sendramp.StatusRamping, 4) })
+	if got.Established || got.ActiveDays != 0 || got.Status != sendramp.StatusRamping {
+		t.Fatalf("state=%+v, want unverified identity held in probation with its scope ignored", got)
+	}
+}
+
+func TestInspectScopeTxTreatsAVerifiedDomainWithNoScopeAsDayZero(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// Stamped ramping, verified, but the scope has not armed yet: day zero.
+	got := inspectDomain(t, pool, "unarmed", "inspect-unarmed.example.com", "verified", sendramp.StatusRamping, nil)
+	if got.Established || got.ActiveDays != 0 || got.Status != sendramp.StatusRamping {
+		t.Fatalf("state=%+v, want day-zero probation", got)
+	}
+}
+
+func TestInspectScopeTxReportsACompletedScopeAsComplete(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// The domain row still says ramping — Reserve stamps `complete` lazily on
+	// the next send — but the scope has finished. The scope is authoritative.
+	got := inspectDomain(t, pool, "scope-complete", "inspect-scope-complete.example.com", "verified", sendramp.StatusRamping,
+		func(userID string) { insertScope(t, pool, userID, "example.com", sendramp.StatusComplete, 4) })
+	if got.Status != sendramp.StatusComplete || !got.Established || got.ActiveDays != 4 {
+		t.Fatalf("state=%+v, want established complete from the scope", got)
+	}
+}
+
+func TestInspectScopeTxEstablishesAfterExactlyOneQualifiedDay(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// Day zero has proved nothing; one qualified day is the bar. The boundary
+	// is pinned on both sides because it is the single number that decides
+	// whether a custom domain keeps drawing on the shared probation pool.
+	for _, tc := range []struct {
+		suffix      string
+		activeDays  int
+		established bool
+	}{
+		{"day-zero", 0, false},
+		{"day-one", 1, true},
+	} {
+		got := inspectDomain(t, pool, tc.suffix, "inspect-"+tc.suffix+".example.net", "verified", sendramp.StatusRamping,
+			func(userID string) {
+				insertScope(t, pool, userID, "example.net", sendramp.StatusRamping, tc.activeDays)
+			})
+		if got.Established != tc.established || got.ActiveDays != tc.activeDays || got.Status != sendramp.StatusRamping {
+			t.Errorf("%s: state=%+v, want established=%v active_days=%d", tc.suffix, got, tc.established, tc.activeDays)
+		}
+	}
+}
+
+func TestInspectScopeTxLooksUpTheScopeByRegistrableDomain(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// The domain row is keyed by the full hostname; the scope is keyed by the
+	// registrable domain (eTLD+1). A scope armed at example.org must be found
+	// from deep.sub.inspect-registrable.example.org, and a scope mistakenly
+	// keyed by the hostname must NOT be.
+	hostname := "deep.sub.inspect-registrable.example.org"
+	got := inspectDomain(t, pool, "registrable", hostname, "verified", sendramp.StatusRamping,
+		func(userID string) {
+			insertScope(t, pool, userID, hostname, sendramp.StatusComplete, 9) // decoy: wrong key
+			insertScope(t, pool, userID, "example.org", sendramp.StatusRamping, 2)
+		})
+	if !got.Established || got.ActiveDays != 2 || got.Status != sendramp.StatusRamping {
+		t.Fatalf("state=%+v, want the example.org scope (2 days), not the hostname decoy", got)
+	}
+}


### PR DESCRIPTION
## Summary

B4 of the sending-protection plan (Task 4). **Stacked on #990** — base is `feat/sending-protection-gate`, not `main`, because this slice needs B3's `Gate`. Review #990 first; this PR's diff is only the ramp composition.

The ramp and the budget answer different questions — *has this domain earned this volume yet* vs. *has this account or the platform exposed SES enough today* — and this makes one transaction answer both, most restrictive winning.

**One lock order for the ramp.** The store used three: `Reserve` took domain → scope → reservation → counter, `Confirm` took reservation → counter → scope, `Release` took reservation → counter. Three orders over four keys is a deadlock waiting for traffic, and it becomes unavoidable once the gate composes both ledgers into one transaction — that transaction already holds highly contended *global* budget counters when it reaches the ramp. `internal/sendramp/tx.go` now holds the single order and the pool-owning methods are thin wrappers, so there is no second implementation to drift.

**Composition** (`internal/sendingpolicy/ramp.go`):

- Probation is the ramp's answer now. Shared-relay traffic stays probationary at every plan level and never graduates; a custom domain is probationary until its scope has one qualified day. That classification decides *which budget counters the transaction must lock*, and the budget counters come **before** the ramp keys in the normative order — so it is read unlocked. That is sound only because ramp progress is monotonic: a stale answer can be stale in the strict direction and no other. This is the subtlest thing in the PR and the comment says so.
- The ramp is authorized **last**. A ramp hold therefore arrives with budget units already taken, and those are released before returning — keeping them would charge an account for a send its own domain was not allowed to make.
- `SettleProvider` moves the ramp: acceptance advances a qualified day, permanent rejection releases, retryable/ambiguous leaves the reservation standing.
- `CancelAttempt` releases both ledgers; `DeferAttempt` still releases only the budget, so a rate-deferred message cannot re-qualify a stage it already qualified.

## Operational risk

Disabled mode is genuinely pass-through: no scope row, no counter, and **no `exempt` write**. That last one matters — writing `exempt` while the ramp is off would permanently grandfather every domain that sent during the disabled window, and the phase-3 activation would find nothing left to ramp. Production ships in exactly this state (`ramp_enabled: false`).

## Test plan

- [x] `go test -p 1 -race -count=1 ./internal/sendingpolicy ./internal/sendramp ./internal/config ./cmd/e2a`
- [x] 264 tests in the package plus the existing ramp suite: 150/213/277 stage caps and their 75/107/139 qualification bars, every probation class, budget-allow/ramp-hold and its mirror, settlement idempotency, permanent-rejection release, defer-vs-cancel, subdomain scope sharing, Free-plan stage-two block with progress retained
- [x] `make fmt-check`, `git diff --check`, synthetic-data scan
- [x] Two `internal/agent` outreach-hook failures were baselined against clean `origin/main` and fail there too — pre-existing, not from this change

**Fixture note worth keeping:** the ramp ledger is keyed by *registrable* domain, so `ramp-1.example.test` and `ramp-2.example.test` are one scope. The first version of these tests read the hostname key, found empty rows, and would have passed for the wrong reason. Each fixture domain is now its own eTLD+1, and the one test that *is* about sharing builds two hostnames under a single registrable domain deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjfGxvXW6fNKWGFHuo68yX