### PR TITLE
fix(mcp): build the image from the committed lockfile

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -6,21 +6,40 @@
 
 FROM node:22-alpine AS deps
 WORKDIR /app
-# Copy only manifests so this layer caches across code changes.
-COPY package.json ./
+# Copy only manifests + the lockfile so this layer caches across code changes.
+#
+# EVERY workspace in the root `workspaces` array must be copied, design-system
+# included. npm resolves the whole workspace graph, so a declared-but-absent
+# member leaves a dangling edge; `npm ci` rejects that outright rather than
+# guessing, which is the behaviour we want from a release build.
+COPY package.json package-lock.json ./
 COPY sdks/typescript/package.json sdks/typescript/
 COPY mcp/package.json mcp/
 COPY cli/package.json cli/
-RUN npm install --package-lock=false --include=dev --workspaces --no-audit --no-fund
+COPY design-system/package.json design-system/
+# `npm ci` installs exactly the committed lockfile. The previous
+# `npm install --package-lock=false` threw that lockfile away and re-resolved
+# from the live registry on every build, which made the image a function of
+# what npm happened to serve that minute rather than of the commit.
+#
+# That is not theoretical. On 2026-09-03 the MCP image built successfully at
+# 05:14:03; `@e2a/sdk@5.9.0` was published to npm at 05:15:45; and every build
+# afterwards died in arborist with `Cannot read properties of null (reading
+# 'edgesOut')` — same commit, same Dockerfile, different registry. Once the
+# workspace's own version also exists upstream, live resolution has two
+# candidates for one edge and picks neither. The lockfile has never been
+# ambiguous about it: `node_modules/@e2a/sdk` links to `sdks/typescript`.
+RUN npm ci --include=dev --no-audit --no-fund
 
 FROM node:22-alpine AS build
 WORKDIR /app
 # npm workspaces hoists all deps to the root node_modules.
 COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/package.json ./
+COPY --from=deps /app/package.json /app/package-lock.json ./
 COPY --from=deps /app/sdks/typescript/package.json sdks/typescript/
 COPY --from=deps /app/mcp/package.json mcp/
 COPY --from=deps /app/cli/package.json cli/
+COPY --from=deps /app/design-system/package.json design-system/
 COPY sdks/typescript ./sdks/typescript
 COPY mcp ./mcp
 RUN npm run build --workspace @e2a/sdk
@@ -31,12 +50,15 @@ WORKDIR /app
 ARG MCP_SERVER_VERSION
 ENV NODE_ENV=production
 ENV MCP_SERVER_VERSION=${MCP_SERVER_VERSION}
-# Fresh install with production-only deps so the runtime image is lean.
-COPY --from=build /app/package.json ./
+# Fresh install with production-only deps so the runtime image is lean — from
+# the same lockfile, so the runtime tree is a strict subset of the one the build
+# stage compiled against rather than a second independent resolution.
+COPY --from=build /app/package.json /app/package-lock.json ./
 COPY --from=build /app/sdks/typescript/package.json sdks/typescript/
 COPY --from=build /app/mcp/package.json mcp/
 COPY --from=build /app/cli/package.json cli/
-RUN npm install --package-lock=false --omit=dev --workspaces --no-audit --no-fund \
+COPY --from=build /app/design-system/package.json design-system/
+RUN npm ci --omit=dev --no-audit --no-fund \
   && npm cache clean --force
 # Built JS only — no TypeScript source ships in the image.
 COPY --from=build /app/sdks/typescript/dist ./sdks/typescript/dist


### PR DESCRIPTION
## Summary

**The MCP image has been unbuildable since 05:15 today**, and would break again after every client publish. This blocks v1.8.8 — `release.env` pins the server and MCP images to the same version, so a release whose MCP image cannot build cannot be promoted at all.

`mcp/Dockerfile` ran `npm install --package-lock=false --workspaces` in both stages, discarding the committed lockfile and re-resolving the whole workspace graph from the live registry every build. That works only while the workspace's own `@e2a/sdk` version does **not** also exist upstream. Once both are true, live resolution has two candidates for one edge and arborist dies:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

The timeline is exact:

| | |
|---|---|
| 05:14:03 | last successful MCP image build |
| 05:15:45 | `@e2a/sdk@5.9.0` published to npm |
| since | every build fails, reruns included — no repo change in between |

## The fix

Both stages use `npm ci`, installing exactly the committed lockfile. That lockfile was never ambiguous about this: lockfileVersion 3, all four workspaces present, `node_modules/@e2a/sdk` → `sdks/typescript`. The build was throwing away the one artifact that knew the answer.

Also copies `design-system/package.json` — the root `workspaces` array has listed it since #333 while no build stage ever copied it. `npm install` tolerated the dangling workspace edge; `npm ci` refuses it, which is the behaviour a release build should have.

## Verification

Done locally, both directions, because this workflow does not run on pull requests:

- [x] Old Dockerfile → reproduces `edgesOut` failure
- [x] New Dockerfile → builds clean
- [x] Container boots and answers `/healthz` 200 (with `E2A_API_URL` + `MCP_ALLOWED_HOSTS`, both correctly required)
- [x] `/app/node_modules/@e2a/sdk` is a symlink to `../../sdks/typescript`, not a registry tarball

**Note for merge:** since `publish-mcp-http.yml` triggers only on `main` pushes, `v*`/`mcp-http-v*` tags, and dispatch, merging this will build `:main`. Getting an image for **v1.8.8** additionally needs the tag moved to include this commit, or a `mcp-http-v*` tag, or a manual dispatch — happy to do whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjfGxvXW6fNKWGFHuo68yX