### PR TITLE
feat(web): move protection save button to top right with dirty state tracking

### DIFF
--- a/web/src/app/(app)/inboxes/(view)/settings/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/settings/page.tsx
@@ -7,7 +7,7 @@
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
-import { Chip, Eyebrow } from "@e2a/ui";
+import { Eyebrow } from "@e2a/ui";
 import { deleteAgent, getProtection } from "../../../../components/onboarding/api";
 import { useAgents } from "../../../../components/hooks/useAgents";
 import {
@@ -135,17 +135,11 @@ function AgentSettingsContent({ email }: { email: string }) {
           domain verification (the approve/reject pipeline needs a real
           domain) and on the protection config having loaded. */}
       {agent.domain_verified && protection && (
-        <Section
-          title="Protection"
-          beta
-          subtitle="Control who may send to and from this inbox, how aggressively content is scanned, and what happens to messages held for review."
-        >
-          <ProtectionEditor
-            email={agent.email}
-            config={protection}
-            onSaved={onEditorSaved}
-          />
-        </Section>
+        <ProtectionEditor
+          email={agent.email}
+          config={protection}
+          onSaved={onEditorSaved}
+        />
       )}
 
       {/* Danger zone */}
@@ -210,46 +204,5 @@ function AgentSettingsContent({ email }: { email: string }) {
         )}
       </section>
     </div>
-  );
-}
-
-function Section({
-  title,
-  subtitle,
-  beta = false,
-  children,
-}: {
-  title: string;
-  subtitle: string;
-  beta?: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <section
-      className="mb-6"
-      style={{
-        background: "var(--bg-panel)",
-        border: "1px solid var(--border)",
-        borderRadius: "var(--r-lg)",
-        padding: "20px 22px",
-      }}
-    >
-      <div className="flex items-center gap-2">
-        <Eyebrow>{title}</Eyebrow>
-        {beta && <Chip tone="warn">Beta</Chip>}
-      </div>
-      <p
-        className="mt-2 mb-4"
-        style={{
-          fontSize: 13,
-          color: "var(--fg-muted)",
-          lineHeight: 1.6,
-          maxWidth: 580,
-        }}
-      >
-        {subtitle}
-      </p>
-      {children}
-    </section>
   );
 }

--- a/web/src/app/(app)/inboxes/_components/ProtectionEditor.test.tsx
+++ b/web/src/app/(app)/inboxes/_components/ProtectionEditor.test.tsx
@@ -38,6 +38,17 @@ beforeEach(() => {
 });
 
 describe("ProtectionEditor — initialization from config", () => {
+  it("renders the header title, beta chip, and subtitle", () => {
+    renderEditor();
+    expect(screen.getByText("Protection")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Control who may send to and from this inbox, how aggressively content is scanned, and what happens to messages held for review.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("selects the configured policy, action, and sensitivity per direction", () => {
     renderEditor();
     expect(gateGroup("Inbound").getByRole("button", { name: "Addresses" }))
@@ -120,6 +131,31 @@ describe("ProtectionEditor — validation", () => {
 });
 
 describe("ProtectionEditor — save", () => {
+  it("disables the Save button when there are no edits", () => {
+    renderEditor();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("does not call the API if submitted when there are no edits", () => {
+    const { container } = renderEditor();
+    fireEvent.submit(container.querySelector("form")!);
+    expect(mockSetProtection).not.toHaveBeenCalled();
+  });
+
+  it("enables the Save button when an edit is made, and disables it if reverted", async () => {
+    renderEditor();
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+
+    // Make an edit (TTL preset)
+    await userEvent.click(screen.getByRole("button", { name: "1 day" }));
+    expect(saveButton).toBeEnabled();
+
+    // Revert back to original preset (1 hour)
+    await userEvent.click(screen.getByRole("button", { name: "1 hour" }));
+    expect(saveButton).toBeDisabled();
+  });
+
   it("PUTs the wholesale replace with the edited drafts", async () => {
     mockSetProtection.mockResolvedValue(undefined);
     const { onSaved } = renderEditor();
@@ -146,6 +182,7 @@ describe("ProtectionEditor — save", () => {
       holds: { ttl_seconds: 86400, on_expiry: "approve" },
     });
     expect(await screen.findByText("Saved ✓")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
     expect(onSaved).toHaveBeenCalledTimes(1);
   });
 
@@ -167,6 +204,7 @@ describe("ProtectionEditor — save", () => {
     mockSetProtection.mockResolvedValue(undefined);
     renderEditor();
 
+    await userEvent.click(screen.getByRole("button", { name: "1 day" }));
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(await screen.findByText("Saved ✓")).toBeInTheDocument();
 
@@ -175,12 +213,14 @@ describe("ProtectionEditor — save", () => {
         .getByRole("button", { name: "High" }),
     );
     expect(screen.queryByText("Saved ✓")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
   });
 
   it("shows the server error when the PUT fails", async () => {
     mockSetProtection.mockRejectedValue(new Error("ttl_seconds out of range"));
     renderEditor();
 
+    await userEvent.click(screen.getByRole("button", { name: "1 day" }));
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(await screen.findByText("ttl_seconds out of range")).toBeInTheDocument();

--- a/web/src/app/(app)/inboxes/_components/ProtectionEditor.tsx
+++ b/web/src/app/(app)/inboxes/_components/ProtectionEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { Chip, Eyebrow } from "@e2a/ui";
 import { setProtection } from "../../../components/onboarding/api";
 import type {
   ProtectionConfig,
@@ -81,6 +82,16 @@ function directionToConfig(d: DirectionDraft) {
     },
     scan: { sensitivity: d.scan },
   };
+}
+
+function isDirectionDirty(current: DirectionDraft, baseline: DirectionDraft): boolean {
+  if (current.policy !== baseline.policy) return true;
+  if (current.action !== baseline.action) return true;
+  if (current.scan !== baseline.scan) return true;
+  if (current.policy !== "open" && current.allowlist !== baseline.allowlist) {
+    return true;
+  }
+  return false;
 }
 
 function Segmented<T extends string>({
@@ -196,14 +207,36 @@ export function ProtectionEditor({
   const [onExpiry, setOnExpiry] = useState<"approve" | "reject">(
     config.holds.on_expiry ?? "reject",
   );
+  const [baseline, setBaseline] = useState(() => ({
+    inbound: directionFromConfig(config.inbound),
+    outbound: directionFromConfig(config.outbound),
+    ttl: config.holds.ttl_seconds ?? 604800,
+    onExpiry: (config.holds.on_expiry ?? "reject") as "approve" | "reject",
+  }));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setBaseline({
+      inbound: directionFromConfig(config.inbound),
+      outbound: directionFromConfig(config.outbound),
+      ttl: config.holds.ttl_seconds ?? 604800,
+      onExpiry: (config.holds.on_expiry ?? "reject") as "approve" | "reject",
+    });
+  }, [config]);
+
+  const hasEdits =
+    isDirectionDirty(inbound, baseline.inbound) ||
+    isDirectionDirty(outbound, baseline.outbound) ||
+    ttl !== baseline.ttl ||
+    onExpiry !== baseline.onExpiry;
 
   const ttlIsPreset = TTL_PRESETS.some((p) => p.seconds === ttl);
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!hasEdits || saving) return;
     if (ttl <= 0 || ttl > MAX_TTL) {
       setError(`Approval window must be between 1 and ${MAX_TTL} seconds (7 days).`);
       return;
@@ -217,6 +250,12 @@ export function ProtectionEditor({
         outbound: directionToConfig(outbound),
         holds: { ttl_seconds: ttl, on_expiry: onExpiry },
       });
+      setBaseline({
+        inbound,
+        outbound,
+        ttl,
+        onExpiry,
+      });
       setSaved(true);
       onSaved();
     } catch (err) {
@@ -227,7 +266,48 @@ export function ProtectionEditor({
   };
 
   return (
-    <form onSubmit={handleSave} className="space-y-4">
+    <form
+      onSubmit={handleSave}
+      className="mb-6 space-y-4"
+      style={{
+        background: "var(--bg-panel)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--r-lg)",
+        padding: "20px 22px",
+      }}
+    >
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <Eyebrow>Protection</Eyebrow>
+            <Chip tone="warn">Beta</Chip>
+          </div>
+          <p
+            className="mt-2 text-[13px] leading-relaxed"
+            style={{
+              color: "var(--fg-muted)",
+              maxWidth: 580,
+            }}
+          >
+            Control who may send to and from this inbox, how aggressively content
+            is scanned, and what happens to messages held for review.
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-1.5 shrink-0 self-start">
+          <div className="flex items-center gap-2">
+            {saved && <span className="text-xs text-success font-medium">Saved ✓</span>}
+            <button
+              type="submit"
+              disabled={saving || !hasEdits}
+              className="text-xs px-3 py-1.5 bg-foreground text-background rounded-md hover:opacity-90 transition disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer font-medium"
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+          {error && <p className="text-xs text-red-600 max-w-[280px] text-right">{error}</p>}
+        </div>
+      </div>
+
       <DirectionFields
         title="Inbound"
         gateLabel="Who may send to this inbox"
@@ -320,18 +400,6 @@ export function ProtectionEditor({
         action above. Held messages and their body + attachments remain in
         message history after the review reaches a terminal state.
       </p>
-
-      <div className="flex items-center gap-2">
-        <button
-          type="submit"
-          disabled={saving}
-          className="text-xs px-3 py-1.5 bg-foreground text-background rounded-md hover:opacity-90 transition disabled:opacity-50"
-        >
-          {saving ? "Saving…" : "Save"}
-        </button>
-        {saved && <span className="text-xs text-success">Saved ✓</span>}
-        {error && <p className="text-xs text-red-600">{error}</p>}
-      </div>
     </form>
   );
 }


### PR DESCRIPTION
## Summary

Moves the "Save" button in the Protection settings card to the upper-right corner of the component for better visibility and adds dirty-state tracking:
- Save button is disabled, greyed out, and non-functional when there are no unsaved edits.
- Editing any protection setting enables the Save button. Reverting changes back to the saved state automatically greys it out again.
- Saving updates the baseline, greys the button out immediately, and displays `Saved ✓`.

## Operational risk

None. Purely client-side UI improvement in the web dashboard for inbox protection settings.

## Test plan

- [x] Run `npm test` and `npm run lint` in `web/` — all 109 test suites (926 tests) passed.
- [x] Verified unit tests for initial disabled state, enabling on edits, reverting to disabled on undo, and disabling upon save in `ProtectionEditor.test.tsx`.
- [x] Verified settings page integration in `page.test.tsx`.
- [x] Interactively verified on a local Next.js service via headless browser testing in both light and dark themes.