### PR TITLE
fix(sendramp): make a disabled sending ramp a true no-op

### DIFF
--- a/docs/runbooks/sending-ramp.md
+++ b/docs/runbooks/sending-ramp.md
@@ -25,10 +25,29 @@ sustained over-cap admission or a ramp-store incident.
 ## Exemptions
 
 Migration `067_domain_sending_ramp.sql` exempts domains that were already
-sending-verified when the feature shipped. A verified domain that sends while `sending_ramp.enabled` is
-false is also persistently exempt. Enabling the feature later does not revoke
-those exemptions. This prevents a rollout from unexpectedly throttling an
+sending-verified when the feature shipped. Enabling the feature later does not
+revoke those exemptions. This prevents a rollout from unexpectedly throttling an
 established sender.
+
+While `sending_ramp.enabled` is false the gate is pass-through: the send is
+allowed and **no ramp state is written**. A domain that sends under a disabled
+ramp stays `inactive` — it is not exempted, and the domain API keeps reporting
+`sending_ramp.status: inactive`. Turning the ramp on therefore ramps every
+domain that has not been exempted deliberately.
+
+Exempting the fleet that is already sending is a one-shot operator decision,
+not a side effect of traffic. Activate the sending-protection policy with
+`-grandfather-current-sending-domains`: it flips every sending-verified,
+ramp-inactive domain to `exempt` inside the activation transaction, behind a
+replay marker and a `SHARE ROW EXCLUSIVE` lock on `domains`, so a concurrent
+pending→verified sender transition either linearizes into the snapshot or meets
+the armed ramp. A second run reports `already grandfathered` and writes nothing.
+
+A deployment that ran an earlier build with the ramp disabled may already hold
+`exempt` rows that the send path stamped once per sending domain. Those rows are
+not remediated automatically; decide per deployment whether they should stand
+(treat that traffic as grandfathered) or be returned to `inactive` with the
+reset below so the domains ramp when the feature is enabled.
 
 ## Operator-only reset
 

--- a/internal/agent/outbound_async.go
+++ b/internal/agent/outbound_async.go
@@ -126,9 +126,22 @@ func NewOutboundRampGate(store *sendramp.Store, schedule sendramp.Schedule, enab
 
 func (g *outboundRampGate) Reserve(ctx context.Context, req outboundsend.RampRequest) (outboundsend.RampDecision, error) {
 	if !g.enabled {
-		if err := g.store.Exempt(ctx, req.UserID, req.Domain); err != nil {
-			return outboundsend.RampDecision{}, err
-		}
+		// Disabled is pass-through: reserve nothing, count nothing, stamp
+		// nothing. The domain stays 'inactive'.
+		//
+		// An earlier revision stamped the domain 'exempt' here, reasoning that
+		// a sender allowed to send unthrottled must not be re-throttled if the
+		// ramp is later enabled. That turned every eligible send into a silent,
+		// unmarked grandfathering decision, and 'exempt' has since grown
+		// meaning beyond "skip the ramp": an exempt domain reads as an
+		// established sender, so it also stops consuming the shared probation
+		// pool that bounds Sybil abuse. Widening that set from the send path,
+		// once per send, is not a decision this gate gets to make.
+		//
+		// Grandfathering belongs to the audited one-shot that already exists
+		// for it: sendingpolicy's ActivationRequest.GrandfatherCurrentSendingDomains,
+		// which writes a replay marker, locks the domains table against
+		// concurrent sender transitions, and can never widen its set twice.
 		return outboundsend.RampDecision{Allowed: true}, nil
 	}
 	d, err := g.store.Reserve(ctx, sendramp.ReserveRequest{
@@ -142,6 +155,10 @@ func (g *outboundRampGate) Reserve(ctx context.Context, req outboundsend.RampReq
 	return outboundsend.RampDecision{Allowed: d.Allowed, RetryAt: d.RetryAt}, err
 }
 
+// Confirm, Release and Resolve delegate unconditionally, including while the
+// ramp is disabled: a reservation taken before an operator turned the ramp off
+// still has to settle. With the ramp disabled no reservation is ever created,
+// so on that path the store methods find no row and write nothing.
 func (g *outboundRampGate) Confirm(ctx context.Context, messageID string) error {
 	return g.store.Confirm(ctx, messageID)
 }

--- a/internal/agent/outbound_ramp_test.go
+++ b/internal/agent/outbound_ramp_test.go
@@ -5,14 +5,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/tokencanopy/e2a/internal/agent"
 	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/outbound"
 	"github.com/tokencanopy/e2a/internal/outboundsend"
 	"github.com/tokencanopy/e2a/internal/sendramp"
 	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/usage"
 )
 
-func seedOutboundRampAdapter(t *testing.T, suffix string) (*sendramp.Store, string, string, string) {
+func seedOutboundRampAdapter(t *testing.T, suffix string) (*pgxpool.Pool, *sendramp.Store, string, string, string) {
 	t.Helper()
 	pool := testutil.TestDB(t)
 	ctx := context.Background()
@@ -36,24 +39,100 @@ func seedOutboundRampAdapter(t *testing.T, suffix string) (*sendramp.Store, stri
 	if err != nil {
 		t.Fatal(err)
 	}
-	return sendramp.NewStore(pool), user.ID, domain, msg.ID
+	return pool, sendramp.NewStore(pool), user.ID, domain, msg.ID
 }
 
-func TestOutboundRampGateDisabledPersistsExemption(t *testing.T) {
-	store, userID, domain, messageID := seedOutboundRampAdapter(t, "disabled")
+// assertNoRampState asserts the full "the ramp wrote nothing" contract for one
+// account: the domain never left 'inactive' and no ledger row was created.
+func assertNoRampState(t *testing.T, pool *pgxpool.Pool, userID, domain, messageID string) {
+	t.Helper()
+	ctx := context.Background()
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT sending_ramp_status FROM domains WHERE domain=$1 AND user_id=$2`, domain, userID).Scan(&status); err != nil {
+		t.Fatalf("read sending_ramp_status: %v", err)
+	}
+	if status != sendramp.StatusInactive {
+		t.Fatalf("sending_ramp_status = %q, want %q: a disabled ramp must not grandfather a domain from the send path", status, sendramp.StatusInactive)
+	}
+	for _, q := range []struct{ table, sql string }{
+		{"sending_ramp_scopes", `SELECT count(*) FROM sending_ramp_scopes WHERE user_id=$1`},
+		{"domain_send_counters", `SELECT count(*) FROM domain_send_counters WHERE user_id=$1`},
+	} {
+		var n int
+		if err := pool.QueryRow(ctx, q.sql, userID).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", q.table, err)
+		}
+		if n != 0 {
+			t.Fatalf("%s has %d rows, want 0", q.table, n)
+		}
+	}
+	var reservations int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM sending_ramp_reservations WHERE message_id=$1`, messageID).Scan(&reservations); err != nil {
+		t.Fatalf("count sending_ramp_reservations: %v", err)
+	}
+	if reservations != 0 {
+		t.Fatalf("sending_ramp_reservations has %d rows, want 0", reservations)
+	}
+}
+
+// TestOutboundRampGateDisabledIsPassThrough pins the disabled contract: allow
+// the send and write NOTHING. The gate used to stamp the domain 'exempt' on
+// every eligible send, which permanently grandfathered any domain that sent
+// while the ramp was off — pre-empting the audited one-shot in sendingpolicy
+// and, because 'exempt' also reads as "established" to the shared probation
+// pool, handing away an abuse bound. Delete-and-re-register made it a repeatable
+// reset primitive on top.
+func TestOutboundRampGateDisabledIsPassThrough(t *testing.T) {
+	pool, store, userID, domain, messageID := seedOutboundRampAdapter(t, "disabled")
 	gate := agent.NewOutboundRampGate(store, sendramp.DefaultSchedule, false)
 	d, err := gate.Reserve(context.Background(), outboundsend.RampRequest{MessageID: messageID, UserID: userID, Domain: domain, Units: 1})
 	if err != nil || !d.Allowed {
 		t.Fatalf("Reserve = %+v, %v", d, err)
 	}
+	assertNoRampState(t, pool, userID, domain, messageID)
+
+	// The read surface (GET /v1/domains/{domain}.sending_ramp.status) therefore
+	// reports 'inactive', not 'exempt', for a domain sending under a disabled ramp.
 	snap, err := store.Snapshot(context.Background(), userID, domain, time.Now())
-	if err != nil || snap.Status != sendramp.StatusExempt {
-		t.Fatalf("Snapshot = %+v, %v", snap, err)
+	if err != nil || snap.Status != sendramp.StatusInactive {
+		t.Fatalf("Snapshot = %+v, %v, want status %q", snap, err, sendramp.StatusInactive)
 	}
 }
 
+// TestSendWorkerDisabledRampWritesNoRampState is the same contract one level
+// out: a real ramp-eligible send (own_address, message_type send) driven
+// through the send worker with the ramp disabled must leave the domain
+// 'inactive' and the ramp ledger empty.
+func TestSendWorkerDisabledRampWritesNoRampState(t *testing.T) {
+	api, store, outbox, _, pool := setupAsyncAPIWithPool(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "rampdisabled")
+	if err := store.SetSendingStatus(ctx, ag.RegisteredDomain, "verified", "verified", "verified", "", nil); err != nil {
+		t.Fatalf("SetSendingStatus: %v", err)
+	}
+	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+		To: []string{"recipient@external.test"}, Subject: "disabled ramp send", Body: "x",
+	}, "send", "", nil, nil)
+	if oerr != nil {
+		t.Fatalf("DeliverOutbound: %+v", oerr)
+	}
+
+	ramp := agent.NewOutboundRampGate(sendramp.NewStore(pool), sendramp.DefaultSchedule, false)
+	deliverer := &countingDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "provider-disabled-ramp", SentAs: "own_address"}}
+	worker := outboundsend.NewSendWorker(
+		agent.NewOutboundSendStore(store, outbox, usage.NewNoopUsageTracker()), deliverer, ramp)
+
+	if err := worker.Work(ctx, workerJobWithID(res.MessageID, 999, 1)); err != nil {
+		t.Fatalf("worker.Work: %v", err)
+	}
+	if deliverer.calls != 1 {
+		t.Fatalf("deliverer calls = %d, want 1: the disabled ramp must still allow the send", deliverer.calls)
+	}
+	assertNoRampState(t, pool, user.ID, ag.RegisteredDomain, res.MessageID)
+}
+
 func TestOutboundRampGateInjectsDayAndDelegatesLifecycle(t *testing.T) {
-	store, userID, domain, messageID := seedOutboundRampAdapter(t, "enabled")
+	_, store, userID, domain, messageID := seedOutboundRampAdapter(t, "enabled")
 	day := time.Date(2026, 7, 2, 23, 30, 0, 0, time.FixedZone("west", -7*60*60))
 	gate := agent.NewOutboundRampGate(store, sendramp.NewSchedule(50, 100, 2), true, func() time.Time { return day })
 	d, err := gate.Reserve(context.Background(), outboundsend.RampRequest{MessageID: messageID, UserID: userID, Domain: domain, Units: 25})

--- a/internal/sendramp/store.go
+++ b/internal/sendramp/store.go
@@ -61,6 +61,14 @@ type Store struct{ pool *pgxpool.Pool }
 
 func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
 
+// Exempt flips one verified, ramp-inactive domain to 'exempt'.
+//
+// No automatic path calls this. The disabled ramp gate used to, once per
+// eligible send, which made "this sender is established" a decision taken
+// silently by the send path (see internal/agent.outboundRampGate.Reserve);
+// hosted grandfathering is the audited one-shot in internal/sendingpolicy
+// instead. This stays as the store-level primitive for an explicit,
+// single-domain operator exemption and must not be re-wired to a hot path.
 func (s *Store) Exempt(ctx context.Context, userID, domain string) error {
 	tag, err := s.pool.Exec(ctx, `
 		UPDATE domains SET sending_ramp_status = 'exempt'


### PR DESCRIPTION
## The bug

The per-domain sending ramp is disabled by default (`SendingRampConfig.Enabled`
defaults to `false`; the hosted config sets no `sending_ramp` block), but the
disabled branch of the gate was never a no-op:

```go
func (g *outboundRampGate) Reserve(...) {
    if !g.enabled {
        if err := g.store.Exempt(ctx, req.UserID, req.Domain); err != nil { ... }
        return outboundsend.RampDecision{Allowed: true}, nil
    }
```

`Store.Exempt` runs `UPDATE domains SET sending_ramp_status='exempt' … AND
sending_ramp_status='inactive'`, and the send worker calls `Reserve` on **every**
eligible send (`sent_as == "own_address" && message_type != "test"`). So every
verified custom sender domain that sends at all is permanently flipped from
`inactive` to `exempt`.

The intent (commit `a270940a7`) was defensible on its own terms: don't
re-throttle a sender that has been sending unthrottled if the ramp is later
switched on. What makes it a defect is that `exempt` no longer means only "skip
the ramp":

- An exempt domain reads as an **established sender**: it both loses its daily
  stage cap and stops consuming the shared probation pool that bounds Sybil
  abuse. The disabled send path was handing that classification out
  automatically, once per domain, to anyone who sends.
- Delete + re-register a domain and it is `inactive` again, so the stamp is a
  repeatable **reset primitive**.
- It silently pre-empts the audited one-shot built for exactly this decision —
  `sendingpolicy`'s `ActivationRequest.GrandfatherCurrentSendingDomains`, which
  writes a replay marker and takes `SHARE ROW EXCLUSIVE` on `domains` so a
  concurrent pending→verified transition can't slip in. This was the careful
  version of what the send path was doing continuously and unmarked.

## The fix

Disabled means pass-through, matching the newer gate's semantics ("correct while
the ramp itself is pass-through"): allow the send, reserve nothing, count
nothing, stamp nothing. Domains stay `inactive`, so the grandfathering decision
stays where it belongs — with the operator, through the audited activation.

`Confirm`/`Release`/`Resolve` deliberately keep delegating even while disabled: a
reservation taken before an operator switched the ramp off still has to settle,
and on the disabled path no reservation row exists, so they find nothing and
write nothing.

## Blast radius

- **`Store.Exempt` is kept, not deleted.** After this change it has no automatic
  caller (its only production caller was this branch; the other references are
  its own tests). It stays as the store-level primitive for an explicit
  single-domain operator exemption, with a doc comment saying it must not be
  re-wired to a hot path. Two in-flight ramp branches still contain the old call
  site and will need to take this change on rebase.
- **Read surface changes for one case.** A domain that sends while the ramp is
  disabled now reports `sending_ramp.status: "inactive"` instead of `"exempt"`
  through `GET /v1/domains/{domain}`. `status` is a documented open set and
  `sendingRampView` derives everything else from the snapshot, so nothing else
  moves: `daily_recipient_limit` stays 0 and `resets_at` /
  `estimated_completion_at` stay absent for both values (only `ramping`
  populates them). No test asserted on the old value except the one this PR
  rewrites.
- **This is a real behaviour change for a self-host that has been relying on the
  old branch, and it is not free.** Previously, running with the ramp disabled
  self-grandfathered every sending domain, so a later enable throttled nobody.
  Now those domains stay `inactive` and will ramp (150/day → 2,000 over 30
  qualified days) when the feature is enabled. The supported replacement is the
  deliberate one-shot: activate with `-grandfather-current-sending-domains`.
  `docs/runbooks/sending-ramp.md` is updated — it previously documented the buggy
  behaviour as intended.

## Data: existing rows are NOT remediated by this PR

Production has been running with the ramp disabled and has therefore already
stamped `exempt` on every custom sender domain that has sent since the ramp
shipped. **This PR changes code only.** It stops new stamps; it does not touch a
single existing row, by design — remediation is an operator decision, not a
deploy side effect.

What still needs deciding, per deployment, before the ramp is enabled:

1. **Let the existing `exempt` rows stand** — treat the domains that were
   already sending as genuinely grandfathered. This is the low-risk choice for
   established senders, but it keeps every domain stamped so far outside the
   probation pool.
2. **Return some or all of them to `inactive`** so they ramp (and consume
   probation) when the feature is enabled, using the operator reset in
   `docs/runbooks/sending-ramp.md`.

Either way the set is worth reviewing rather than inheriting: it is "every domain
that happened to send", not "every domain we decided was established". Whichever
is chosen, run it before enabling the ramp — after activation the two states
diverge in caps and in pool consumption.

## Tests

Both new tests fail on the pre-change code with
`sending_ramp_status = "exempt", want "inactive"`, and pass after (verified by
reverting `internal/agent/outbound_async.go` and re-running):

- `TestOutboundRampGateDisabledIsPassThrough` — the gate directly (this replaces
  `TestOutboundRampGateDisabledPersistsExemption`, which asserted the old
  contract; the coverage is rewritten, not dropped).
- `TestSendWorkerDisabledRampWritesNoRampState` — a real ramp-eligible send
  (`own_address`, `message_type=send`) driven through `outboundsend.SendWorker`
  with a disabled gate, proving the production path.

Both assert the domain stays `inactive` **and** that no `sending_ramp_scopes`,
`domain_send_counters`, or `sending_ramp_reservations` rows are created.

Also run: `go test -count=1 ./internal/sendramp ./internal/outboundsend`,
`go test -race -p 2 ./internal/sendramp ./internal/outboundsend` (the CI race
gate), `go test -count=1 ./internal/agent` (the two `TestMarkSent*` outreach
failures are pre-existing — baselined failing on a clean `origin/main` tree),
`make fmt-check`, `go vet`, `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjfGxvXW6fNKWGFHuo68yX
