### PR TITLE
docs(readme): use warm gold for logo and hosted button

### DIFF
--- a/assets/e2a-wordmark-dark.svg
+++ b/assets/e2a-wordmark-dark.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="640" height="200" viewBox="0 0 640 200" role="img" aria-label="e2a">
-  <text x="320" y="148" text-anchor="middle" font-family="Geist, 'Inter', ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="176" letter-spacing="-12" fill="#ECE6D9"><tspan>e</tspan><tspan fill="#7E9270">2</tspan><tspan>a</tspan></text>
+  <text x="320" y="148" text-anchor="middle" font-family="Geist, 'Inter', ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="176" letter-spacing="-12" fill="#ECE6D9"><tspan>e</tspan><tspan fill="#8A5214">2</tspan><tspan>a</tspan></text>
 </svg>

--- a/assets/e2a-wordmark-light.svg
+++ b/assets/e2a-wordmark-light.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="640" height="200" viewBox="0 0 640 200" role="img" aria-label="e2a">
-  <text x="320" y="148" text-anchor="middle" font-family="Geist, 'Inter', ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="176" letter-spacing="-12" fill="#1A1714"><tspan>e</tspan><tspan fill="#2B4033">2</tspan><tspan>a</tspan></text>
+  <text x="320" y="148" text-anchor="middle" font-family="Geist, 'Inter', ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="176" letter-spacing="-12" fill="#1A1714"><tspan>e</tspan><tspan fill="#8A5214">2</tspan><tspan>a</tspan></text>
 </svg>

--- a/assets/hosted-cta.svg
+++ b/assets/hosted-cta.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="56" viewBox="0 0 320 56" role="img" aria-labelledby="title">
   <title id="title">Try hosted e2a — start free</title>
-  <rect width="320" height="56" rx="10" fill="#2B4033"/>
+  <rect width="320" height="56" rx="10" fill="#8A5214"/>
   <text x="160" y="34" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" fill="#F2ECE2">Try hosted e2a — start free →</text>
 </svg>


### PR DESCRIPTION
## Summary

Match the README wordmark’s “2” and hosted-service button background to the warm gold already used by the website: `#8A5214`. Apply the same requested color to both wordmark variants and retain cream button text. Only three SVG fill values change.

## Validation

- [x] SVG XML parses and `git diff --check` passes
- [x] Repository text-integrity gate passes, including four example tests
- [x] GitHub dark-mode rendering inspected
- [x] Independent and adversarial reviews: no blockers

Cream button text has 5.42:1 contrast. The exact gold is less prominent than moss green in the dark wordmark; this preserves the requested shared color. No runtime changes.
