### PR TITLE
docs: fix stale toolchain and config references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,9 @@ is explicitly enumerated in `docs/api.md` → "Stability: GA and beta surface"
 | Design system | `design-system/` | React + tsup + Storybook | `@e2a/ui` ("Loft", consumed via `file:` dep) |
 | Agent plugins | `plugins/e2a/`, `plugins/e2a-labs/` | Markdown skills + manifests | Core: Claude / Codex / Cursor; Labs: Claude / Codex |
 
-Toolchain versions: `go.mod` declares Go 1.25; CI and the Dockerfiles build
-with Go 1.26. Node: engines `>=18`, CI runs on 22. Python: `requires-python
->=3.9`, CI runs on 3.12.
+Toolchain versions: `go.mod` declares Go 1.26; CI builds with Go 1.26; the
+Dockerfiles build with Go 1.27. Node: engines `>=18`, CI runs on 22. Python:
+`requires-python >=3.9`, CI runs on 3.12.
 
 ## Repository layout
 
@@ -249,7 +249,10 @@ Key packages, grouped (name — a few words each):
   (List-Unsubscribe); `usage`/`limits` usage metering + plan/account
   entitlements; `sendramp` per-domain recipient-volume ramping; `sendrate`
   per-agent fire-time submission rate limiting (durable sliding window
-  enforced in the send worker immediately before provider submission).
+  enforced in the send worker immediately before provider submission);
+  `sendingpolicy` authoritative sending-protection runtime policy — the sole
+  provider-authorization gate (single-use, bound to one durable attempt),
+  ramp/budget composition, and operator activation.
 - Auth: `auth` API key authentication; `oauth` fosite-based MCP OAuth
   server; Google OAuth + optional generic OIDC login.
 - Misc/infra: `ratelimit`; `telemetry` (metrics interface); `logredact`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ The fork workflow above is the expected path for everyone else.
 
 | Tool | Version | Why |
 |---|---|---|
-| Go | 1.25 | backend |
+| Go | 1.26 | backend |
 | Node | 18+ (CI tests on 22) | CLI, TypeScript SDK, MCP server, web dashboard |
 | Python | 3.9+ | Python SDK |
 | Docker (Desktop or engine) | any recent | local Postgres + Mailpit |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,6 +28,7 @@ Copy `config.example.yaml` to `config.yaml` and fill in values, or set the envir
 | `E2A_OIDC_CLIENT_SECRET` | if OIDC enabled | Confidential client secret |
 | `E2A_OIDC_REDIRECT_URL` | if OIDC enabled | Registered absolute callback URL |
 | `E2A_OIDC_USER_ID_CLAIM` | if OIDC enabled | ID-token claim naming an existing `users.id` — OIDC login never provisions new users |
+| `E2A_OIDC_LOGOUT_URL` | no | Optional fixed upstream logout URL to redirect to after local logout (absolute `http(s)` URL, no query/fragment) |
 | `E2A_PROVISIONING_ENABLED` | no (default off) | Internal-only. Turns on `POST /api/internal/users/provision`, which lets an external control plane create users idempotently ahead of their first sign-in (see below) |
 | `E2A_PROVISIONING_SECRET` | if provisioning enabled | Internal-only, env-only. Shared HMAC key the control plane signs provisioning request bodies with (`X-E2A-Internal-Signature`); must match on both ends. Production requires ≥32 bytes — generate with `openssl rand -hex 32` |
 | `E2A_DELEGATED_ENABLED` | no (default off) | Turns on delegated access-token verification (RFC 9068 `at+jwt`) so an external control plane can call `/v1` on behalf of its signed-in humans (see below). The rest of the policy — `issuer_url`, `audience`, `authorized_party`, `required_scope`, `allowed_algorithms`, `max_token_lifetime_seconds`, `clock_skew_seconds`, `required_claims`, `forbidden_claims` — is non-secret and lives in the `delegated:` block of `config.yaml`; there is no shared key |


### PR DESCRIPTION
## Summary

Small doc-only audit pass fixing three stale/incomplete references found by cross-checking docs against current code, config, and CI:

- **`AGENTS.md`** — the "Toolchain versions" line still said `go.mod` declares Go 1.25 and the Dockerfiles build with Go 1.26. `go.mod` is now `go 1.26.0` (CI runs `go-version: "1.26"`), and `Dockerfile`/`Dockerfile.prober` moved to `golang:1.27-alpine`.
- **`CONTRIBUTING.md`** — the prerequisites table had the same stale `Go 1.25` entry.
- **`AGENTS.md`** — the "Send guards & accounting" package list under "Backend architecture" never mentioned `internal/sendingpolicy`, the sending-protection runtime policy package (the sole provider-authorization gate, ramp/budget composition, operator activation) that several recent PRs built out.
- **`docs/deployment.md`** — the OIDC config table omitted `E2A_OIDC_LOGOUT_URL`, which `config.example.yaml` and `internal/config` already document and `internal/auth` wires up as the optional post-logout redirect.

No behavior changes — documentation only.

## Client surface checklist

_Not applicable — this PR is documentation-only and touches no API or client surface._

## Operational risk

None — Markdown-only changes.

## Test plan

- [x] Manually verified each claim against current code: `go.mod:3`, `Dockerfile:7`, `Dockerfile.prober:10`, `.github/workflows/test.yml` `go-version` entries, `internal/sendingpolicy/gate.go`, `internal/config/config.go:242-245,778-779`, `internal/auth/auth.go:191-195,553-558`, `config.example.yaml:86-91`.
- [x] `scripts/check-repository-text-integrity.sh` — passes (no merge-conflict markers, JSON files untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CR23fVs5zSjJreAZYtpQkb

---
_Generated by [Claude Code](https://claude.ai/code/session_01CR23fVs5zSjJreAZYtpQkb)_