### PR TITLE
feat(sending): deletion-resistant feedback provenance and subtype aggregation (B8)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -370,6 +370,19 @@ func main() {
 	// seam with tokens from the same gate.
 	sendingGate, providerSubmitter := outboundSending.gate, outboundSending.submitter
 	registrars = append(registrars, sendramp.NewMaintenanceJobs(rampStore))
+	// Deletion-resistant feedback provenance (B8): refuse to start if any
+	// retained recipient row was signed under a key version this keyring
+	// does not hold — feedback for it could never be matched and the
+	// detector would be silently blind. The retention janitor and the
+	// consumer's accounting seam hang off the same module.
+	if outboundSending.module == nil {
+		log.Fatalf("sending policy gate is not the concrete module; feedback accounting cannot be wired")
+	}
+	if err := outboundSending.module.VerifyKeyringCoverage(ctx); err != nil {
+		log.Fatalf("Sending feedback keyring coverage: %v", err)
+	}
+	store.SetFeedbackRetention(time.Duration(spPolicy.SendingFeedbackPostAcctRetention) * 24 * time.Hour)
+	registrars = append(registrars, sendingpolicy.NewMaintenanceJobs(outboundSending.module))
 	// Queue depth/age gauges: a 30s maintenance periodic sampling river_job
 	// per queue+state (docs/observability.md).
 	registrars = append(registrars, jobs.NewQueueStatsJobs(pool, metrics))
@@ -907,7 +920,8 @@ func main() {
 	// 4b). Fail-closed: the SNS signature is verified and the TopicArn must be
 	// in the configured allow-list (empty allow-list → every message is
 	// rejected, so this is inert until ops wires the topic).
-	deliveryConsumer := delivery.NewConsumer(store, deliveryEventFirer(webhookOutbox), outboundSendStore.FinalizeProviderAcceptedTx)
+	deliveryConsumer := delivery.NewConsumer(store, deliveryEventFirer(webhookOutbox), outboundSendStore.FinalizeProviderAcceptedTx).
+		WithFeedbackProcessor(outboundSending.module)
 	deliveryVerifier := delivery.NewVerifier(cfg.DeliveryFeedback.SNSTopicARNs, delivery.HTTPCertFetcher)
 	// Public webhook receiver for AWS SNS (SES delivery/bounce/complaint). Named
 	// /webhooks/<provider> — it's an inbound third-party callback, not an internal

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -382,7 +382,7 @@ func main() {
 		log.Fatalf("Sending feedback keyring coverage: %v", err)
 	}
 	store.SetFeedbackRetention(time.Duration(spPolicy.SendingFeedbackPostAcctRetention) * 24 * time.Hour)
-	registrars = append(registrars, sendingpolicy.NewMaintenanceJobs(outboundSending.module))
+	registrars = append(registrars, outboundSending.feedbackMaintenance())
 	// Queue depth/age gauges: a 30s maintenance periodic sampling river_job
 	// per queue+state (docs/observability.md).
 	registrars = append(registrars, jobs.NewQueueStatsJobs(pool, metrics))
@@ -920,8 +920,8 @@ func main() {
 	// 4b). Fail-closed: the SNS signature is verified and the TopicArn must be
 	// in the configured allow-list (empty allow-list → every message is
 	// rejected, so this is inert until ops wires the topic).
-	deliveryConsumer := delivery.NewConsumer(store, deliveryEventFirer(webhookOutbox), outboundSendStore.FinalizeProviderAcceptedTx).
-		WithFeedbackProcessor(outboundSending.module)
+	deliveryConsumer := outboundSending.armDeliveryConsumer(
+		delivery.NewConsumer(store, deliveryEventFirer(webhookOutbox), outboundSendStore.FinalizeProviderAcceptedTx))
 	deliveryVerifier := delivery.NewVerifier(cfg.DeliveryFeedback.SNSTopicARNs, delivery.HTTPCertFetcher)
 	// Public webhook receiver for AWS SNS (SES delivery/bounce/complaint). Named
 	// /webhooks/<provider> — it's an inbound third-party callback, not an internal

--- a/cmd/e2a/outbound_wiring.go
+++ b/cmd/e2a/outbound_wiring.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/delivery"
 	"github.com/tokencanopy/e2a/internal/hitlnotify"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/outbound"
@@ -97,4 +98,19 @@ func newNotificationJobs(d notificationDeps) notificationJobs {
 // itself (public feedback).
 func (s outboundSending) armAPI(api *agent.API) {
 	api.SetProviderSubmitter(s.submitter, s.gate)
+}
+
+// armDeliveryConsumer installs the deletion-resistant accounting seam on the
+// SES feedback consumer. Without it the consumer still acks and still runs
+// the message lifecycle, so the omission is silent: provider evidence for a
+// purged message is simply dropped and the detector reads as healthy.
+func (s outboundSending) armDeliveryConsumer(c *delivery.Consumer) *delivery.Consumer {
+	return c.WithFeedbackProcessor(s.module)
+}
+
+// feedbackMaintenance is the retention janitor for feedback provenance and
+// daily outcome aggregates. Unregistered, nothing enforces the
+// post-deletion horizon.
+func (s outboundSending) feedbackMaintenance() *sendingpolicy.MaintenanceJobs {
+	return sendingpolicy.NewMaintenanceJobs(s.module)
 }

--- a/cmd/e2a/outbound_wiring.go
+++ b/cmd/e2a/outbound_wiring.go
@@ -32,6 +32,9 @@ type outboundSending struct {
 	gate      sendingpolicy.Gate
 	submitter *outbound.ProviderSubmitter
 	jobs      *outboundsend.Jobs
+	// module is the concrete gate: the deletion-resistant feedback processor,
+	// the keyring coverage check, and the retention janitor hang off it.
+	module *sendingpolicy.Module
 }
 
 // newOutboundSending is the ONE composition root for provider-bound customer
@@ -50,7 +53,8 @@ func newOutboundSending(d outboundSendingDeps) outboundSending {
 		WithGate(gate).
 		WithMetrics(d.metrics).
 		WithRateGate(d.rate)
-	return outboundSending{gate: gate, submitter: submitter, jobs: jobs}
+	module, _ := gate.(*sendingpolicy.Module)
+	return outboundSending{gate: gate, submitter: submitter, jobs: jobs, module: module}
 }
 
 // notificationDeps is what the notification composition needs: the same gate

--- a/cmd/e2a/sending_policy_wiring_test.go
+++ b/cmd/e2a/sending_policy_wiring_test.go
@@ -46,6 +46,9 @@ func TestSendingPolicyWiring(t *testing.T) {
 	if got := composed.submitter.SESConfigurationSet(); got != "e2a-delivery-test" {
 		t.Fatalf("submitter configuration set = %q, want the deployment's — delivery feedback must stay on", got)
 	}
+	if composed.module == nil || sendingpolicy.Gate(composed.module) != composed.gate {
+		t.Fatal("the concrete module (feedback processor, keyring coverage, retention janitor) is not the composed gate")
+	}
 	if composed.jobs.Gate() != composed.gate {
 		t.Fatal("the jobs bundle does not hold the composed gate")
 	}

--- a/cmd/e2a/sending_policy_wiring_test.go
+++ b/cmd/e2a/sending_policy_wiring_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tokencanopy/e2a/internal/agent"
 	"github.com/tokencanopy/e2a/internal/config"
+	"github.com/tokencanopy/e2a/internal/delivery"
 	"github.com/tokencanopy/e2a/internal/outbound"
 	"github.com/tokencanopy/e2a/internal/sendingpolicy"
 	"github.com/tokencanopy/e2a/internal/testutil/testdb"
@@ -126,5 +127,41 @@ func TestNotificationAndPlatformMailWiring(t *testing.T) {
 	composed.armAPI(api)
 	if !api.ProviderSubmitterWired() {
 		t.Fatal("armAPI did not hand the API the submitter and gate")
+	}
+}
+
+// TestFeedbackAccountingWiring pins the two composition-root edges that are
+// invisible at runtime when they are missing. A delivery consumer without
+// the accounting seam still acks every SES notification and still runs the
+// message lifecycle, so nothing fails — the detector simply never receives
+// evidence. An unregistered retention janitor never enforces the
+// post-deletion horizon, so provenance accumulates forever. Both are one
+// line in main.go, and neither has any other test.
+func TestFeedbackAccountingWiring(t *testing.T) {
+	pool := testdb.TestDB(t)
+	relay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{Host: "relay.invalid", Port: 587, FromDomain: "test.e2a.dev"})
+	composed := newOutboundSending(outboundSendingDeps{
+		pool:    pool,
+		relay:   relay,
+		secrets: sendingpolicy.Secrets{},
+		source:  sendingpolicy.PolicySourceConfig,
+		policy:  sendingpolicy.DisabledPolicy(),
+	})
+
+	bare := delivery.NewConsumer(nil, nil)
+	if bare.FeedbackProcessorWired() {
+		t.Fatal("a bare consumer must not claim an accounting seam")
+	}
+	if armed := composed.armDeliveryConsumer(bare); !armed.FeedbackProcessorWired() {
+		t.Fatal("the composition root did not install the feedback processor on the delivery consumer")
+	}
+
+	janitor := composed.feedbackMaintenance()
+	if janitor == nil {
+		t.Fatal("no feedback retention janitor composed")
+	}
+	periodics := janitor.RegisterJobs(river.NewWorkers())
+	if len(periodics) != 1 {
+		t.Fatalf("retention periodics = %d, want 1", len(periodics))
 	}
 }

--- a/docs/design/async-message-pipeline.md
+++ b/docs/design/async-message-pipeline.md
@@ -363,9 +363,10 @@ of Prepare itself, not of every caller.
 
 Two consequences worth knowing. Notification and feedback mail now cross the
 same submitter as customer mail, so it carries `X-SES-CONFIGURATION-SET`
-and SES publishes delivery feedback for it; none of it correlates to a
-message row, and the SNS consumer acks it as unknown (a log line, no
-suppression). And the closure guard fences `net/smtp` and the SES v2 SDK
+and SES publishes delivery feedback for it. None of it correlates to a
+message row, so the SNS consumer's message-lifecycle half still acks it as
+unknown; since B8 its retained sending correlation does match, which feeds
+the detector but never repairs a suppression (see that addendum). And the closure guard fences `net/smtp` and the SES v2 SDK
 import; a send through some other HTTP provider API would be a new
 dependency, which is where review catches it.
 
@@ -402,23 +403,38 @@ provider retries. The seam never reads `messages`, `agent_identities`, or
   a delayed lower-ranked callback never erases a hard bounce or complaint;
   equal rank is a zero delta with provider time then event id deciding the
   stored provenance.
-- **Suppression repair** happens only while the account exists, from the
-  signed event's plaintext recipient; the retained rows never store one.
-  Upserts go through `internal/suppressionsync`, which advances the row's
-  `sync_generation` and clears `removal_pending`, so a removal that observed
-  an earlier generation deletes nothing (the contract Task 11's provider
-  reconciliation builds on).
+- **Suppression ownership stays with the live message.** The seam only
+  *reports* the repairs an event proves; when a message row survives, the
+  consumer writes the suppression inside its own transaction exactly as
+  before, keeping the `source_message_id` and diagnostic reason the
+  suppression API returns and keeping the row's insert atomic with the
+  `suppression_added` event that announces it. Only when no message can own
+  the row — the purged-message case this slice exists for — does the
+  consumer apply the repair through the seam, and that repair announces
+  nothing because there is no message for an event to reference. Repair is
+  limited to customer messages: a bounce on an approval notice must not
+  suppress the account owner's own address. Upserts go through
+  `internal/suppressionsync`, which advances the row's `sync_generation` and
+  clears `removal_pending`; that guard has no production remover yet and is
+  the contract Task 11's provider reconciliation will build on.
 - **After account deletion** feedback still advances the retained bucket
   provenance but recreates no customer state; account deletion stamps the
   30-day post-deletion horizon on the account's correlations and events, and
   the hourly `sending_feedback_maintenance` job removes expired provenance and
   daily outcome rows older than the detector window plus one day.
-- **Keyring coverage is a startup gate**: the server refuses to start if any
-  unexpired recipient row was signed under a key version the keyring does not
-  hold. Rotation is superset-first: add the new key while the old stays
-  active, then move the active version, and drop the old key only once no
-  retained row references it.
+- **Keyring coverage is a startup gate**: a server that HAS a keyring
+  refuses to start if any unexpired recipient row was signed under a version
+  that keyring does not hold. Rotation is superset-first: add the new key
+  while the old stays active, then move the active version, and drop the old
+  key only once no retained row references it. Because a live account's rows
+  never expire, a version that has signed for a live account is effectively
+  permanent — treat the keyring as append-only. A deployment with no keyring
+  at all is not checked: it signs and matches nothing by design, and
+  bricking it over rows an earlier configuration wrote would turn a disabled
+  feature into an outage.
 
-The detector itself (thresholds, pauses, notices) is B9; B8 only captures
-evidence, so nothing here changes customer-visible behavior beyond the
-suppression repairs the old path already made.
+The detector itself (thresholds, pauses, notices) is B9. B8 captures
+evidence; the one new customer-visible behavior is that a hard bounce or
+complaint for a message that has since been purged now repairs the account
+suppression, where before it was acked and dropped. Suppressions for live
+messages keep their existing shape and events exactly.

--- a/docs/design/async-message-pipeline.md
+++ b/docs/design/async-message-pipeline.md
@@ -368,3 +368,57 @@ message row, and the SNS consumer acks it as unknown (a log line, no
 suppression). And the closure guard fences `net/smtp` and the SES v2 SDK
 import; a send through some other HTTP provider API would be a new
 dependency, which is where review catches it.
+
+
+## Addendum (2026-09-07): deletion-resistant feedback provenance (B8)
+
+Slice B8 makes provider feedback count even when the message, the agent, or
+the whole account it belongs to is gone. The SNS consumer now runs a
+deletion-resistant accounting seam (`delivery.FeedbackProcessor`, implemented
+by the sending-policy module) BEFORE it looks for a live message, in its own
+transaction, and fails the notification if that accounting fails so the
+provider retries. The seam never reads `messages`, `agent_identities`, or
+`users`:
+
+- **Correlation** is by the SES message id bound at settlement (normalized
+  to SES's bare form), then by the random `X-E2A-Provider-Attempt` marker SES
+  echoes from the submitted headers. Each recipient the event names is
+  matched against the keyed HMACs recorded at authorization; an address
+  outside the authorized envelope proves nothing and is ignored.
+- **One row per provider event id** (`sending_feedback_events`), so a
+  redelivered notification is a zero delta.
+- **Buckets** are derived from the full kind and retained subtypes:
+  `delivered`; `terminal_other` for a transient or undetermined bounce;
+  `hard_bounce` for a permanent bounce, including the global-list subtype
+  `Suppressed`; `complaint` for a genuine complaint. The account- and
+  tenant-suppression-list subtypes are `none` (SES never attempted delivery)
+  but still repair the local suppression list, and so does a complaint with
+  a suppression-list `complaintSubType`.
+- **Evidence is monotonic per authorized recipient**: `none < delivered <
+  terminal_other < hard_bounce < complaint`. Higher evidence replaces lower
+  (the prior bucket is subtracted from the epoch/day it was counted in and
+  the new one added to the account's current `outcome_epoch` and the
+  ingestion UTC day, on the correlation's immutable shared/dedicated path);
+  a delayed lower-ranked callback never erases a hard bounce or complaint;
+  equal rank is a zero delta with provider time then event id deciding the
+  stored provenance.
+- **Suppression repair** happens only while the account exists, from the
+  signed event's plaintext recipient; the retained rows never store one.
+  Upserts go through `internal/suppressionsync`, which advances the row's
+  `sync_generation` and clears `removal_pending`, so a removal that observed
+  an earlier generation deletes nothing (the contract Task 11's provider
+  reconciliation builds on).
+- **After account deletion** feedback still advances the retained bucket
+  provenance but recreates no customer state; account deletion stamps the
+  30-day post-deletion horizon on the account's correlations and events, and
+  the hourly `sending_feedback_maintenance` job removes expired provenance and
+  daily outcome rows older than the detector window plus one day.
+- **Keyring coverage is a startup gate**: the server refuses to start if any
+  unexpired recipient row was signed under a key version the keyring does not
+  hold. Rotation is superset-first: add the new key while the old stays
+  active, then move the active version, and drop the old key only once no
+  retained row references it.
+
+The detector itself (thresholds, pauses, notices) is B9; B8 only captures
+evidence, so nothing here changes customer-visible behavior beyond the
+suppression repairs the old path already made.

--- a/internal/delivery/consumer.go
+++ b/internal/delivery/consumer.go
@@ -163,6 +163,12 @@ func (c *Consumer) WithFeedbackProcessor(p FeedbackProcessor) *Consumer {
 	return c
 }
 
+// FeedbackProcessorWired reports whether the accounting seam is installed.
+// Without it every notification is still acked and the lifecycle half still
+// runs, so a missing processor is invisible at runtime — the detector just
+// never sees anything. The composition root's test asserts this.
+func (c *Consumer) FeedbackProcessorWired() bool { return c.feedback != nil }
+
 // NewConsumer builds the consumer. fire may be nil (no events).
 func NewConsumer(store Store, fire Firer, finalizers ...ProviderAcceptanceFinalizer) *Consumer {
 	consumer := &Consumer{store: store, fire: fire}

--- a/internal/delivery/consumer.go
+++ b/internal/delivery/consumer.go
@@ -227,6 +227,33 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 			if err := c.feedback.RepairSuppressions(ctx, accounted.AccountRef, accounted.RepairNeeded); err != nil {
 				return fmt.Errorf("suppression repair: %w", err)
 			}
+			// Announce it. A row appearing in the customer's suppression
+			// list with no event is the same state/notification desync the
+			// message-backed path deliberately avoids; the payload's
+			// message id is documented as present only when still known,
+			// which is exactly this case. Keyed on the provider event, so a
+			// redelivery dedupes at the outbox and a retry after a failure
+			// here still ends with one event.
+			if c.fire != nil {
+				if err := c.store.WithTx(ctx, func(tx pgx.Tx) error {
+					for _, rep := range accounted.RepairNeeded {
+						if err := c.fire(ctx, tx, FiredEvent{
+							UserID: accounted.AccountRef,
+							Type:   EventSuppressionAdded,
+							Data: eventpayload.DomainSuppressionAddedData{
+								Address: rep.Address, Source: rep.Source, Reason: rep.Reason,
+							},
+							DedupKey:   "provider-feedback:" + ev.ProviderEventID + ":" + rep.Address + ":" + EventSuppressionAdded,
+							OccurredAt: ev.OccurredAt,
+						}); err != nil {
+							return err
+						}
+					}
+					return nil
+				}); err != nil {
+					return fmt.Errorf("announce repaired suppression: %w", err)
+				}
+			}
 			log.Printf("[delivery] SES %s repaired %d suppression(s) for a message that no longer exists", ev.Kind, len(accounted.RepairNeeded))
 		}
 		if len(ev.Recipients) == 0 {

--- a/internal/delivery/consumer.go
+++ b/internal/delivery/consumer.go
@@ -218,6 +218,17 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 		}
 	}
 	if !found {
+		// No live message can own a suppression for this event, but the
+		// retained provenance may still prove one — this is the purged /
+		// deleted-message case B8 exists for. The account-wide repair is
+		// applied here, outside any message transaction, and announces
+		// nothing: there is no message for an event to reference.
+		if c.feedback != nil && accounted.AccountRef != "" && len(accounted.RepairNeeded) > 0 {
+			if err := c.feedback.RepairSuppressions(ctx, accounted.AccountRef, accounted.RepairNeeded); err != nil {
+				return fmt.Errorf("suppression repair: %w", err)
+			}
+			log.Printf("[delivery] SES %s repaired %d suppression(s) for a message that no longer exists", ev.Kind, len(accounted.RepairNeeded))
+		}
 		if len(ev.Recipients) == 0 {
 			return nil
 		}
@@ -294,22 +305,16 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 					source = suppressionSourceCompl
 					suppressionReason = messagelifecycle.ReasonSuppressionComplaintApplied
 				}
-				// The accounting seam may already have upserted this
-				// suppression (it repairs the list from the signed
-				// recipient whenever the account exists). Its verdict on
-				// whether the row was NEW is what decides the event, so a
-				// second upsert here cannot turn a genuine insert into a
-				// silent refresh.
-				var suppressionID string
-				var added bool
-				if s, ok := accounted.SuppressionFor(r.Address); ok {
-					suppressionID, added = s.ID, s.Inserted
-				} else {
-					var err error
-					suppressionID, added, err = c.store.AddSuppressionTx(ctx, tx, m.UserID, r.Address, r.Detail, source, m.MessageID)
-					if err != nil {
-						return err
-					}
+				// The live message owns the customer-visible row: it is the
+				// only writer that knows the source message id and the
+				// diagnostic the suppression API returns, and its insert
+				// must share this transaction with the event that
+				// announces it. The accounting seam deliberately does not
+				// write it here (see the !found branch below, which is the
+				// only case where no message can own the repair).
+				suppressionID, added, err := c.store.AddSuppressionTx(ctx, tx, m.UserID, r.Address, r.Detail, source, m.MessageID)
+				if err != nil {
+					return err
 				}
 				if added {
 					suppressionTransition, err := c.store.AppendLifecycleTx(ctx, tx, messagelifecycle.AppendInput{MessageID: m.MessageID, DedupeKey: fmt.Sprintf("suppression:feedback:%s:%s:%s", suppressionID, m.MessageID, r.Address), Direction: "outbound", Recipient: r.Address, ReasonCode: suppressionReason, Evidence: map[string]any{"suppression_scope": "account", "suppression_source": source}, CorrelationIDs: feedbackCorrelations(ev), OccurredAt: ev.OccurredAt})

--- a/internal/delivery/consumer.go
+++ b/internal/delivery/consumer.go
@@ -150,6 +150,17 @@ type Consumer struct {
 	store              Store
 	fire               Firer
 	finalizeAcceptance ProviderAcceptanceFinalizer
+	// feedback is the deletion-resistant accounting seam (B8). It runs
+	// before any live-message lookup, in its own transaction, so provider
+	// evidence for a purged message still lands; nil means no accounting
+	// (self-host with the policy module absent).
+	feedback FeedbackProcessor
+}
+
+// WithFeedbackProcessor installs the deletion-resistant accounting seam.
+func (c *Consumer) WithFeedbackProcessor(p FeedbackProcessor) *Consumer {
+	c.feedback = p
+	return c
 }
 
 // NewConsumer builds the consumer. fire may be nil (no events).
@@ -175,6 +186,21 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 	if ev.OccurredAt.IsZero() {
 		return fmt.Errorf("provider event timestamp is required")
 	}
+	// Deletion-resistant accounting first, and on its own: it must not
+	// depend on a surviving message, agent, or user row, and a failure here
+	// must make the provider retry rather than let the lifecycle path below
+	// consume the notification. Its event-id dedupe makes that retry a zero
+	// delta, and the lifecycle path has its own dedupe keys, so the two
+	// halves committing independently is safe in both orders.
+	var accounted FeedbackResult
+	if c.feedback != nil {
+		var err error
+		accounted, err = c.feedback.ProcessProviderFeedback(ctx, ev.FeedbackFor())
+		if err != nil {
+			return fmt.Errorf("provider feedback accounting: %w", err)
+		}
+	}
+
 	m, found, err := c.store.CorrelateBySESMessageID(ctx, ev.SESMessageID)
 	if err != nil {
 		return err
@@ -268,9 +294,22 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 					source = suppressionSourceCompl
 					suppressionReason = messagelifecycle.ReasonSuppressionComplaintApplied
 				}
-				suppressionID, added, err := c.store.AddSuppressionTx(ctx, tx, m.UserID, r.Address, r.Detail, source, m.MessageID)
-				if err != nil {
-					return err
+				// The accounting seam may already have upserted this
+				// suppression (it repairs the list from the signed
+				// recipient whenever the account exists). Its verdict on
+				// whether the row was NEW is what decides the event, so a
+				// second upsert here cannot turn a genuine insert into a
+				// silent refresh.
+				var suppressionID string
+				var added bool
+				if s, ok := accounted.SuppressionFor(r.Address); ok {
+					suppressionID, added = s.ID, s.Inserted
+				} else {
+					var err error
+					suppressionID, added, err = c.store.AddSuppressionTx(ctx, tx, m.UserID, r.Address, r.Detail, source, m.MessageID)
+					if err != nil {
+						return err
+					}
 				}
 				if added {
 					suppressionTransition, err := c.store.AppendLifecycleTx(ctx, tx, messagelifecycle.AppendInput{MessageID: m.MessageID, DedupeKey: fmt.Sprintf("suppression:feedback:%s:%s:%s", suppressionID, m.MessageID, r.Address), Direction: "outbound", Recipient: r.Address, ReasonCode: suppressionReason, Evidence: map[string]any{"suppression_scope": "account", "suppression_source": source}, CorrelationIDs: feedbackCorrelations(ev), OccurredAt: ev.OccurredAt})

--- a/internal/delivery/feedback_seam.go
+++ b/internal/delivery/feedback_seam.go
@@ -36,14 +36,15 @@ type ProviderFeedback struct {
 	Recipients []string
 }
 
-// FeedbackSuppression reports a suppression the processor upserted for one
-// recipient while its account still existed.
-type FeedbackSuppression struct {
-	Address  string
-	ID       string
-	Source   string
-	Reason   string
-	Inserted bool
+// FeedbackRepair names an account-wide suppression the signed event proves
+// should exist. The processor reports these rather than writing them
+// whenever a live message still owns the customer-visible row: that row
+// carries the source message id and diagnostic the suppression API returns,
+// and its insert must share a transaction with the event that announces it.
+type FeedbackRepair struct {
+	Address string
+	Source  string
+	Reason  string
 }
 
 // FeedbackResult is what the processor did with one notification.
@@ -51,24 +52,16 @@ type FeedbackResult struct {
 	// Correlated is false when no retained correlation matched either key;
 	// the notification is then foreign or past its retention.
 	Correlated bool
-	// Duplicate is true when this provider event id was already processed;
-	// nothing changed.
+	// Duplicate is true when this provider event id was already accounted;
+	// evidence was not moved again. RepairNeeded is still reported, so a
+	// retry that failed after the accounting commit can still finish.
 	Duplicate bool
 	// AccountRef is the opaque source account when it still exists; empty
-	// after account deletion or for non-customer purposes.
+	// after account deletion and for non-customer purposes.
 	AccountRef string
-	// Suppressions lists the account suppressions upserted, keyed by address.
-	Suppressions []FeedbackSuppression
-}
-
-// SuppressionFor returns the upsert recorded for a normalized address.
-func (r FeedbackResult) SuppressionFor(address string) (FeedbackSuppression, bool) {
-	for _, s := range r.Suppressions {
-		if s.Address == address {
-			return s, true
-		}
-	}
-	return FeedbackSuppression{}, false
+	// RepairNeeded lists the suppressions this event proves, for recipients
+	// that matched the authorized envelope, while the account exists.
+	RepairNeeded []FeedbackRepair
 }
 
 // FeedbackProcessor is the deletion-resistant accounting seam the consumer
@@ -77,4 +70,10 @@ func (r FeedbackResult) SuppressionFor(address string) (FeedbackSuppression, boo
 // Implemented by the sending-policy module.
 type FeedbackProcessor interface {
 	ProcessProviderFeedback(context.Context, ProviderFeedback) (FeedbackResult, error)
+	// RepairSuppressions writes the account-wide suppressions a signed event
+	// proved, for the case where no live message row can own them (the
+	// message was purged, or belongs to another deployment). The live path
+	// keeps ownership whenever a message survives, so this never competes
+	// with it.
+	RepairSuppressions(ctx context.Context, accountRef string, repairs []FeedbackRepair) error
 }

--- a/internal/delivery/feedback_seam.go
+++ b/internal/delivery/feedback_seam.go
@@ -1,0 +1,80 @@
+package delivery
+
+import (
+	"context"
+	"time"
+)
+
+// ProviderAttemptHeader is the random per-attempt correlation marker the
+// provider adapter stamps on every submission (outbound.ProviderAttemptHeader
+// — that package imports this one, so the name is mirrored here and pinned
+// equal by a test there). SES echoes it back in mail.headers; it is the
+// correlation fallback when the worker died between SES accepting a message
+// and the provider id being stored.
+const ProviderAttemptHeader = "X-E2A-Provider-Attempt"
+
+// ProviderFeedback is one signed provider notification reduced to what the
+// deletion-resistant accounting needs: identity (event id, time), kind and
+// subtypes, the two correlation keys, and the plaintext recipients the
+// provider named. It carries no message, agent, or account reference — the
+// processor derives those from its own retained rows.
+type ProviderFeedback struct {
+	ProviderEventID string
+	OccurredAt      time.Time
+	Kind            EventKind
+	// BounceType is the normalized permanent | transient | undetermined;
+	// BounceSubType and ComplaintSubType are the raw SES subtypes, retained
+	// because the detector bucket is derived from them.
+	BounceType       string
+	BounceSubType    string
+	ComplaintSubType string
+	// ProviderMessageID is the SES mail.messageId; AttemptCorrelationID is
+	// the echoed ProviderAttemptHeader (empty when headers were absent).
+	ProviderMessageID    string
+	AttemptCorrelationID string
+	// Recipients are the normalized addresses this notification is about.
+	Recipients []string
+}
+
+// FeedbackSuppression reports a suppression the processor upserted for one
+// recipient while its account still existed.
+type FeedbackSuppression struct {
+	Address  string
+	ID       string
+	Source   string
+	Reason   string
+	Inserted bool
+}
+
+// FeedbackResult is what the processor did with one notification.
+type FeedbackResult struct {
+	// Correlated is false when no retained correlation matched either key;
+	// the notification is then foreign or past its retention.
+	Correlated bool
+	// Duplicate is true when this provider event id was already processed;
+	// nothing changed.
+	Duplicate bool
+	// AccountRef is the opaque source account when it still exists; empty
+	// after account deletion or for non-customer purposes.
+	AccountRef string
+	// Suppressions lists the account suppressions upserted, keyed by address.
+	Suppressions []FeedbackSuppression
+}
+
+// SuppressionFor returns the upsert recorded for a normalized address.
+func (r FeedbackResult) SuppressionFor(address string) (FeedbackSuppression, bool) {
+	for _, s := range r.Suppressions {
+		if s.Address == address {
+			return s, true
+		}
+	}
+	return FeedbackSuppression{}, false
+}
+
+// FeedbackProcessor is the deletion-resistant accounting seam the consumer
+// calls BEFORE it looks for a live message: it must succeed (or fail, so the
+// provider retries) without any message, agent, or user row surviving.
+// Implemented by the sending-policy module.
+type FeedbackProcessor interface {
+	ProcessProviderFeedback(context.Context, ProviderFeedback) (FeedbackResult, error)
+}

--- a/internal/delivery/feedback_seam_test.go
+++ b/internal/delivery/feedback_seam_test.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 type fakeProcessor struct {
-	calls  []ProviderFeedback
-	result FeedbackResult
-	err    error
+	calls   []ProviderFeedback
+	repairs [][]FeedbackRepair
+	result  FeedbackResult
+	err     error
 	// order records "processor" / "correlate" so the test can pin that
 	// accounting runs before any live-message lookup.
 	order *[]string
@@ -24,14 +27,47 @@ func (p *fakeProcessor) ProcessProviderFeedback(_ context.Context, fb ProviderFe
 	return p.result, p.err
 }
 
+func (p *fakeProcessor) RepairSuppressions(_ context.Context, _ string, repairs []FeedbackRepair) error {
+	p.repairs = append(p.repairs, repairs)
+	return nil
+}
+
 type orderingStore struct {
 	*fakeConsumerStore
 	order *[]string
+	// failTxOnce makes the first live transaction fail, the two-phase
+	// window an SNS retry has to recover from.
+	failTxOnce bool
+	txCalls    int
+	// rollback discards whatever the failed transaction's firer recorded.
+	rollback func()
 }
 
 func (s *orderingStore) CorrelateBySESMessageID(ctx context.Context, id string) (*CorrelatedMessage, bool, error) {
-	*s.order = append(*s.order, "correlate")
+	if s.order != nil {
+		*s.order = append(*s.order, "correlate")
+	}
 	return s.fakeConsumerStore.CorrelateBySESMessageID(ctx, id)
+}
+
+func (s *orderingStore) WithTx(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	s.txCalls++
+	// Mirror a real rollback: the body runs, then every write it made —
+	// suppression rows AND the outbox events it fired — is discarded. That
+	// fidelity is the whole point: the retry must be able to redo them.
+	before := make(map[string]bool, len(s.suppressed))
+	for k, v := range s.suppressed {
+		before[k] = v
+	}
+	err := fn(nil)
+	if s.failTxOnce && s.txCalls == 1 {
+		s.fakeConsumerStore.suppressed = before
+		if s.rollback != nil {
+			s.rollback()
+		}
+		return errors.New("live transaction failed")
+	}
+	return err
 }
 
 func bounceEvent(id, ses string) *Event {
@@ -84,44 +120,92 @@ func TestConsumerProcessorErrorMakesProviderRetry(t *testing.T) {
 	}
 }
 
-// TestConsumerUsesProcessorSuppressionVerdict: when the seam already
-// upserted the suppression, its Inserted verdict decides the event, so a
-// second upsert cannot hide a genuine insert; without a verdict the store
-// path decides as before.
-func TestConsumerUsesProcessorSuppressionVerdict(t *testing.T) {
-	for name, tc := range map[string]struct {
-		result     FeedbackResult
-		wantEvents int
-		wantStore  bool
-	}{
-		"processor inserted":    {result: FeedbackResult{Correlated: true, Suppressions: []FeedbackSuppression{{Address: "bob@example.test", ID: "supp_p", Inserted: true}}}, wantEvents: 1},
-		"processor refreshed":   {result: FeedbackResult{Correlated: true, Suppressions: []FeedbackSuppression{{Address: "bob@example.test", ID: "supp_p", Inserted: false}}}, wantEvents: 0},
-		"no verdict falls back": {result: FeedbackResult{Correlated: true}, wantEvents: 1, wantStore: true},
-	} {
-		t.Run(name, func(t *testing.T) {
-			st := newFakeConsumerStore()
-			st.corr["ses-1"] = &CorrelatedMessage{MessageID: "msg_1", UserID: "usr_1", AgentID: "agt_1"}
-			fire, events := recordingFirer()
-			c := NewConsumer(st, fire).WithFeedbackProcessor(&fakeProcessor{result: tc.result})
-			if err := c.Process(context.Background(), bounceEvent("evt-3", "ses-1")); err != nil {
-				t.Fatalf("Process: %v", err)
-			}
-			got := 0
-			for _, e := range *events {
-				if e.eventType == EventSuppressionAdded {
-					got++
-					if !tc.wantStore && e.dedupKey == "" {
-						t.Fatal("suppression event without dedup key")
-					}
-				}
-			}
-			if got != tc.wantEvents {
-				t.Fatalf("suppression events = %d, want %d", got, tc.wantEvents)
-			}
-			if stored := st.suppressed["usr_1|bob@example.test"]; stored != tc.wantStore {
-				t.Fatalf("store upsert = %v, want %v", stored, tc.wantStore)
-			}
-		})
+// TestLiveMessageOwnsTheSuppression: when a message survives, the store
+// writes the suppression inside the live transaction with the source
+// message id and the provider diagnostic, and the seam's reported repair is
+// NOT applied separately — one writer, one announcement.
+func TestLiveMessageOwnsTheSuppression(t *testing.T) {
+	st := newFakeConsumerStore()
+	st.corr["ses-1"] = &CorrelatedMessage{MessageID: "msg_1", UserID: "usr_1", AgentID: "agt_1"}
+	fire, events := recordingFirer()
+	p := &fakeProcessor{result: FeedbackResult{Correlated: true, AccountRef: "usr_1",
+		RepairNeeded: []FeedbackRepair{{Address: "bob@example.test", Source: "bounce", Reason: "bounce:General"}}}}
+	c := NewConsumer(st, fire).WithFeedbackProcessor(p)
+	if err := c.Process(context.Background(), bounceEvent("evt-3", "ses-1")); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if !st.suppressed["usr_1|bob@example.test"] {
+		t.Fatal("the live path must write the suppression")
+	}
+	if len(p.repairs) != 0 {
+		t.Fatalf("the seam must not repair while a message owns the row: %v", p.repairs)
+	}
+	got := 0
+	for _, e := range *events {
+		if e.eventType == EventSuppressionAdded {
+			got++
+		}
+	}
+	if got != 1 {
+		t.Fatalf("suppression events = %d, want 1", got)
+	}
+}
+
+// TestSuppressionSurvivesLiveTransactionFailureAndRetry is the regression
+// this design exists for: the accounting seam commits on its own, the live
+// transaction then fails, and the SNS retry must still end with exactly one
+// suppression and exactly one suppression_added event. An earlier shape,
+// where the seam wrote the row and the consumer trusted its insert verdict,
+// lost the event forever on that retry.
+func TestSuppressionSurvivesLiveTransactionFailureAndRetry(t *testing.T) {
+	base := newFakeConsumerStore()
+	base.corr["ses-1"] = &CorrelatedMessage{MessageID: "msg_1", UserID: "usr_1", AgentID: "agt_1"}
+	st := &orderingStore{fakeConsumerStore: base, failTxOnce: true}
+	fire, events := recordingFirer()
+	st.rollback = func() { *events = (*events)[:0] }
+	// The seam is a duplicate on the retry, exactly as the real one is.
+	p := &fakeProcessor{result: FeedbackResult{Correlated: true, AccountRef: "usr_1",
+		RepairNeeded: []FeedbackRepair{{Address: "bob@example.test", Source: "bounce", Reason: "bounce:General"}}}}
+	c := NewConsumer(st, fire).WithFeedbackProcessor(p)
+
+	if err := c.Process(context.Background(), bounceEvent("evt-4", "ses-1")); err == nil {
+		t.Fatal("a failing live transaction must fail Process so SNS retries")
+	}
+	p.result.Duplicate = true
+	if err := c.Process(context.Background(), bounceEvent("evt-4", "ses-1")); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	got := 0
+	for _, e := range *events {
+		if e.eventType == EventSuppressionAdded {
+			got++
+		}
+	}
+	if got != 1 {
+		t.Fatalf("suppression events across the retry = %d, want exactly 1", got)
+	}
+	if !st.suppressed["usr_1|bob@example.test"] {
+		t.Fatal("the retry must leave the suppression in place")
+	}
+}
+
+// TestPurgedMessageRepairsThroughTheSeam: with no live message to own the
+// row, the account-wide repair is applied through the seam instead, and
+// announces nothing (there is no message for an event to reference).
+func TestPurgedMessageRepairsThroughTheSeam(t *testing.T) {
+	st := newFakeConsumerStore() // no correlation → message is gone
+	fire, events := recordingFirer()
+	p := &fakeProcessor{result: FeedbackResult{Correlated: true, AccountRef: "usr_1",
+		RepairNeeded: []FeedbackRepair{{Address: "bob@example.test", Source: "bounce", Reason: "bounce:General"}}}}
+	c := NewConsumer(st, fire).WithFeedbackProcessor(p)
+	if err := c.Process(context.Background(), bounceEvent("evt-5", "ses-gone")); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if len(p.repairs) != 1 || len(p.repairs[0]) != 1 || p.repairs[0][0].Address != "bob@example.test" {
+		t.Fatalf("repairs = %v, want the one address", p.repairs)
+	}
+	if len(*events) != 0 {
+		t.Fatalf("a repair with no message must announce nothing, got %v", *events)
 	}
 }
 

--- a/internal/delivery/feedback_seam_test.go
+++ b/internal/delivery/feedback_seam_test.go
@@ -1,0 +1,158 @@
+package delivery
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeProcessor struct {
+	calls  []ProviderFeedback
+	result FeedbackResult
+	err    error
+	// order records "processor" / "correlate" so the test can pin that
+	// accounting runs before any live-message lookup.
+	order *[]string
+}
+
+func (p *fakeProcessor) ProcessProviderFeedback(_ context.Context, fb ProviderFeedback) (FeedbackResult, error) {
+	p.calls = append(p.calls, fb)
+	if p.order != nil {
+		*p.order = append(*p.order, "processor")
+	}
+	return p.result, p.err
+}
+
+type orderingStore struct {
+	*fakeConsumerStore
+	order *[]string
+}
+
+func (s *orderingStore) CorrelateBySESMessageID(ctx context.Context, id string) (*CorrelatedMessage, bool, error) {
+	*s.order = append(*s.order, "correlate")
+	return s.fakeConsumerStore.CorrelateBySESMessageID(ctx, id)
+}
+
+func bounceEvent(id, ses string) *Event {
+	return &Event{
+		Kind: KindBounce, SESMessageID: ses, ProviderEventID: id, OccurredAt: time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC),
+		BounceType: "permanent", BounceSubType: "General", AttemptCorrelationID: "cor_0123abcd",
+		Recipients: []RecipientOutcome{{Address: "Bob@Example.test", Status: StatusBounced, Detail: "550", Suppress: true}},
+	}
+}
+
+// TestConsumerRunsAccountingBeforeLiveLookupAndForUncorrelated: the
+// deletion-resistant seam sees every notification first — including one
+// whose message is gone — and receives the retained subtypes, the attempt
+// marker, and the normalized recipients.
+func TestConsumerRunsAccountingBeforeLiveLookupAndForUncorrelated(t *testing.T) {
+	var order []string
+	st := &orderingStore{fakeConsumerStore: newFakeConsumerStore(), order: &order}
+	p := &fakeProcessor{order: &order, result: FeedbackResult{Correlated: true}}
+	c := NewConsumer(st, nil).WithFeedbackProcessor(p)
+
+	if err := c.Process(context.Background(), bounceEvent("evt-1", "ses-unknown")); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if len(order) < 2 || order[0] != "processor" || order[1] != "correlate" {
+		t.Fatalf("order = %v, want accounting before the live lookup", order)
+	}
+	if len(p.calls) != 1 {
+		t.Fatalf("processor calls = %d, want 1 even though the message is unknown", len(p.calls))
+	}
+	fb := p.calls[0]
+	if fb.ProviderEventID != "evt-1" || fb.Kind != KindBounce || fb.BounceType != "permanent" || fb.BounceSubType != "General" ||
+		fb.ProviderMessageID != "ses-unknown" || fb.AttemptCorrelationID != "cor_0123abcd" ||
+		len(fb.Recipients) != 1 || fb.Recipients[0] != "bob@example.test" {
+		t.Fatalf("processor input = %+v", fb)
+	}
+}
+
+// TestConsumerProcessorErrorMakesProviderRetry: accounting failure is the
+// consumer's failure; the notification must not be acked.
+func TestConsumerProcessorErrorMakesProviderRetry(t *testing.T) {
+	st := newFakeConsumerStore()
+	st.corr["ses-1"] = &CorrelatedMessage{MessageID: "msg_1", UserID: "usr_1", AgentID: "agt_1"}
+	p := &fakeProcessor{err: errors.New("ledger unavailable")}
+	c := NewConsumer(st, nil).WithFeedbackProcessor(p)
+	if err := c.Process(context.Background(), bounceEvent("evt-2", "ses-1")); err == nil {
+		t.Fatal("a failing processor must fail Process so the provider retries")
+	}
+	if len(st.outcomes) != 0 {
+		t.Fatalf("lifecycle path ran despite accounting failure: %v", st.outcomes)
+	}
+}
+
+// TestConsumerUsesProcessorSuppressionVerdict: when the seam already
+// upserted the suppression, its Inserted verdict decides the event, so a
+// second upsert cannot hide a genuine insert; without a verdict the store
+// path decides as before.
+func TestConsumerUsesProcessorSuppressionVerdict(t *testing.T) {
+	for name, tc := range map[string]struct {
+		result     FeedbackResult
+		wantEvents int
+		wantStore  bool
+	}{
+		"processor inserted":    {result: FeedbackResult{Correlated: true, Suppressions: []FeedbackSuppression{{Address: "bob@example.test", ID: "supp_p", Inserted: true}}}, wantEvents: 1},
+		"processor refreshed":   {result: FeedbackResult{Correlated: true, Suppressions: []FeedbackSuppression{{Address: "bob@example.test", ID: "supp_p", Inserted: false}}}, wantEvents: 0},
+		"no verdict falls back": {result: FeedbackResult{Correlated: true}, wantEvents: 1, wantStore: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			st := newFakeConsumerStore()
+			st.corr["ses-1"] = &CorrelatedMessage{MessageID: "msg_1", UserID: "usr_1", AgentID: "agt_1"}
+			fire, events := recordingFirer()
+			c := NewConsumer(st, fire).WithFeedbackProcessor(&fakeProcessor{result: tc.result})
+			if err := c.Process(context.Background(), bounceEvent("evt-3", "ses-1")); err != nil {
+				t.Fatalf("Process: %v", err)
+			}
+			got := 0
+			for _, e := range *events {
+				if e.eventType == EventSuppressionAdded {
+					got++
+					if !tc.wantStore && e.dedupKey == "" {
+						t.Fatal("suppression event without dedup key")
+					}
+				}
+			}
+			if got != tc.wantEvents {
+				t.Fatalf("suppression events = %d, want %d", got, tc.wantEvents)
+			}
+			if stored := st.suppressed["usr_1|bob@example.test"]; stored != tc.wantStore {
+				t.Fatalf("store upsert = %v, want %v", stored, tc.wantStore)
+			}
+		})
+	}
+}
+
+// TestParseRetainsSubtypesAndAttemptMarker: complaintSubType and the
+// attempt header survive parsing; a malformed marker is dropped, not used.
+func TestParseRetainsSubtypesAndAttemptMarker(t *testing.T) {
+	body := `{"eventType":"Complaint","mail":{"messageId":"ses-9","headers":[
+	  {"name":"x-e2a-provider-attempt","value":" cor_00ff11aa "},
+	  {"name":"X-E2A-Message-ID","value":"msg_abc"}]},
+	  "complaint":{"complainedRecipients":[{"emailAddress":"D@x.com"}],"complaintFeedbackType":"abuse","complaintSubType":"OnAccountSuppressionList"}}`
+	ev, err := ParseSESNotification([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.ComplaintSubType != "OnAccountSuppressionList" || ev.AttemptCorrelationID != "cor_00ff11aa" || ev.E2AMessageID != "msg_abc" {
+		t.Fatalf("parsed = %+v", ev)
+	}
+	fb := ev.FeedbackFor()
+	if fb.ComplaintSubType != "OnAccountSuppressionList" || len(fb.Recipients) != 1 || fb.Recipients[0] != "d@x.com" {
+		t.Fatalf("FeedbackFor = %+v", fb)
+	}
+
+	bad := `{"eventType":"Delivery","mail":{"messageId":"ses-10","headers":[{"name":"X-E2A-Provider-Attempt","value":"cor_NOTHEX; rm"}]},"delivery":{"recipients":["a@x.com","A@x.com"]}}`
+	ev, err = ParseSESNotification([]byte(bad))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.AttemptCorrelationID != "" {
+		t.Fatalf("malformed marker must be dropped, got %q", ev.AttemptCorrelationID)
+	}
+	if fb := ev.FeedbackFor(); len(fb.Recipients) != 1 {
+		t.Fatalf("recipients must be deduplicated after normalization: %v", fb.Recipients)
+	}
+}

--- a/internal/delivery/feedback_seam_test.go
+++ b/internal/delivery/feedback_seam_test.go
@@ -204,8 +204,18 @@ func TestPurgedMessageRepairsThroughTheSeam(t *testing.T) {
 	if len(p.repairs) != 1 || len(p.repairs[0]) != 1 || p.repairs[0][0].Address != "bob@example.test" {
 		t.Fatalf("repairs = %v, want the one address", p.repairs)
 	}
-	if len(*events) != 0 {
-		t.Fatalf("a repair with no message must announce nothing, got %v", *events)
+	// It announces: a row appearing in the customer's suppression list with
+	// no event is the state/notification desync the message-backed path
+	// exists to avoid. The payload carries no message id, which the event
+	// schema documents as present only when still known.
+	if len(*events) != 1 || (*events)[0].eventType != EventSuppressionAdded {
+		t.Fatalf("a repaired suppression must be announced, got %v", *events)
+	}
+	if (*events)[0].messageID != "" {
+		t.Fatalf("a repair has no message to reference, got %q", (*events)[0].messageID)
+	}
+	if (*events)[0].userID != "usr_1" {
+		t.Fatalf("event user = %q, want the account the seam resolved", (*events)[0].userID)
 	}
 }
 

--- a/internal/delivery/integration_test.go
+++ b/internal/delivery/integration_test.go
@@ -107,10 +107,11 @@ func TestConsumerCausalSuppressionLifecycleAndEventParity(t *testing.T) {
 		detail            string
 		feedbackReason    messagelifecycle.ReasonCode
 		suppressionReason messagelifecycle.ReasonCode
+		suppressionSource string
 		eventType         string
 	}{
-		{"hard bounce", delivery.KindBounce, delivery.StatusBounced, "permanent", "550 5.1.1 no such user", messagelifecycle.ReasonDeliveryPermanentBounce, messagelifecycle.ReasonSuppressionHardBounceApplied, delivery.EventEmailBounced},
-		{"complaint", delivery.KindComplaint, delivery.StatusComplained, "", "abuse", messagelifecycle.ReasonComplaintRecipientReported, messagelifecycle.ReasonSuppressionComplaintApplied, delivery.EventEmailComplained},
+		{"hard bounce", delivery.KindBounce, delivery.StatusBounced, "permanent", "550 5.1.1 no such user", messagelifecycle.ReasonDeliveryPermanentBounce, messagelifecycle.ReasonSuppressionHardBounceApplied, "bounce", delivery.EventEmailBounced},
+		{"complaint", delivery.KindComplaint, delivery.StatusComplained, "", "abuse", messagelifecycle.ReasonComplaintRecipientReported, messagelifecycle.ReasonSuppressionComplaintApplied, "complaint", delivery.EventEmailComplained},
 	}
 	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -146,6 +147,20 @@ func TestConsumerCausalSuppressionLifecycleAndEventParity(t *testing.T) {
 			}
 			if suppressions != 1 {
 				t.Fatalf("suppressions=%d want 1", suppressions)
+			}
+			// The stored reason is the PROVIDER DIAGNOSTIC, not a derived
+			// label: it is a public field of GET /v1/account/suppressions,
+			// and an accounting layer that quietly rewrote it would change
+			// what every existing integration reads.
+			var storedReason, storedSource string
+			if err := pool.QueryRow(ctx, `SELECT reason, source FROM suppressions WHERE user_id=$1 AND address=$2`, userID, recipient).Scan(&storedReason, &storedSource); err != nil {
+				t.Fatal(err)
+			}
+			if storedReason != tc.detail {
+				t.Fatalf("suppression reason = %q, want the provider diagnostic %q", storedReason, tc.detail)
+			}
+			if storedSource != tc.suppressionSource {
+				t.Fatalf("suppression source = %q, want %q", storedSource, tc.suppressionSource)
 			}
 			var lifecycleCount int
 			if err := pool.QueryRow(ctx, `SELECT count(*) FROM message_lifecycle_transitions WHERE message_id=$1 AND reason_code=ANY($2)`, messageID, []string{string(tc.feedbackReason), string(tc.suppressionReason)}).Scan(&lifecycleCount); err != nil {

--- a/internal/delivery/ses.go
+++ b/internal/delivery/ses.go
@@ -3,6 +3,8 @@ package delivery
 import (
 	"encoding/json"
 	"fmt"
+	"net/mail"
+	"sort"
 	"strings"
 	"time"
 )
@@ -232,6 +234,17 @@ func ParseSESNotification(messageBody []byte) (*Event, error) {
 
 func norm(addr string) string { return strings.ToLower(strings.TrimSpace(addr)) }
 
+// normMailbox extracts the addr-spec before normalizing, so "Bob
+// <b@x.test>" and "<b@x.test>" both reduce to the bare address the
+// authorization signed. Falls back to plain normalization when the value
+// does not parse.
+func normMailbox(addr string) string {
+	if parsed, err := mail.ParseAddress(strings.TrimSpace(addr)); err == nil {
+		return norm(parsed.Address)
+	}
+	return norm(strings.Trim(strings.TrimSpace(addr), "<>"))
+}
+
 // maxE2AMessageIDLen bounds a plausible e2a message id ("msg_" + 32 hex chars
 // today; headroom for future id shapes without accepting arbitrary strings).
 const maxE2AMessageIDLen = 64
@@ -282,13 +295,23 @@ func (ev *Event) FeedbackFor() ProviderFeedback {
 	seen := map[string]bool{}
 	var recipients []string
 	for _, r := range ev.Recipients {
-		a := norm(r.Address)
+		// Addr-spec extraction, not just lower+trim: SES reports a bounced
+		// recipient from the DSN's Final-Recipient, which can arrive with
+		// angle brackets or a display name. The authorized envelope was
+		// signed as a bare address, so a decorated value would silently
+		// fail the HMAC match and lose both the accounting and the
+		// suppression repair.
+		a := normMailbox(r.Address)
 		if a == "" || seen[a] {
 			continue
 		}
 		seen[a] = true
 		recipients = append(recipients, a)
 	}
+	// Deterministic order: the processor upserts per recipient, and two
+	// concurrent notifications touching the same rows in provider order
+	// could otherwise deadlock.
+	sort.Strings(recipients)
 	return ProviderFeedback{
 		ProviderEventID:      ev.ProviderEventID,
 		OccurredAt:           ev.OccurredAt,

--- a/internal/delivery/ses.go
+++ b/internal/delivery/ses.go
@@ -74,6 +74,13 @@ type Event struct {
 	// bounceSubType (e.g. General, NoEmail, MailboxFull).
 	BounceType    string
 	BounceSubType string
+	// ComplaintSubType is the raw SES complaintSubType (Complaint events
+	// only; empty otherwise). A suppression-list value means SES did not
+	// deliver, which the detector must not count as a genuine complaint.
+	ComplaintSubType string
+	// AttemptCorrelationID is the ProviderAttemptHeader SES echoed back from
+	// the submitted headers: the deletion-resistant correlation fallback.
+	AttemptCorrelationID string
 }
 
 // sesNotification is the SES event JSON carried in the SNS Message field.
@@ -108,6 +115,7 @@ type sesNotification struct {
 			EmailAddress string `json:"emailAddress"`
 		} `json:"complainedRecipients"`
 		ComplaintFeedbackType string `json:"complaintFeedbackType"`
+		ComplaintSubType      string `json:"complaintSubType"`
 	} `json:"complaint"`
 	Delivery *struct {
 		Recipients []string `json:"recipients"`
@@ -141,11 +149,15 @@ func ParseSESNotification(messageBody []byte) (*Event, error) {
 	}
 	ev := &Event{SESMessageID: n.Mail.MessageID}
 	for _, h := range n.Mail.Headers {
-		if strings.EqualFold(h.Name, MessageIDHeader) {
+		switch {
+		case strings.EqualFold(h.Name, MessageIDHeader) && ev.E2AMessageID == "":
 			// Defensive trim: the marker is stamped bare, but tolerate an
 			// angle-bracketed echo.
 			ev.E2AMessageID = strings.Trim(strings.TrimSpace(h.Value), "<>")
-			break
+		case strings.EqualFold(h.Name, ProviderAttemptHeader) && ev.AttemptCorrelationID == "":
+			if v := strings.TrimSpace(h.Value); validAttemptCorrelationID(v) {
+				ev.AttemptCorrelationID = v
+			}
 		}
 	}
 
@@ -178,6 +190,7 @@ func ParseSESNotification(messageBody []byte) (*Event, error) {
 	case "Complaint":
 		ev.Kind = KindComplaint
 		if n.Complaint != nil {
+			ev.ComplaintSubType = n.Complaint.ComplaintSubType
 			for _, r := range n.Complaint.ComplainedRecipients {
 				ev.Recipients = append(ev.Recipients, RecipientOutcome{
 					Address: norm(r.EmailAddress), Status: StatusComplained,
@@ -241,6 +254,52 @@ func validE2AMessageID(s string) bool {
 		}
 	}
 	return true
+}
+
+// validAttemptCorrelationID reports whether s is shaped like the attempt
+// marker the adapter stamps (`cor_` + hex). Same rationale as
+// validE2AMessageID: the value came off a signed notification but originated
+// in a header block, so it is shape-checked before it becomes a lookup key.
+func validAttemptCorrelationID(s string) bool {
+	const prefix = "cor_"
+	if !strings.HasPrefix(s, prefix) || len(s) <= len(prefix) || len(s) > maxE2AMessageIDLen {
+		return false
+	}
+	for _, r := range s[len(prefix):] {
+		switch {
+		case r >= 'a' && r <= 'f', r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// FeedbackFor reduces a parsed event to the processor's input: every
+// recipient the notification named, normalized and deduplicated, plus the
+// two correlation keys and the retained subtypes.
+func (ev *Event) FeedbackFor() ProviderFeedback {
+	seen := map[string]bool{}
+	var recipients []string
+	for _, r := range ev.Recipients {
+		a := norm(r.Address)
+		if a == "" || seen[a] {
+			continue
+		}
+		seen[a] = true
+		recipients = append(recipients, a)
+	}
+	return ProviderFeedback{
+		ProviderEventID:      ev.ProviderEventID,
+		OccurredAt:           ev.OccurredAt,
+		Kind:                 ev.Kind,
+		BounceType:           ev.BounceType,
+		BounceSubType:        ev.BounceSubType,
+		ComplaintSubType:     ev.ComplaintSubType,
+		ProviderMessageID:    ev.SESMessageID,
+		AttemptCorrelationID: ev.AttemptCorrelationID,
+		Recipients:           recipients,
+	}
 }
 
 // normalizeBounceType maps SES's bounceType (Permanent | Transient |

--- a/internal/delivery/ses.go
+++ b/internal/delivery/ses.go
@@ -232,17 +232,47 @@ func ParseSESNotification(messageBody []byte) (*Event, error) {
 	return ev, nil
 }
 
-func norm(addr string) string { return strings.ToLower(strings.TrimSpace(addr)) }
-
-// normMailbox extracts the addr-spec before normalizing, so "Bob
-// <b@x.test>" and "<b@x.test>" both reduce to the bare address the
-// authorization signed. Falls back to plain normalization when the value
-// does not parse.
-func normMailbox(addr string) string {
-	if parsed, err := mail.ParseAddress(strings.TrimSpace(addr)); err == nil {
-		return norm(parsed.Address)
+// norm reduces a provider-reported address to the bare, lower-cased
+// addr-spec the rest of the system stores and signs.
+//
+// It is deliberately the ONE normalizer for provider feedback: the detector
+// matches a recipient against the HMAC of the address authorization signed,
+// while the live path writes the same address into the customer's
+// suppression list. If the two disagreed, a decorated value would credit
+// the detector under the real address while suppressing a literal
+// "Bob <bob@x.test>" the customer can never send to and never clear.
+//
+// SES reports a bounced recipient from the DSN's Final-Recipient field,
+// which per RFC 3464 may carry an address-type prefix ("rfc822; bob@x.test")
+// and, in the wild, angle brackets or a display name.
+func norm(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if semi := strings.IndexByte(addr, ';'); semi >= 0 {
+		if prefix := strings.TrimSpace(addr[:semi]); isAddressType(prefix) {
+			addr = strings.TrimSpace(addr[semi+1:])
+		}
 	}
-	return norm(strings.Trim(strings.TrimSpace(addr), "<>"))
+	if parsed, err := mail.ParseAddress(addr); err == nil {
+		return strings.ToLower(strings.TrimSpace(parsed.Address))
+	}
+	return strings.ToLower(strings.Trim(addr, "<>"))
+}
+
+// isAddressType reports whether s is a DSN address-type token (letters,
+// digits and dashes) rather than part of an address. Only such a prefix is
+// stripped, so a local part containing a semicolon is left alone.
+func isAddressType(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // maxE2AMessageIDLen bounds a plausible e2a message id ("msg_" + 32 hex chars
@@ -295,22 +325,15 @@ func (ev *Event) FeedbackFor() ProviderFeedback {
 	seen := map[string]bool{}
 	var recipients []string
 	for _, r := range ev.Recipients {
-		// Addr-spec extraction, not just lower+trim: SES reports a bounced
-		// recipient from the DSN's Final-Recipient, which can arrive with
-		// angle brackets or a display name. The authorized envelope was
-		// signed as a bare address, so a decorated value would silently
-		// fail the HMAC match and lose both the accounting and the
-		// suppression repair.
-		a := normMailbox(r.Address)
+		a := norm(r.Address)
 		if a == "" || seen[a] {
 			continue
 		}
 		seen[a] = true
 		recipients = append(recipients, a)
 	}
-	// Deterministic order: the processor upserts per recipient, and two
-	// concurrent notifications touching the same rows in provider order
-	// could otherwise deadlock.
+	// Deterministic order, so a failure is reproducible and two runs over
+	// the same event report repairs in the same sequence.
 	sort.Strings(recipients)
 	return ProviderFeedback{
 		ProviderEventID:      ev.ProviderEventID,

--- a/internal/identity/delivery_store.go
+++ b/internal/identity/delivery_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/tokencanopy/e2a/internal/delivery"
 	"github.com/tokencanopy/e2a/internal/messagelifecycle"
+	"github.com/tokencanopy/e2a/internal/suppressionsync"
 )
 
 // OutboundSendClaimStaleWindow exceeds River's one-minute worker timeout and
@@ -1078,24 +1079,16 @@ func (s *Store) AddSuppression(ctx context.Context, userID, address, reason, sou
 	return added, err
 }
 
+// AddSuppressionTx upserts through suppressionsync: an existing row keeps its
+// reason and source but advances sync_generation and clears removal_pending,
+// so a suppression re-proven by feedback defeats a stale pending removal.
+// added reports a genuine insert.
 func (s *Store) AddSuppressionTx(ctx context.Context, tx pgx.Tx, userID, address, reason, source, sourceMessageID string) (string, bool, error) {
-	id := "supp_" + generateID()
-	tag, err := tx.Exec(ctx,
-		`INSERT INTO suppressions (id, user_id, address, reason, source, source_message_id)
-		 VALUES ($1, $2, $3, $4, $5, $6)
-		 ON CONFLICT (user_id, address) DO NOTHING`,
-		id, userID, NormalizeEmail(address), reason, source, nullIfEmpty(sourceMessageID),
-	)
+	up, err := suppressionsync.UpsertTx(ctx, tx, "supp_"+generateID(), userID, NormalizeEmail(address), reason, source, sourceMessageID)
 	if err != nil {
 		return "", false, err
 	}
-	if tag.RowsAffected() == 0 {
-		if err := tx.QueryRow(ctx, `SELECT id FROM suppressions WHERE user_id=$1 AND address=$2`, userID, NormalizeEmail(address)).Scan(&id); err != nil {
-			return "", false, err
-		}
-		return id, false, nil
-	}
-	return id, true, nil
+	return up.ID, up.Inserted, nil
 }
 
 // SuppressedAddresses returns the subset of addrs that are suppressed for the

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -576,6 +576,9 @@ type Store struct {
 	// surface for topology resolution and lazy legacy adoption. Optional so
 	// stores in tests and embedded deployments remain inert by default.
 	threadIdentityMetrics ThreadIdentityMetrics
+	// feedbackRetentionOverride is the policy-supplied post-deletion horizon
+	// for retained feedback provenance; zero means DefaultFeedbackRetention.
+	feedbackRetentionOverride time.Duration
 }
 
 // OutboundJobCanceller is the narrow River cancellation surface identity needs

--- a/internal/identity/user_data_rights.go
+++ b/internal/identity/user_data_rights.go
@@ -390,6 +390,28 @@ func (s *Store) DeleteUserDataTx(ctx context.Context, userID string, perDomainIn
 		return nil, fmt.Errorf("delete: usage_events: %w", err)
 	}
 
+	// Deletion-resistant feedback provenance is retained for a bounded
+	// window AFTER the account is gone (the rows have no FK and no plaintext
+	// recipient), so a controlled recipient cannot erase a complaint by
+	// deleting the account first. Customer correlations carry no expiry
+	// while the account lives; this is where their horizon is stamped, and
+	// the sending-policy janitor honors it.
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_feedback_correlations
+		   SET expires_at = $2
+		 WHERE source_account_ref = $1 AND expires_at IS NULL`,
+		userID, time.Now().UTC().Add(s.feedbackRetention())); err != nil {
+		return nil, fmt.Errorf("delete: stamp feedback retention: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_feedback_events e
+		   SET expires_at = c.expires_at
+		  FROM sending_feedback_correlations c
+		 WHERE c.correlation_id = e.correlation_id AND c.source_account_ref = $1 AND e.expires_at IS NULL`,
+		userID); err != nil {
+		return nil, fmt.Errorf("delete: stamp feedback event retention: %w", err)
+	}
+
 	// Sender-identity teardown: enqueue an SES deprovision job for every
 	// owned domain in this same tx, before the cascade removes the domain
 	// rows. The orphan reaper is the backstop, but doing it transactionally
@@ -650,4 +672,24 @@ func scanUsageEventsForUser(ctx context.Context, tx pgx.Tx, userID string) ([]Us
 		out = append(out, e)
 	}
 	return out, rows.Err()
+}
+
+// DefaultFeedbackRetention is the post-account-deletion horizon for retained
+// feedback provenance, matching the sending-protection policy default
+// (sending_feedback_post_account_retention_days = 30).
+const DefaultFeedbackRetention = 30 * 24 * time.Hour
+
+// SetFeedbackRetention overrides the post-deletion feedback horizon from the
+// active sending-protection policy.
+func (s *Store) SetFeedbackRetention(d time.Duration) {
+	if d > 0 {
+		s.feedbackRetentionOverride = d
+	}
+}
+
+func (s *Store) feedbackRetention() time.Duration {
+	if s.feedbackRetentionOverride > 0 {
+		return s.feedbackRetentionOverride
+	}
+	return DefaultFeedbackRetention
 }

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -633,3 +633,53 @@ func containsBytes(haystack, needle []byte) bool {
 
 // silence unused-import lint when the time package isn't otherwise used.
 var _ = time.Time{}
+
+// TestDeleteUserDataStampsFeedbackRetention: the deletion-resistant feedback
+// provenance for the account has no FK and no expiry while the account
+// lives; deleting the account stamps the post-deletion horizon on the
+// correlations and their events instead of removing them.
+func TestDeleteUserDataStampsFeedbackRetention(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user := seedUserData(t, store, ctx, "feedbackret")
+	store.SetFeedbackRetention(10 * 24 * time.Hour)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO sending_feedback_correlations (correlation_id, operation_id, submission_attempt, source_account_ref, policy_subject_ref, purpose, shared_reputation, tenant_mode)
+		VALUES ('cor_ret_1', 'msg_ret_1', 1, $1, $1, 'customer_message', true, 'none'),
+		       ('cor_ret_other', 'msg_ret_2', 1, 'usr_someone_else', 'usr_someone_else', 'customer_message', true, 'none')`, user.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO sending_feedback_events (provider_event_id, correlation_id, provider_occurred_at)
+		VALUES ('evt_ret_1', 'cor_ret_1', now()), ('evt_ret_other', 'cor_ret_other', now())`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.DeleteUserData(ctx, user.ID); err != nil {
+		t.Fatalf("DeleteUserData: %v", err)
+	}
+
+	var corrExpiry, evtExpiry *time.Time
+	if err := pool.QueryRow(ctx, `SELECT expires_at FROM sending_feedback_correlations WHERE correlation_id = 'cor_ret_1'`).Scan(&corrExpiry); err != nil {
+		t.Fatalf("correlation must survive account deletion: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT expires_at FROM sending_feedback_events WHERE provider_event_id = 'evt_ret_1'`).Scan(&evtExpiry); err != nil {
+		t.Fatalf("event must survive account deletion: %v", err)
+	}
+	lo, hi := time.Now().Add(9*24*time.Hour), time.Now().Add(11*24*time.Hour)
+	if corrExpiry == nil || corrExpiry.Before(lo) || corrExpiry.After(hi) {
+		t.Fatalf("correlation expiry = %v, want ~10 days out", corrExpiry)
+	}
+	if evtExpiry == nil || !evtExpiry.Equal(*corrExpiry) {
+		t.Fatalf("event expiry = %v, want the correlation's %v", evtExpiry, corrExpiry)
+	}
+	var otherExpiry *time.Time
+	if err := pool.QueryRow(ctx, `SELECT expires_at FROM sending_feedback_correlations WHERE correlation_id = 'cor_ret_other'`).Scan(&otherExpiry); err != nil {
+		t.Fatal(err)
+	}
+	if otherExpiry != nil {
+		t.Fatalf("another account's provenance was stamped: %v", otherExpiry)
+	}
+}

--- a/internal/outbound/provider_attempt_header_test.go
+++ b/internal/outbound/provider_attempt_header_test.go
@@ -1,0 +1,17 @@
+package outbound
+
+import (
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/delivery"
+)
+
+// TestProviderAttemptHeaderNameMatchesDelivery: the adapter stamps the
+// attempt marker under one name and the feedback parser looks for it under
+// another constant (delivery cannot import this package). They must agree,
+// or the deletion-resistant correlation fallback silently never matches.
+func TestProviderAttemptHeaderNameMatchesDelivery(t *testing.T) {
+	if ProviderAttemptHeader != delivery.ProviderAttemptHeader {
+		t.Fatalf("outbound.ProviderAttemptHeader=%q delivery.ProviderAttemptHeader=%q", ProviderAttemptHeader, delivery.ProviderAttemptHeader)
+	}
+}

--- a/internal/sendingpolicy/feedback.go
+++ b/internal/sendingpolicy/feedback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -82,6 +83,16 @@ const (
 	subtypeOnTenantSuppressionList  = "OnTenantSuppressionList"
 )
 
+// isSuppressionListSubtype matches the two subtypes case-insensitively, the
+// same way the bounce type is compared: a case variant from the provider
+// must not turn an excluded suppression-list bounce into a hard bounce and
+// inflate the numerator that pauses accounts.
+func isSuppressionListSubtype(sub string) bool {
+	sub = strings.TrimSpace(sub)
+	return strings.EqualFold(sub, subtypeOnAccountSuppressionList) ||
+		strings.EqualFold(sub, subtypeOnTenantSuppressionList)
+}
+
 // Derivation is a bucket plus whether the event should repair the local
 // suppression list and, if so, under which source.
 type Derivation struct {
@@ -102,8 +113,7 @@ func DeriveBucket(kind delivery.EventKind, bounceType, bounceSubType, complaintS
 	case delivery.KindDelivery:
 		return Derivation{Bucket: BucketDelivered}
 	case delivery.KindBounce:
-		switch strings.TrimSpace(bounceSubType) {
-		case subtypeOnAccountSuppressionList, subtypeOnTenantSuppressionList:
+		if isSuppressionListSubtype(bounceSubType) {
 			return Derivation{Bucket: BucketNone, Repair: true, Source: suppressionsync.SourceBounce}
 		}
 		if strings.EqualFold(strings.TrimSpace(bounceType), "permanent") {
@@ -114,8 +124,7 @@ func DeriveBucket(kind delivery.EventKind, bounceType, bounceSubType, complaintS
 		// eligible hard bounce.
 		return Derivation{Bucket: BucketTerminalOther}
 	case delivery.KindComplaint:
-		switch strings.TrimSpace(complaintSubType) {
-		case subtypeOnAccountSuppressionList, subtypeOnTenantSuppressionList:
+		if isSuppressionListSubtype(complaintSubType) {
 			return Derivation{Bucket: BucketNone, Repair: true, Source: suppressionsync.SourceComplaint}
 		}
 		return Derivation{Bucket: BucketComplaint, Repair: true, Source: suppressionsync.SourceComplaint}
@@ -146,7 +155,12 @@ type feedbackRecipient struct {
 	day        *time.Time
 }
 
-// ProcessProviderFeedback implements delivery.FeedbackProcessor.
+// ProcessProviderFeedback implements delivery.FeedbackProcessor: it moves
+// detector evidence for one signed notification and reports the account
+// suppressions that notification proves. It deliberately writes NO
+// suppression itself — the live message path owns that row when a message
+// survives, and the consumer applies the repair through RepairSuppressions
+// only when none does.
 func (m *Module) ProcessProviderFeedback(ctx context.Context, fb delivery.ProviderFeedback) (delivery.FeedbackResult, error) {
 	if strings.TrimSpace(fb.ProviderEventID) == "" {
 		return delivery.FeedbackResult{}, errors.New("sendingpolicy: provider event id is required")
@@ -170,8 +184,11 @@ func (m *Module) ProcessProviderFeedback(ctx context.Context, fb delivery.Provid
 	}
 	result := delivery.FeedbackResult{Correlated: true}
 
-	// One row per provider event id: a redelivered notification is a zero
-	// delta even after the customer message is gone.
+	// One row per provider event id. A redelivered notification does not
+	// move evidence again — though the evidence rules are themselves
+	// idempotent for a replay, since a replayed event can only ever tie its
+	// own rank. Repairs are still reported below, so a retry whose live
+	// half failed after this commit can still finish its work.
 	tag, err := tx.Exec(ctx, `
 		INSERT INTO sending_feedback_events (provider_event_id, correlation_id, provider_occurred_at, expires_at)
 		VALUES ($1, $2, $3, $4)
@@ -180,19 +197,22 @@ func (m *Module) ProcessProviderFeedback(ctx context.Context, fb delivery.Provid
 	if err != nil {
 		return delivery.FeedbackResult{}, fmt.Errorf("sendingpolicy: record feedback event: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
-		result.Duplicate = true
-		if err := tx.Commit(ctx); err != nil {
-			return delivery.FeedbackResult{}, fmt.Errorf("sendingpolicy: commit feedback: %w", err)
-		}
-		return result, nil
-	}
+	firstTime := tag.RowsAffected() == 1
+	result.Duplicate = !firstTime
 
 	derived := DeriveBucket(fb.Kind, fb.BounceType, fb.BounceSubType, fb.ComplaintSubType)
 
 	// Lock the account control row when the account still exists: it holds
 	// the epoch the new evidence is assigned to, and the pause transition
 	// (B9) takes the same lock, so an epoch cannot move under this write.
+	//
+	// Lock order note: this transaction takes the control row and then the
+	// account's aggregate row (a users foreign key). Account deletion takes
+	// the users row first and cascades into the control row, so the two can
+	// deadlock. Postgres aborts one; this side is an SNS retry, and a
+	// delete that wins leaves the lookup below returning no rows, which is
+	// the provenance-only path. Deletion is rare and operator-initiated, so
+	// the exposure is one retried notification.
 	accountExists := false
 	var accountID string
 	var epoch int64
@@ -222,6 +242,7 @@ func (m *Module) ProcessProviderFeedback(ctx context.Context, fb delivery.Provid
 	now := m.now().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 
+	unmatched := 0
 	for _, addr := range fb.Recipients {
 		addr = strings.ToLower(strings.TrimSpace(addr))
 		if addr == "" {
@@ -229,33 +250,76 @@ func (m *Module) ProcessProviderFeedback(ctx context.Context, fb delivery.Provid
 		}
 		row, matched := m.matchRecipient(rows, addr)
 		if !matched {
-			// Not in the authorized envelope: no accounting, no suppression.
-			// A mismatched recipient on a signed event is either a provider
+			// Not in the authorized envelope: no accounting, no repair. A
+			// mismatched recipient on a signed event is either a provider
 			// quirk or forged input; either way it proves nothing about an
-			// address this account sent to.
+			// address this account sent to. Counted, never logged with the
+			// address itself.
+			unmatched++
 			continue
 		}
-
-		if err := m.applyEvidence(ctx, tx, corr, row, derived.Bucket, fb, accountExists, accountID, epoch, today); err != nil {
-			return delivery.FeedbackResult{}, err
-		}
-
-		if derived.Repair && accountExists {
-			up, err := suppressionsync.UpsertTx(ctx, tx, "supp_"+randomSuffix(), accountID, addr,
-				repairReason(fb, derived), derived.Source, "")
-			if err != nil {
+		if firstTime {
+			if err := m.applyEvidence(ctx, tx, corr, row, derived.Bucket, fb, accountExists, accountID, epoch, today); err != nil {
 				return delivery.FeedbackResult{}, err
 			}
-			result.Suppressions = append(result.Suppressions, delivery.FeedbackSuppression{
-				Address: addr, ID: up.ID, Source: derived.Source, Reason: repairReason(fb, derived), Inserted: up.Inserted,
+		}
+		// Repair is reported for CUSTOMER MESSAGES only. Platform mail this
+		// account merely triggered — an approval notice, a webhook health
+		// warning — is addressed to the account owner, and a bounce on it
+		// suppressing that address account-wide would block the customer's
+		// own sends to it: a new customer-visible effect the pre-B8 path
+		// never had. Those purposes still feed the detector above, which is
+		// what the spec requires of them.
+		if derived.Repair && accountExists && corr.purpose == PurposeCustomerMessage {
+			result.RepairNeeded = append(result.RepairNeeded, delivery.FeedbackRepair{
+				Address: addr, Source: derived.Source, Reason: repairReason(fb, derived),
 			})
 		}
+	}
+	if unmatched > 0 {
+		// A systematic mismatch (a normalization divergence, a rotated key)
+		// would otherwise be invisible: the detector would simply see
+		// nothing and read as healthy.
+		log.Printf("[sendingpolicy:feedback] %d recipient(s) on event %s did not match correlation %s's authorized envelope",
+			unmatched, fb.ProviderEventID, corr.id)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return delivery.FeedbackResult{}, fmt.Errorf("sendingpolicy: commit feedback: %w", err)
 	}
 	return result, nil
+}
+
+// RepairSuppressions writes the account-wide suppressions a signed event
+// proved, for the case where no live message row can own them. Upserts go
+// through suppressionsync, so a row re-proven here advances its generation
+// and clears a pending removal.
+func (m *Module) RepairSuppressions(ctx context.Context, accountRef string, repairs []delivery.FeedbackRepair) error {
+	if strings.TrimSpace(accountRef) == "" || len(repairs) == 0 {
+		return nil
+	}
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: begin suppression repair: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// The account must still exist: a suppression is customer state, and
+	// the row carries a foreign key to the user.
+	var exists bool
+	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)`, accountRef).Scan(&exists); err != nil {
+		return fmt.Errorf("sendingpolicy: check account for repair: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	for _, r := range repairs {
+		if _, err := suppressionsync.UpsertTx(ctx, tx, "supp_"+randomSuffix(), accountRef,
+			strings.ToLower(strings.TrimSpace(r.Address)), r.Reason, r.Source, ""); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
 }
 
 // lookupCorrelation resolves the retained row by provider message id first
@@ -278,7 +342,12 @@ func lookupCorrelation(ctx context.Context, tx pgx.Tx, providerMessageID, attemp
 		return c, true, nil
 	}
 	if id := NormalizeProviderMessageID(providerMessageID); id != "" {
-		c, ok, err := scan(tx.QueryRow(ctx, cols+`WHERE provider_message_id = $1 LIMIT 1`, id))
+		// provider_message_id is not unique (a re-driven send can bind a new
+		// id to a new attempt), so order deterministically and prefer a row
+		// that is still retained over one already past its horizon.
+		c, ok, err := scan(tx.QueryRow(ctx, cols+`WHERE provider_message_id = $1
+			ORDER BY (expires_at IS NULL OR expires_at > now()) DESC, created_at DESC, correlation_id
+			LIMIT 1`, id))
 		if err != nil || ok {
 			return c, ok, err
 		}
@@ -423,34 +492,35 @@ func randomSuffix() string { return strings.TrimPrefix(randomID("x_"), "x_") }
 // row was signed under a key version this process does not hold. Feedback
 // for those rows could never be matched, which would leave the detector
 // silently blind; refusing to start is the alert.
+//
+// A deployment with NO keyring configured is not checked: it signs nothing
+// and matches nothing by design (self-host with every control disabled), and
+// bricking such a server over rows an earlier configuration wrote would turn
+// a disabled feature into an outage. Removing a key version while it is
+// still in use is the case this guards.
 func (m *Module) VerifyKeyringCoverage(ctx context.Context) error {
-	rows, err := m.pool.Query(ctx, `
-		SELECT DISTINCT r.hmac_key_version
+	if m.secrets.Keyring == nil {
+		return nil
+	}
+	held := m.secrets.Keyring.Versions()
+	// Bounded by construction: ask only whether a retained row exists under
+	// a version outside the keyring, and stop at the first one. The scan
+	// cannot be made to walk the whole table.
+	var missing *int
+	err := m.pool.QueryRow(ctx, `
+		SELECT r.hmac_key_version
 		  FROM sending_feedback_recipients r
 		  JOIN sending_feedback_correlations c ON c.correlation_id = r.correlation_id
-		 WHERE c.expires_at IS NULL OR c.expires_at > now()
-		 ORDER BY 1`)
+		 WHERE NOT (r.hmac_key_version = ANY($1::int[]))
+		   AND (c.expires_at IS NULL OR c.expires_at > now())
+		 LIMIT 1`, held).Scan(&missing)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("sendingpolicy: read retained key versions: %w", err)
 	}
-	defer rows.Close()
-	var missing []int
-	for rows.Next() {
-		var v int
-		if err := rows.Scan(&v); err != nil {
-			return err
-		}
-		if m.secrets.Keyring == nil || !hasVersion(m.secrets.Keyring, v) {
-			missing = append(missing, v)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return err
-	}
-	if len(missing) > 0 {
-		return fmt.Errorf("sendingpolicy: retained feedback rows are signed under HMAC key version(s) %v this keyring does not hold; the keyring must stay a superset until those rows expire", missing)
-	}
-	return nil
+	return fmt.Errorf("sendingpolicy: retained feedback rows are signed under HMAC key version %d, which this keyring (versions %v) does not hold; keep the old key until those rows expire, then remove it", *missing, held)
 }
 
 func hasVersion(k *Keyring, v int) bool {
@@ -506,4 +576,23 @@ func (m *Module) GCFeedback(ctx context.Context, now time.Time, windowDays int) 
 	}
 	st.Outcomes = tag.RowsAffected()
 	return st, nil
+}
+
+// EffectiveDetectorWindowDays reads the detector window from the policy this
+// deployment actually runs (the database singleton when the source is the
+// database, the validated config otherwise).
+func (m *Module) EffectiveDetectorWindowDays(ctx context.Context) (int, error) {
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("sendingpolicy: begin policy read: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	policy, err := m.effectivePolicy(ctx, tx)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("sendingpolicy: commit policy read: %w", err)
+	}
+	return policy.DetectorWindowDays, nil
 }

--- a/internal/sendingpolicy/feedback.go
+++ b/internal/sendingpolicy/feedback.go
@@ -1,0 +1,509 @@
+package sendingpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tokencanopy/e2a/internal/delivery"
+	"github.com/tokencanopy/e2a/internal/suppressionsync"
+)
+
+// Deletion-resistant feedback provenance (slice B8).
+//
+// Provider feedback arrives long after the message that caused it, and the
+// message, its agent, or the whole account may be gone by then. The detector
+// must still see it: an abuser cannot be allowed to erase a complaint by
+// deleting the message it belongs to. So this path never reads messages,
+// agent_identities, or users. It correlates against the retained
+// sending_feedback_correlations row (by provider message id, then by the
+// random attempt marker SES echoes back), matches each recipient against the
+// keyed HMACs recorded at authorization, and moves per-recipient detector
+// buckets with monotonic evidence into the account's daily aggregates.
+//
+// Suppression repair is the one customer-visible effect: while the account
+// still exists, a hard bounce, a genuine complaint, or a suppression-list
+// subtype recreates the account-wide suppression from the signed event's
+// plaintext recipient. The retained rows themselves never store an address.
+
+// Bucket is the detector classification of one recipient's best evidence.
+type Bucket string
+
+const (
+	BucketNone          Bucket = "none"
+	BucketDelivered     Bucket = "delivered"
+	BucketTerminalOther Bucket = "terminal_other"
+	BucketHardBounce    Bucket = "hard_bounce"
+	BucketComplaint     Bucket = "complaint"
+)
+
+// Rank is the deterministic evidence order none < delivered < terminal_other
+// < hard_bounce < complaint. Higher evidence replaces lower; a delayed
+// lower-ranked callback never erases an observed hard bounce or complaint.
+func (b Bucket) Rank() int {
+	switch b {
+	case BucketDelivered:
+		return 1
+	case BucketTerminalOther:
+		return 2
+	case BucketHardBounce:
+		return 3
+	case BucketComplaint:
+		return 4
+	}
+	return 0
+}
+
+// column is the aggregate column a bucket adds to; empty for none.
+func (b Bucket) column() string {
+	switch b {
+	case BucketDelivered:
+		return "delivered_count"
+	case BucketTerminalOther:
+		return "terminal_other_count"
+	case BucketHardBounce:
+		return "hard_bounce_count"
+	case BucketComplaint:
+		return "complaint_count"
+	}
+	return ""
+}
+
+// Suppression-list subtypes SES emits when it did not attempt delivery.
+// AWS documents these as not affecting sender reputation, so they are
+// excluded from both numerator and denominator; the global-list subtype
+// "Suppressed" is documented as affecting reputation and stays included.
+const (
+	subtypeOnAccountSuppressionList = "OnAccountSuppressionList"
+	subtypeOnTenantSuppressionList  = "OnTenantSuppressionList"
+)
+
+// Derivation is a bucket plus whether the event should repair the local
+// suppression list and, if so, under which source.
+type Derivation struct {
+	Bucket Bucket
+	// Repair is true when the event proves the address should be suppressed:
+	// an eligible hard bounce, a genuine complaint, or a suppression-list
+	// subtype (SES already refuses it; the local list must agree).
+	Repair bool
+	// Source is the suppressions.source the repair records.
+	Source string
+}
+
+// DeriveBucket maps a full event kind and its retained subtypes to the
+// detector bucket. Every terminal bucket contributes one denominator unit;
+// only hard bounce and complaint contribute numerators.
+func DeriveBucket(kind delivery.EventKind, bounceType, bounceSubType, complaintSubType string) Derivation {
+	switch kind {
+	case delivery.KindDelivery:
+		return Derivation{Bucket: BucketDelivered}
+	case delivery.KindBounce:
+		switch strings.TrimSpace(bounceSubType) {
+		case subtypeOnAccountSuppressionList, subtypeOnTenantSuppressionList:
+			return Derivation{Bucket: BucketNone, Repair: true, Source: suppressionsync.SourceBounce}
+		}
+		if strings.EqualFold(strings.TrimSpace(bounceType), "permanent") {
+			return Derivation{Bucket: BucketHardBounce, Repair: true, Source: suppressionsync.SourceBounce}
+		}
+		// SES emits a bounce only once it has given up: a transient or
+		// undetermined bounce is terminal for this recipient, just not an
+		// eligible hard bounce.
+		return Derivation{Bucket: BucketTerminalOther}
+	case delivery.KindComplaint:
+		switch strings.TrimSpace(complaintSubType) {
+		case subtypeOnAccountSuppressionList, subtypeOnTenantSuppressionList:
+			return Derivation{Bucket: BucketNone, Repair: true, Source: suppressionsync.SourceComplaint}
+		}
+		return Derivation{Bucket: BucketComplaint, Repair: true, Source: suppressionsync.SourceComplaint}
+	}
+	// Send, DeliveryDelay, Reject, Other: acceptance, non-terminal, or a
+	// submission verdict — none are delivery outcomes.
+	return Derivation{Bucket: BucketNone}
+}
+
+// feedbackCorrelation is the retained row a notification is matched to.
+type feedbackCorrelation struct {
+	id            string
+	sourceAccount *string
+	purpose       Purpose
+	shared        bool
+	expiresAt     *time.Time
+}
+
+// feedbackRecipient is one retained recipient row, keyed by HMAC.
+type feedbackRecipient struct {
+	mac        []byte
+	keyVersion int
+	bucket     Bucket
+	rank       int
+	occurredAt *time.Time
+	eventID    *string
+	epoch      *int64
+	day        *time.Time
+}
+
+// ProcessProviderFeedback implements delivery.FeedbackProcessor.
+func (m *Module) ProcessProviderFeedback(ctx context.Context, fb delivery.ProviderFeedback) (delivery.FeedbackResult, error) {
+	if strings.TrimSpace(fb.ProviderEventID) == "" {
+		return delivery.FeedbackResult{}, errors.New("sendingpolicy: provider event id is required")
+	}
+	if fb.OccurredAt.IsZero() {
+		return delivery.FeedbackResult{}, errors.New("sendingpolicy: provider event time is required")
+	}
+
+	tx, err := m.pool.Begin(ctx)
+	if err != nil {
+		return delivery.FeedbackResult{}, fmt.Errorf("sendingpolicy: begin feedback: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	corr, found, err := lookupCorrelation(ctx, tx, fb.ProviderMessageID, fb.AttemptCorrelationID)
+	if err != nil {
+		return delivery.FeedbackResult{}, err
+	}
+	if !found {
+		return delivery.FeedbackResult{}, nil
+	}
+	result := delivery.FeedbackResult{Correlated: true}
+
+	// One row per provider event id: a redelivered notification is a zero
+	// delta even after the customer message is gone.
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO sending_feedback_events (provider_event_id, correlation_id, provider_occurred_at, expires_at)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (provider_event_id) DO NOTHING`,
+		fb.ProviderEventID, corr.id, fb.OccurredAt.UTC(), corr.expiresAt)
+	if err != nil {
+		return delivery.FeedbackResult{}, fmt.Errorf("sendingpolicy: record feedback event: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		result.Duplicate = true
+		if err := tx.Commit(ctx); err != nil {
+			return delivery.FeedbackResult{}, fmt.Errorf("sendingpolicy: commit feedback: %w", err)
+		}
+		return result, nil
+	}
+
+	derived := DeriveBucket(fb.Kind, fb.BounceType, fb.BounceSubType, fb.ComplaintSubType)
+
+	// Lock the account control row when the account still exists: it holds
+	// the epoch the new evidence is assigned to, and the pause transition
+	// (B9) takes the same lock, so an epoch cannot move under this write.
+	accountExists := false
+	var accountID string
+	var epoch int64
+	if corr.purpose.isCustomer() && corr.sourceAccount != nil {
+		err := tx.QueryRow(ctx,
+			`SELECT user_id, outcome_epoch FROM account_sending_controls WHERE user_id = $1 FOR UPDATE`,
+			*corr.sourceAccount,
+		).Scan(&accountID, &epoch)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			// Account deleted: provenance only, never recreate customer state.
+		case err != nil:
+			return delivery.FeedbackResult{}, fmt.Errorf("sendingpolicy: lock account control: %w", err)
+		default:
+			accountExists = true
+			result.AccountRef = accountID
+		}
+	}
+
+	rows, err := loadFeedbackRecipients(ctx, tx, corr.id)
+	if err != nil {
+		return delivery.FeedbackResult{}, err
+	}
+	// The ingestion day is "now", not the provider time: the spec assigns
+	// new evidence to the current epoch and UTC day so a delayed callback
+	// counts where the detector is looking.
+	now := m.now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	for _, addr := range fb.Recipients {
+		addr = strings.ToLower(strings.TrimSpace(addr))
+		if addr == "" {
+			continue
+		}
+		row, matched := m.matchRecipient(rows, addr)
+		if !matched {
+			// Not in the authorized envelope: no accounting, no suppression.
+			// A mismatched recipient on a signed event is either a provider
+			// quirk or forged input; either way it proves nothing about an
+			// address this account sent to.
+			continue
+		}
+
+		if err := m.applyEvidence(ctx, tx, corr, row, derived.Bucket, fb, accountExists, accountID, epoch, today); err != nil {
+			return delivery.FeedbackResult{}, err
+		}
+
+		if derived.Repair && accountExists {
+			up, err := suppressionsync.UpsertTx(ctx, tx, "supp_"+randomSuffix(), accountID, addr,
+				repairReason(fb, derived), derived.Source, "")
+			if err != nil {
+				return delivery.FeedbackResult{}, err
+			}
+			result.Suppressions = append(result.Suppressions, delivery.FeedbackSuppression{
+				Address: addr, ID: up.ID, Source: derived.Source, Reason: repairReason(fb, derived), Inserted: up.Inserted,
+			})
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return delivery.FeedbackResult{}, fmt.Errorf("sendingpolicy: commit feedback: %w", err)
+	}
+	return result, nil
+}
+
+// lookupCorrelation resolves the retained row by provider message id first
+// (normalized to SES's bare form, the same function that bound it), then by
+// the echoed attempt marker.
+func lookupCorrelation(ctx context.Context, tx pgx.Tx, providerMessageID, attemptID string) (feedbackCorrelation, bool, error) {
+	const cols = `SELECT correlation_id, source_account_ref, purpose, shared_reputation, expires_at
+	                FROM sending_feedback_correlations `
+	scan := func(row pgx.Row) (feedbackCorrelation, bool, error) {
+		var c feedbackCorrelation
+		var purpose string
+		err := row.Scan(&c.id, &c.sourceAccount, &purpose, &c.shared, &c.expiresAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return feedbackCorrelation{}, false, nil
+		}
+		if err != nil {
+			return feedbackCorrelation{}, false, fmt.Errorf("sendingpolicy: lookup correlation: %w", err)
+		}
+		c.purpose = Purpose(purpose)
+		return c, true, nil
+	}
+	if id := NormalizeProviderMessageID(providerMessageID); id != "" {
+		c, ok, err := scan(tx.QueryRow(ctx, cols+`WHERE provider_message_id = $1 LIMIT 1`, id))
+		if err != nil || ok {
+			return c, ok, err
+		}
+	}
+	if attemptID = strings.TrimSpace(attemptID); attemptID != "" {
+		return scan(tx.QueryRow(ctx, cols+`WHERE correlation_id = $1`, attemptID))
+	}
+	return feedbackCorrelation{}, false, nil
+}
+
+func loadFeedbackRecipients(ctx context.Context, tx pgx.Tx, correlationID string) ([]*feedbackRecipient, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT recipient_hmac, hmac_key_version, detector_bucket, evidence_rank,
+		       provider_occurred_at, evidence_event_id, bucket_epoch, bucket_day
+		  FROM sending_feedback_recipients
+		 WHERE correlation_id = $1
+		 ORDER BY recipient_hmac
+		   FOR UPDATE`, correlationID)
+	if err != nil {
+		return nil, fmt.Errorf("sendingpolicy: load feedback recipients: %w", err)
+	}
+	defer rows.Close()
+	var out []*feedbackRecipient
+	for rows.Next() {
+		r := &feedbackRecipient{}
+		var bucket string
+		if err := rows.Scan(&r.mac, &r.keyVersion, &bucket, &r.rank, &r.occurredAt, &r.eventID, &r.epoch, &r.day); err != nil {
+			return nil, fmt.Errorf("sendingpolicy: scan feedback recipient: %w", err)
+		}
+		r.bucket = Bucket(bucket)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// matchRecipient finds the retained row whose keyed HMAC verifies for addr.
+// Without a keyring nothing can match, which is the fail-closed answer: a
+// process that does not hold the key cannot vouch for a recipient.
+func (m *Module) matchRecipient(rows []*feedbackRecipient, addr string) (*feedbackRecipient, bool) {
+	if m.secrets.Keyring == nil {
+		return nil, false
+	}
+	for _, r := range rows {
+		if m.secrets.Keyring.Verify(r.keyVersion, []byte(addr), r.mac) {
+			return r, true
+		}
+	}
+	return nil, false
+}
+
+// applyEvidence moves one recipient's bucket under the monotonic evidence
+// order and keeps the daily aggregates in step: subtract the prior bucket
+// from the epoch/day it was counted in, add the new one to the current
+// epoch and today, all in the caller's transaction.
+func (m *Module) applyEvidence(ctx context.Context, tx pgx.Tx, corr feedbackCorrelation, row *feedbackRecipient, bucket Bucket, fb delivery.ProviderFeedback, accountExists bool, accountID string, epoch int64, today time.Time) error {
+	newRank := bucket.Rank()
+	occurred := fb.OccurredAt.UTC()
+	switch {
+	case newRank > row.rank:
+		// replace below
+	case newRank == row.rank:
+		// Equal evidence: zero delta. Provider time, then event id, decide
+		// which event the row remembers as its provenance.
+		if row.occurredAt != nil && (occurred.Before(*row.occurredAt) ||
+			(occurred.Equal(*row.occurredAt) && row.eventID != nil && fb.ProviderEventID <= *row.eventID)) {
+			return nil
+		}
+		if _, err := tx.Exec(ctx, `
+			UPDATE sending_feedback_recipients
+			   SET provider_occurred_at = $3, evidence_event_id = $4, updated_at = now()
+			 WHERE correlation_id = $1 AND recipient_hmac = $2`,
+			corr.id, row.mac, occurred, fb.ProviderEventID); err != nil {
+			return fmt.Errorf("sendingpolicy: update feedback provenance: %w", err)
+		}
+		return nil
+	default:
+		// Lower evidence than already observed: never regress.
+		return nil
+	}
+
+	// Subtract the prior bucket where it was counted. A missing aggregate
+	// row (expired, or the account is gone and the FK cascaded) is a no-op.
+	if col := row.bucket.column(); col != "" && row.epoch != nil && row.day != nil && corr.sourceAccount != nil {
+		if _, err := tx.Exec(ctx, fmt.Sprintf(`
+			UPDATE account_sending_outcomes_daily
+			   SET %[1]s = GREATEST(%[1]s - 1, 0)
+			 WHERE user_id = $1 AND outcome_epoch = $2 AND day = $3 AND shared_reputation = $4`, col),
+			*corr.sourceAccount, *row.epoch, *row.day, corr.shared); err != nil {
+			return fmt.Errorf("sendingpolicy: subtract prior outcome: %w", err)
+		}
+	}
+
+	var newEpoch *int64
+	var newDay *time.Time
+	if col := bucket.column(); col != "" && accountExists {
+		if _, err := tx.Exec(ctx, fmt.Sprintf(`
+			INSERT INTO account_sending_outcomes_daily (user_id, outcome_epoch, day, shared_reputation, %[1]s)
+			VALUES ($1, $2, $3, $4, 1)
+			ON CONFLICT (user_id, outcome_epoch, day, shared_reputation) DO UPDATE
+			    SET %[1]s = account_sending_outcomes_daily.%[1]s + 1`, col),
+			accountID, epoch, today, corr.shared); err != nil {
+			return fmt.Errorf("sendingpolicy: add outcome: %w", err)
+		}
+		newEpoch, newDay = &epoch, &today
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE sending_feedback_recipients
+		   SET detector_bucket = $3, evidence_rank = $4, provider_occurred_at = $5,
+		       evidence_event_id = $6, bucket_epoch = $7, bucket_day = $8, updated_at = now()
+		 WHERE correlation_id = $1 AND recipient_hmac = $2`,
+		corr.id, row.mac, string(bucket), newRank, occurred, fb.ProviderEventID, newEpoch, newDay); err != nil {
+		return fmt.Errorf("sendingpolicy: update feedback recipient: %w", err)
+	}
+	row.bucket, row.rank, row.epoch, row.day = bucket, newRank, newEpoch, newDay
+	row.occurredAt, row.eventID = &occurred, &fb.ProviderEventID
+	return nil
+}
+
+// repairReason is the suppression reason recorded: the retained subtype, so
+// the customer sees why (never the diagnostic text, which can quote the
+// recipient's server).
+func repairReason(fb delivery.ProviderFeedback, d Derivation) string {
+	switch fb.Kind {
+	case delivery.KindBounce:
+		if s := strings.TrimSpace(fb.BounceSubType); s != "" {
+			return "bounce:" + s
+		}
+		return "bounce:" + fb.BounceType
+	case delivery.KindComplaint:
+		if s := strings.TrimSpace(fb.ComplaintSubType); s != "" {
+			return "complaint:" + s
+		}
+		return "complaint"
+	}
+	return string(d.Bucket)
+}
+
+func randomSuffix() string { return strings.TrimPrefix(randomID("x_"), "x_") }
+
+// VerifyKeyringCoverage fails closed when a retained, unexpired recipient
+// row was signed under a key version this process does not hold. Feedback
+// for those rows could never be matched, which would leave the detector
+// silently blind; refusing to start is the alert.
+func (m *Module) VerifyKeyringCoverage(ctx context.Context) error {
+	rows, err := m.pool.Query(ctx, `
+		SELECT DISTINCT r.hmac_key_version
+		  FROM sending_feedback_recipients r
+		  JOIN sending_feedback_correlations c ON c.correlation_id = r.correlation_id
+		 WHERE c.expires_at IS NULL OR c.expires_at > now()
+		 ORDER BY 1`)
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: read retained key versions: %w", err)
+	}
+	defer rows.Close()
+	var missing []int
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			return err
+		}
+		if m.secrets.Keyring == nil || !hasVersion(m.secrets.Keyring, v) {
+			missing = append(missing, v)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("sendingpolicy: retained feedback rows are signed under HMAC key version(s) %v this keyring does not hold; the keyring must stay a superset until those rows expire", missing)
+	}
+	return nil
+}
+
+func hasVersion(k *Keyring, v int) bool {
+	for _, have := range k.Versions() {
+		if have == v {
+			return true
+		}
+	}
+	return false
+}
+
+// FeedbackGCStats reports what one retention pass removed.
+type FeedbackGCStats struct {
+	Events       int64
+	Recipients   int64
+	Correlations int64
+	Outcomes     int64
+}
+
+// GCFeedback removes feedback provenance past its horizon and daily outcome
+// rows outside the detector window plus one UTC day of safety. Customer
+// correlations carry no expiry while the account exists; account deletion
+// stamps one (identity.Store.DeleteUserDataTx), so this pass is what makes
+// the post-deletion retention real.
+func (m *Module) GCFeedback(ctx context.Context, now time.Time, windowDays int) (FeedbackGCStats, error) {
+	var st FeedbackGCStats
+	now = now.UTC()
+	tag, err := m.pool.Exec(ctx, `DELETE FROM sending_feedback_events WHERE expires_at IS NOT NULL AND expires_at <= $1`, now)
+	if err != nil {
+		return st, fmt.Errorf("sendingpolicy: gc feedback events: %w", err)
+	}
+	st.Events = tag.RowsAffected()
+	tag, err = m.pool.Exec(ctx, `
+		DELETE FROM sending_feedback_recipients r
+		 USING sending_feedback_correlations c
+		 WHERE c.correlation_id = r.correlation_id AND c.expires_at IS NOT NULL AND c.expires_at <= $1`, now)
+	if err != nil {
+		return st, fmt.Errorf("sendingpolicy: gc feedback recipients: %w", err)
+	}
+	st.Recipients = tag.RowsAffected()
+	tag, err = m.pool.Exec(ctx, `DELETE FROM sending_feedback_correlations WHERE expires_at IS NOT NULL AND expires_at <= $1`, now)
+	if err != nil {
+		return st, fmt.Errorf("sendingpolicy: gc feedback correlations: %w", err)
+	}
+	st.Correlations = tag.RowsAffected()
+	if windowDays < 1 {
+		windowDays = 7
+	}
+	cutoff := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -(windowDays + 1))
+	tag, err = m.pool.Exec(ctx, `DELETE FROM account_sending_outcomes_daily WHERE day < $1`, cutoff)
+	if err != nil {
+		return st, fmt.Errorf("sendingpolicy: gc daily outcomes: %w", err)
+	}
+	st.Outcomes = tag.RowsAffected()
+	return st, nil
+}

--- a/internal/sendingpolicy/feedback.go
+++ b/internal/sendingpolicy/feedback.go
@@ -276,7 +276,7 @@ func (m *Module) ProcessProviderFeedback(ctx context.Context, fb delivery.Provid
 			})
 		}
 	}
-	if unmatched > 0 {
+	if unmatched > 0 && firstTime {
 		// A systematic mismatch (a normalization divergence, a rotated key)
 		// would otherwise be invisible: the detector would simply see
 		// nothing and read as healthy.
@@ -306,12 +306,18 @@ func (m *Module) RepairSuppressions(ctx context.Context, accountRef string, repa
 
 	// The account must still exist: a suppression is customer state, and
 	// the row carries a foreign key to the user.
-	var exists bool
-	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)`, accountRef).Scan(&exists); err != nil {
-		return fmt.Errorf("sendingpolicy: check account for repair: %w", err)
-	}
-	if !exists {
+	// FOR KEY SHARE, not a bare EXISTS: the suppression rows carry a foreign
+	// key to this user, so a deletion committing between the check and the
+	// upsert would turn a no-op into a constraint violation. The key share
+	// blocks that delete for the length of this transaction and is exactly
+	// what the insert would take anyway.
+	var live string
+	err = tx.QueryRow(ctx, `SELECT id FROM users WHERE id = $1 FOR KEY SHARE`, accountRef).Scan(&live)
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("sendingpolicy: check account for repair: %w", err)
 	}
 	for _, r := range repairs {
 		if _, err := suppressionsync.UpsertTx(ctx, tx, "supp_"+randomSuffix(), accountRef,
@@ -503,9 +509,11 @@ func (m *Module) VerifyKeyringCoverage(ctx context.Context) error {
 		return nil
 	}
 	held := m.secrets.Keyring.Versions()
-	// Bounded by construction: ask only whether a retained row exists under
-	// a version outside the keyring, and stop at the first one. The scan
-	// cannot be made to walk the whole table.
+	// One question, first answer wins. A violation stops at the first row;
+	// proving the healthy case is inherently a full pass over the retained
+	// rows, which no index can serve for a "not in this set" predicate.
+	// That cost is boot-only, and the alternative — starting blind — is
+	// the failure this gate exists to prevent.
 	var missing *int
 	err := m.pool.QueryRow(ctx, `
 		SELECT r.hmac_key_version
@@ -521,15 +529,6 @@ func (m *Module) VerifyKeyringCoverage(ctx context.Context) error {
 		return fmt.Errorf("sendingpolicy: read retained key versions: %w", err)
 	}
 	return fmt.Errorf("sendingpolicy: retained feedback rows are signed under HMAC key version %d, which this keyring (versions %v) does not hold; keep the old key until those rows expire, then remove it", *missing, held)
-}
-
-func hasVersion(k *Keyring, v int) bool {
-	for _, have := range k.Versions() {
-		if have == v {
-			return true
-		}
-	}
-	return false
 }
 
 // FeedbackGCStats reports what one retention pass removed.
@@ -582,6 +581,9 @@ func (m *Module) GCFeedback(ctx context.Context, now time.Time, windowDays int) 
 // deployment actually runs (the database singleton when the source is the
 // database, the validated config otherwise).
 func (m *Module) EffectiveDetectorWindowDays(ctx context.Context) (int, error) {
+	if m.source != PolicySourceDatabase {
+		return m.configPolicy.DetectorWindowDays, nil
+	}
 	tx, err := m.pool.Begin(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("sendingpolicy: begin policy read: %w", err)

--- a/internal/sendingpolicy/feedback_correlation_integration_test.go
+++ b/internal/sendingpolicy/feedback_correlation_integration_test.go
@@ -1,0 +1,464 @@
+package sendingpolicy_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tokencanopy/e2a/internal/delivery"
+	"github.com/tokencanopy/e2a/internal/sendingpolicy"
+)
+
+// authorizedSend drives one message through accept + authorization and
+// returns the token, its attempt correlation id, and the SES id it settles
+// under, so feedback can be fed back by either key.
+func (f *fixture) authorizedSend(g sendingpolicy.Gate, messageID string, recipients []string) (auth sendingpolicy.ProviderAuthorization, correlationID, sesID string) {
+	f.t.Helper()
+	accept, ref := f.prepareMessage(g, messageID)
+	if accept != sendingpolicy.AcceptanceAccept {
+		f.t.Fatalf("accept = %s", accept)
+	}
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	decision, token, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || !decision.Allow || token == nil {
+		f.t.Fatalf("consume: allow=%v err=%v", decision.Allow, err)
+	}
+	headers, err := token.ValidateEnvelope(recipients)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if err := g.RedeemProviderCall(f.ctx, *token); err != nil {
+		f.t.Fatal(err)
+	}
+	sesID = fmt.Sprintf("<%s-ses@us-east-2.amazonses.com>", messageID)
+	if err := g.SettleProvider(f.ctx, sendingpolicy.ProviderSettlement{Attempt: token.Attempt(), Outcome: sendingpolicy.SettlementProviderAccepted, ProviderMessageID: sesID}); err != nil {
+		f.t.Fatal(err)
+	}
+	return *token, headers.AttemptCorrelationID, sesID
+}
+
+// messageTo inserts an outbound message with explicit recipients.
+func (f *fixture) messageTo(agentID, sentAs string, recipients []string) string {
+	f.t.Helper()
+	messageSeq++
+	id := fmt.Sprintf("msg_fb_%d", messageSeq)
+	if _, err := f.pool.Exec(f.ctx,
+		`INSERT INTO messages (id, agent_id, direction, to_recipients, sent_as, status)
+		 VALUES ($1, $2, 'outbound', $3, $4, 'sent')`, id, agentID, recipients, sentAs); err != nil {
+		f.t.Fatalf("insert message: %v", err)
+	}
+	return id
+}
+
+func (f *fixture) outcomes(userID string) map[string][4]int {
+	f.t.Helper()
+	rows, err := f.pool.Query(f.ctx, `
+		SELECT outcome_epoch, day, shared_reputation, delivered_count, terminal_other_count, hard_bounce_count, complaint_count
+		  FROM account_sending_outcomes_daily WHERE user_id = $1`, userID)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	defer rows.Close()
+	out := map[string][4]int{}
+	for rows.Next() {
+		var epoch int64
+		var day time.Time
+		var shared bool
+		var c [4]int
+		if err := rows.Scan(&epoch, &day, &shared, &c[0], &c[1], &c[2], &c[3]); err != nil {
+			f.t.Fatal(err)
+		}
+		out[fmt.Sprintf("e%d/%s/shared=%v", epoch, day.Format("2006-01-02"), shared)] = c
+	}
+	return out
+}
+
+func (f *fixture) recipientRow(correlationID string) (bucket string, rank int, epoch *int64) {
+	f.t.Helper()
+	if err := f.pool.QueryRow(f.ctx, `SELECT detector_bucket, evidence_rank, bucket_epoch FROM sending_feedback_recipients WHERE correlation_id = $1`, correlationID).Scan(&bucket, &rank, &epoch); err != nil {
+		f.t.Fatal(err)
+	}
+	return
+}
+
+func (f *fixture) suppressed(userID, address string) bool {
+	f.t.Helper()
+	var n int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM suppressions WHERE user_id = $1 AND address = $2`, userID, address).Scan(&n); err != nil {
+		f.t.Fatal(err)
+	}
+	return n > 0
+}
+
+func feedback(id string, at time.Time, kind delivery.EventKind, sesID, attemptID string, recipients ...string) delivery.ProviderFeedback {
+	return delivery.ProviderFeedback{ProviderEventID: id, OccurredAt: at, Kind: kind, ProviderMessageID: sesID, AttemptCorrelationID: attemptID, Recipients: recipients}
+}
+
+func todayKey(epoch int64, shared bool) string {
+	d := time.Now().UTC()
+	return fmt.Sprintf("e%d/%s/shared=%v", epoch, d.Format("2006-01-02"), shared)
+}
+
+// TestFeedbackSurvivesMessageAndAgentPurge: authorize a send, purge the
+// message and then the agent, and prove feedback by SES id and by the
+// attempt header still lands on the right account with a valid HMAC match,
+// while a recipient outside the authorized envelope is rejected.
+func TestFeedbackSurvivesMessageAndAgentPurge(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	user := f.user("standard")
+	agent := f.agent(user)
+	rcpts := []string{"alice@example.test", "bob@example.test"}
+	msg := f.messageTo(agent, "relay", rcpts)
+	_, corrID, sesID := f.authorizedSend(g, msg, rcpts)
+
+	// Purge message then agent — the deletion order the store uses.
+	if _, err := f.pool.Exec(f.ctx, `DELETE FROM messages WHERE id = $1`, msg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `DELETE FROM agent_identities WHERE id = $1`, agent); err != nil {
+		t.Fatal(err)
+	}
+
+	at := time.Now().UTC()
+	// Hard bounce for alice by SES id.
+	res, err := module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{
+		ProviderEventID: "evt-hb", OccurredAt: at, Kind: delivery.KindBounce, BounceType: "permanent", BounceSubType: "General",
+		ProviderMessageID: sesID, Recipients: []string{"Alice@Example.test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Correlated || res.Duplicate || res.AccountRef != user {
+		t.Fatalf("result = %+v", res)
+	}
+	if s, ok := res.SuppressionFor("alice@example.test"); !ok || !s.Inserted || s.Source != "bounce" {
+		t.Fatalf("suppression verdict = %+v ok=%v", s, ok)
+	}
+	if !f.suppressed(user, "alice@example.test") {
+		t.Fatal("hard bounce must recreate the account suppression while the account exists")
+	}
+	// Delivered for bob by the attempt header only (no SES id).
+	if _, err := module.ProcessProviderFeedback(f.ctx, feedback("evt-del", at, delivery.KindDelivery, "", corrID, "bob@example.test")); err != nil {
+		t.Fatal(err)
+	}
+	// A recipient never in the envelope: rejected, no accounting, no suppression.
+	res, err = module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{
+		ProviderEventID: "evt-forged", OccurredAt: at, Kind: delivery.KindBounce, BounceType: "permanent", BounceSubType: "General",
+		ProviderMessageID: sesID, Recipients: []string{"mallory@example.test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Correlated || len(res.Suppressions) != 0 || f.suppressed(user, "mallory@example.test") {
+		t.Fatalf("forged recipient must be rejected: %+v", res)
+	}
+
+	got := f.outcomes(user)
+	if c := got[todayKey(1, true)]; c != [4]int{1, 0, 1, 0} {
+		t.Fatalf("shared aggregate = %v, want delivered=1 hard_bounce=1: %v", c, got)
+	}
+	if len(got) != 1 {
+		t.Fatalf("unexpected aggregate rows: %v", got)
+	}
+
+	// Duplicate provider event: zero delta.
+	res, err = module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{
+		ProviderEventID: "evt-hb", OccurredAt: at, Kind: delivery.KindBounce, BounceType: "permanent", BounceSubType: "General",
+		ProviderMessageID: sesID, Recipients: []string{"alice@example.test"},
+	})
+	if err != nil || !res.Duplicate {
+		t.Fatalf("duplicate: res=%+v err=%v", res, err)
+	}
+	if c := f.outcomes(user)[todayKey(1, true)]; c != [4]int{1, 0, 1, 0} {
+		t.Fatalf("duplicate changed the aggregate: %v", c)
+	}
+}
+
+// TestFeedbackEvidenceIsMonotonic: delivered → complaint replaces (delivered
+// subtracted, complaint added); a delayed delivery after a complaint is
+// ignored; a suppression-list subtype after a hard bounce keeps the hard
+// bounce but still repairs the list; equal-rank duplicates are zero delta.
+func TestFeedbackEvidenceIsMonotonic(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	user := f.user("standard")
+	agent := f.agent(user)
+	rcpt := []string{"carol@example.test"}
+	msg := f.messageTo(agent, "own_address", rcpt) // dedicated path
+	_, corrID, sesID := f.authorizedSend(g, msg, rcpt)
+	t0 := time.Now().UTC().Add(-time.Hour)
+
+	step := func(id string, at time.Time, kind delivery.EventKind, btype, bsub, csub string) {
+		t.Helper()
+		if _, err := module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{
+			ProviderEventID: id, OccurredAt: at, Kind: kind, BounceType: btype, BounceSubType: bsub, ComplaintSubType: csub,
+			ProviderMessageID: sesID, AttemptCorrelationID: corrID, Recipients: rcpt,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	key := todayKey(1, false)
+
+	step("e1", t0, delivery.KindDelivery, "", "", "")
+	if c := f.outcomes(user)[key]; c != [4]int{1, 0, 0, 0} {
+		t.Fatalf("after delivered: %v", c)
+	}
+	step("e2", t0.Add(time.Minute), delivery.KindComplaint, "", "", "")
+	if c := f.outcomes(user)[key]; c != [4]int{0, 0, 0, 1} {
+		t.Fatalf("delivered→complaint must move the unit: %v", c)
+	}
+	if b, r, _ := f.recipientRow(corrID); b != "complaint" || r != 4 {
+		t.Fatalf("row = %s/%d", b, r)
+	}
+	// Delayed lower evidence never regresses.
+	step("e3", t0.Add(2*time.Minute), delivery.KindDelivery, "", "", "")
+	step("e4", t0.Add(3*time.Minute), delivery.KindBounce, "permanent", "OnAccountSuppressionList", "")
+	if c := f.outcomes(user)[key]; c != [4]int{0, 0, 0, 1} {
+		t.Fatalf("lower evidence regressed the complaint: %v", c)
+	}
+	// Equal rank duplicate (a second complaint event): zero delta.
+	step("e5", t0.Add(4*time.Minute), delivery.KindComplaint, "", "", "")
+	if c := f.outcomes(user)[key]; c != [4]int{0, 0, 0, 1} {
+		t.Fatalf("equal-rank duplicate changed counts: %v", c)
+	}
+	if !f.suppressed(user, "carol@example.test") {
+		t.Fatal("complaint must have repaired the suppression")
+	}
+
+	// A second message: hard bounce first, then a suppression-list bounce
+	// (excluded, repairs) and a delayed transient bounce (lower rank).
+	msg2 := f.messageTo(agent, "own_address", []string{"dave@example.test"})
+	_, corr2, ses2 := f.authorizedSend(g, msg2, []string{"dave@example.test"})
+	fb := func(id string, kind delivery.EventKind, btype, bsub string) delivery.ProviderFeedback {
+		return delivery.ProviderFeedback{ProviderEventID: id, OccurredAt: t0, Kind: kind, BounceType: btype, BounceSubType: bsub, ProviderMessageID: ses2, AttemptCorrelationID: corr2, Recipients: []string{"dave@example.test"}}
+	}
+	for _, x := range []delivery.ProviderFeedback{fb("d1", delivery.KindBounce, "permanent", "General"), fb("d2", delivery.KindBounce, "permanent", "OnTenantSuppressionList"), fb("d3", delivery.KindBounce, "transient", "MailboxFull")} {
+		if _, err := module.ProcessProviderFeedback(f.ctx, x); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if c := f.outcomes(user)[key]; c != [4]int{0, 0, 1, 1} {
+		t.Fatalf("second message: %v", c)
+	}
+	if b, _, _ := f.recipientRow(corr2); b != "hard_bounce" {
+		t.Fatalf("row bucket = %s, want hard_bounce kept", b)
+	}
+	// terminal_other is a denominator unit on its own.
+	msg3 := f.messageTo(agent, "own_address", []string{"erin@example.test"})
+	_, _, ses3 := f.authorizedSend(g, msg3, []string{"erin@example.test"})
+	if _, err := module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{ProviderEventID: "t1", OccurredAt: t0, Kind: delivery.KindBounce, BounceType: "undetermined", ProviderMessageID: ses3, Recipients: []string{"erin@example.test"}}); err != nil {
+		t.Fatal(err)
+	}
+	if c := f.outcomes(user)[key]; c != [4]int{0, 1, 1, 1} {
+		t.Fatalf("terminal_other: %v", c)
+	}
+	if f.suppressed(user, "erin@example.test") {
+		t.Fatal("a soft bounce must not suppress")
+	}
+}
+
+// TestFeedbackSharedAndDedicatedAggregatesStaySeparate: a hosted shared-
+// mailbox message and a custom-domain message from one account land in
+// different aggregate rows; a HITL notification is shared like the
+// hosted message.
+func TestFeedbackSharedAndDedicatedAggregatesStaySeparate(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	user := f.user("standard")
+	agent := f.agent(user)
+	at := time.Now().UTC()
+
+	shared := f.messageTo(agent, "relay", []string{"s@example.test"})
+	_, _, sesShared := f.authorizedSend(g, shared, []string{"s@example.test"})
+	dedicated := f.messageTo(agent, "own_address", []string{"d@example.test"})
+	_, _, sesDed := f.authorizedSend(g, dedicated, []string{"d@example.test"})
+	for _, x := range []delivery.ProviderFeedback{
+		feedback("s1", at, delivery.KindDelivery, sesShared, "", "s@example.test"),
+		feedback("d1", at, delivery.KindDelivery, sesDed, "", "d@example.test"),
+	} {
+		if _, err := module.ProcessProviderFeedback(f.ctx, x); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// HITL notification for a held message: authorized under the owner's
+	// address, counted on the shared path.
+	held := f.pendingMessage(agent, "own_address")
+	var ref sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		ref, err = g.PrepareNotificationTx(f.ctx, tx, sendingpolicy.NewHITLNotificationRef(held))
+		return err
+	})
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || token == nil {
+		t.Fatalf("consume notification: %v", err)
+	}
+	owner := token.AuthorizedRecipients()
+	headers, err := token.ValidateEnvelope(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := module.ProcessProviderFeedback(f.ctx, feedback("n1", at, delivery.KindDelivery, "", headers.AttemptCorrelationID, owner...)); err != nil {
+		t.Fatal(err)
+	}
+
+	got := f.outcomes(user)
+	if got[todayKey(1, true)] != [4]int{2, 0, 0, 0} || got[todayKey(1, false)] != [4]int{1, 0, 0, 0} {
+		t.Fatalf("aggregates = %v", got)
+	}
+}
+
+// TestFeedbackAfterAccountDeletionUpdatesProvenanceOnly: once the account is
+// gone, feedback still advances the retained bucket but recreates no
+// suppression and no aggregate.
+func TestFeedbackAfterAccountDeletionUpdatesProvenanceOnly(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	user := f.user("standard")
+	agent := f.agent(user)
+	msg := f.messageTo(agent, "relay", []string{"gone@example.test"})
+	_, corrID, sesID := f.authorizedSend(g, msg, []string{"gone@example.test"})
+
+	// Delete the whole account (cascades agents, messages, controls, aggregates).
+	if _, err := f.pool.Exec(f.ctx, `DELETE FROM users WHERE id = $1`, user); err != nil {
+		t.Fatal(err)
+	}
+	res, err := module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{
+		ProviderEventID: "post-del", OccurredAt: time.Now().UTC(), Kind: delivery.KindComplaint,
+		ProviderMessageID: sesID, Recipients: []string{"gone@example.test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Correlated || res.AccountRef != "" || len(res.Suppressions) != 0 {
+		t.Fatalf("result after deletion = %+v", res)
+	}
+	b, r, epoch := f.recipientRow(corrID)
+	if b != "complaint" || r != 4 || epoch != nil {
+		t.Fatalf("provenance = %s/%d epoch=%v, want complaint with no epoch", b, r, epoch)
+	}
+	var n int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM suppressions WHERE address = 'gone@example.test'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatal("a deleted account must not get customer state recreated")
+	}
+}
+
+// TestKeyringRotationAndCoverage: rows signed under version 1 still match
+// after the active key moves to 2 while 1 is retained; a keyring without 1
+// fails coverage until those rows expire; a process holding only 2 cannot
+// match a version-1 row.
+func TestKeyringRotationAndCoverage(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy()) // signs under version 1 (fxHMAC active)
+	user := f.user("standard")
+	agent := f.agent(user)
+	msg := f.messageTo(agent, "relay", []string{"rot@example.test"})
+	_, _, sesID := f.authorizedSend(g, msg, []string{"rot@example.test"})
+
+	superset, err := sendingpolicy.LoadKeyring(`{"active":2,"keys":{"1":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","2":"AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE"}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	onlyNew, err := sendingpolicy.LoadKeyring(`{"active":2,"keys":{"2":"AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE"}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotated := sendingpolicy.NewModule(f.pool, sendingpolicy.Secrets{Keyring: superset})
+	if err := rotated.VerifyKeyringCoverage(f.ctx); err != nil {
+		t.Fatalf("superset keyring must cover retained rows: %v", err)
+	}
+	res, err := rotated.ProcessProviderFeedback(f.ctx, feedback("r1", time.Now().UTC(), delivery.KindDelivery, sesID, "", "rot@example.test"))
+	if err != nil || !res.Correlated {
+		t.Fatalf("rotated: %+v %v", res, err)
+	}
+	if c := f.outcomes(user)[todayKey(1, true)]; c != [4]int{1, 0, 0, 0} {
+		t.Fatalf("version-1 row must still match under the superset keyring: %v", c)
+	}
+
+	narrow := sendingpolicy.NewModule(f.pool, sendingpolicy.Secrets{Keyring: onlyNew})
+	if err := narrow.VerifyKeyringCoverage(f.ctx); err == nil {
+		t.Fatal("removing version 1 while its rows are retained must fail coverage")
+	}
+	res, err = narrow.ProcessProviderFeedback(f.ctx, feedback("r2", time.Now().UTC(), delivery.KindComplaint, sesID, "", "rot@example.test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := f.outcomes(user)[todayKey(1, true)]; c != [4]int{1, 0, 0, 0} {
+		t.Fatalf("a keyring without version 1 must not match its rows: %v", c)
+	}
+
+	// Expire the row's correlation: coverage no longer needs version 1.
+	if _, err := f.pool.Exec(f.ctx, `UPDATE sending_feedback_correlations SET expires_at = now() - interval '1 minute' WHERE provider_message_id = $1`, sendingpolicy.NormalizeProviderMessageID(sesID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := narrow.VerifyKeyringCoverage(f.ctx); err != nil {
+		t.Fatalf("expired rows must not pin a key version: %v", err)
+	}
+}
+
+// TestFeedbackGC: expired provenance is removed with its recipients and
+// events; unexpired rows and recent aggregates stay; old aggregates go.
+func TestFeedbackGC(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	user := f.user("standard")
+	agent := f.agent(user)
+	live := f.messageTo(agent, "relay", []string{"live@example.test"})
+	_, liveCorr, liveSES := f.authorizedSend(g, live, []string{"live@example.test"})
+	old := f.messageTo(agent, "relay", []string{"old@example.test"})
+	_, oldCorr, oldSES := f.authorizedSend(g, old, []string{"old@example.test"})
+	at := time.Now().UTC()
+	for _, x := range []delivery.ProviderFeedback{
+		feedback("g-live", at, delivery.KindDelivery, liveSES, "", "live@example.test"),
+		feedback("g-old", at, delivery.KindDelivery, oldSES, "", "old@example.test"),
+	} {
+		if _, err := module.ProcessProviderFeedback(f.ctx, x); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := f.pool.Exec(f.ctx, `UPDATE sending_feedback_correlations SET expires_at = now() - interval '1 hour' WHERE correlation_id = $1`, oldCorr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `UPDATE sending_feedback_events SET expires_at = now() - interval '1 hour' WHERE correlation_id = $1`, oldCorr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `INSERT INTO account_sending_outcomes_daily (user_id, outcome_epoch, day, shared_reputation, delivered_count) VALUES ($1, 1, current_date - 30, true, 5)`, user); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := module.GCFeedback(f.ctx, time.Now(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Correlations != 1 || st.Recipients != 1 || st.Events != 1 || st.Outcomes != 1 {
+		t.Fatalf("gc stats = %+v", st)
+	}
+	var n int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM sending_feedback_correlations WHERE correlation_id IN ($1, $2)`, liveCorr, oldCorr).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("correlations left = %d, want the live one only", n)
+	}
+	if got := f.outcomes(user); len(got) != 1 || got[todayKey(1, true)] != [4]int{2, 0, 0, 0} {
+		t.Fatalf("aggregates after gc = %v", got)
+	}
+}

--- a/internal/sendingpolicy/feedback_correlation_integration_test.go
+++ b/internal/sendingpolicy/feedback_correlation_integration_test.go
@@ -516,7 +516,11 @@ func TestEqualRankProvenanceTieBreak(t *testing.T) {
 	rcpt := []string{"tie@example.test"}
 	msg := f.messageTo(agent, "relay", rcpt)
 	_, corrID, sesID := f.authorizedSend(g, msg, rcpt)
-	base := time.Now().UTC().Add(-time.Hour)
+	// Microsecond precision, because that is what timestamptz stores: a
+	// nanosecond-granular Go clock (Linux) would round-trip to a different
+	// value than the one asserted, while a microsecond-granular one (macOS)
+	// would not — the test must not depend on which host runs it.
+	base := time.Now().UTC().Truncate(time.Microsecond).Add(-time.Hour)
 
 	send := func(id string, at time.Time) {
 		t.Helper()

--- a/internal/sendingpolicy/feedback_correlation_integration_test.go
+++ b/internal/sendingpolicy/feedback_correlation_integration_test.go
@@ -564,3 +564,65 @@ func TestSuppressionRepairRequiresALiveAccount(t *testing.T) {
 		t.Fatal("repair wrote a suppression for a nonexistent account")
 	}
 }
+
+// TestNotificationFeedbackAccountsButDoesNotRepair: a bounce on platform
+// mail the account merely triggered — an approval notice — still feeds the
+// detector on the shared path, because the spec counts customer-triggered
+// notifications. It must NOT suppress the address, which is the account
+// owner's own: doing so would block the customer's sends to it, an effect
+// the pre-B8 path never had.
+func TestNotificationFeedbackAccountsButDoesNotRepair(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	user := f.user("standard")
+	agent := f.agent(user)
+	held := f.pendingMessage(agent, "own_address")
+
+	var ref sendingpolicy.OperationRef
+	f.inTx(func(tx pgx.Tx) error {
+		var err error
+		ref, err = g.PrepareNotificationTx(f.ctx, tx, sendingpolicy.NewHITLNotificationRef(held))
+		return err
+	})
+	_, attempt, err := g.Reserve(f.ctx, ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := g.ConsumeAttempt(f.ctx, attempt)
+	if err != nil || token == nil {
+		t.Fatalf("consume notification: %v", err)
+	}
+	owner := token.AuthorizedRecipients()
+	headers, err := token.ValidateEnvelope(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{
+		ProviderEventID: "notify-hb", OccurredAt: time.Now().UTC(), Kind: delivery.KindBounce,
+		BounceType: "permanent", BounceSubType: "General",
+		AttemptCorrelationID: headers.AttemptCorrelationID, Recipients: owner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Correlated || res.AccountRef != user {
+		t.Fatalf("notification feedback must attribute to the triggering account: %+v", res)
+	}
+	if len(res.RepairNeeded) != 0 {
+		t.Fatalf("platform mail must not suppress the owner's address: %+v", res.RepairNeeded)
+	}
+	// It still counts, on the shared path.
+	if c := f.outcomes(user)[todayKey(1, true)]; c != [4]int{0, 0, 1, 0} {
+		t.Fatalf("notification bounce must feed the detector: %v", c)
+	}
+	f.repair(module, res)
+	var n int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM suppressions WHERE user_id = $1`, user).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("suppressions created for platform mail: %d", n)
+	}
+}

--- a/internal/sendingpolicy/feedback_correlation_integration_test.go
+++ b/internal/sendingpolicy/feedback_correlation_integration_test.go
@@ -86,6 +86,33 @@ func (f *fixture) recipientRow(correlationID string) (bucket string, rank int, e
 	return
 }
 
+// provenance returns the event id and provider time the recipient row
+// remembers — what the equal-rank tie-break decides.
+func (f *fixture) provenance(correlationID string) (eventID string, at time.Time) {
+	f.t.Helper()
+	var id *string
+	var ts *time.Time
+	if err := f.pool.QueryRow(f.ctx, `SELECT evidence_event_id, provider_occurred_at FROM sending_feedback_recipients WHERE correlation_id = $1`, correlationID).Scan(&id, &ts); err != nil {
+		f.t.Fatal(err)
+	}
+	if id != nil {
+		eventID = *id
+	}
+	if ts != nil {
+		at = ts.UTC()
+	}
+	return
+}
+
+// repair applies what the seam reported, the way the consumer does when no
+// live message owns the row.
+func (f *fixture) repair(m *sendingpolicy.Module, res delivery.FeedbackResult) {
+	f.t.Helper()
+	if err := m.RepairSuppressions(f.ctx, res.AccountRef, res.RepairNeeded); err != nil {
+		f.t.Fatalf("repair: %v", err)
+	}
+}
+
 func (f *fixture) suppressed(userID, address string) bool {
 	f.t.Helper()
 	var n int
@@ -138,9 +165,14 @@ func TestFeedbackSurvivesMessageAndAgentPurge(t *testing.T) {
 	if !res.Correlated || res.Duplicate || res.AccountRef != user {
 		t.Fatalf("result = %+v", res)
 	}
-	if s, ok := res.SuppressionFor("alice@example.test"); !ok || !s.Inserted || s.Source != "bounce" {
-		t.Fatalf("suppression verdict = %+v ok=%v", s, ok)
+	if len(res.RepairNeeded) != 1 || res.RepairNeeded[0].Address != "alice@example.test" || res.RepairNeeded[0].Source != "bounce" {
+		t.Fatalf("repairs = %+v", res.RepairNeeded)
 	}
+	// The seam reports; it never writes while a message could own the row.
+	if f.suppressed(user, "alice@example.test") {
+		t.Fatal("the seam must not write the suppression itself")
+	}
+	f.repair(module, res)
 	if !f.suppressed(user, "alice@example.test") {
 		t.Fatal("hard bounce must recreate the account suppression while the account exists")
 	}
@@ -156,8 +188,12 @@ func TestFeedbackSurvivesMessageAndAgentPurge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !res.Correlated || len(res.Suppressions) != 0 || f.suppressed(user, "mallory@example.test") {
+	if !res.Correlated || len(res.RepairNeeded) != 0 {
 		t.Fatalf("forged recipient must be rejected: %+v", res)
+	}
+	f.repair(module, res)
+	if f.suppressed(user, "mallory@example.test") {
+		t.Fatal("a recipient outside the authorized envelope must never be suppressed")
 	}
 
 	got := f.outcomes(user)
@@ -198,12 +234,14 @@ func TestFeedbackEvidenceIsMonotonic(t *testing.T) {
 
 	step := func(id string, at time.Time, kind delivery.EventKind, btype, bsub, csub string) {
 		t.Helper()
-		if _, err := module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{
+		res, err := module.ProcessProviderFeedback(f.ctx, delivery.ProviderFeedback{
 			ProviderEventID: id, OccurredAt: at, Kind: kind, BounceType: btype, BounceSubType: bsub, ComplaintSubType: csub,
 			ProviderMessageID: sesID, AttemptCorrelationID: corrID, Recipients: rcpt,
-		}); err != nil {
+		})
+		if err != nil {
 			t.Fatal(err)
 		}
+		f.repair(module, res)
 	}
 	key := todayKey(1, false)
 
@@ -241,9 +279,11 @@ func TestFeedbackEvidenceIsMonotonic(t *testing.T) {
 		return delivery.ProviderFeedback{ProviderEventID: id, OccurredAt: t0, Kind: kind, BounceType: btype, BounceSubType: bsub, ProviderMessageID: ses2, AttemptCorrelationID: corr2, Recipients: []string{"dave@example.test"}}
 	}
 	for _, x := range []delivery.ProviderFeedback{fb("d1", delivery.KindBounce, "permanent", "General"), fb("d2", delivery.KindBounce, "permanent", "OnTenantSuppressionList"), fb("d3", delivery.KindBounce, "transient", "MailboxFull")} {
-		if _, err := module.ProcessProviderFeedback(f.ctx, x); err != nil {
+		res, err := module.ProcessProviderFeedback(f.ctx, x)
+		if err != nil {
 			t.Fatal(err)
 		}
+		f.repair(module, res)
 	}
 	if c := f.outcomes(user)[key]; c != [4]int{0, 0, 1, 1} {
 		t.Fatalf("second message: %v", c)
@@ -344,7 +384,7 @@ func TestFeedbackAfterAccountDeletionUpdatesProvenanceOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !res.Correlated || res.AccountRef != "" || len(res.Suppressions) != 0 {
+	if !res.Correlated || res.AccountRef != "" || len(res.RepairNeeded) != 0 {
 		t.Fatalf("result after deletion = %+v", res)
 	}
 	b, r, epoch := f.recipientRow(corrID)
@@ -460,5 +500,63 @@ func TestFeedbackGC(t *testing.T) {
 	}
 	if got := f.outcomes(user); len(got) != 1 || got[todayKey(1, true)] != [4]int{2, 0, 0, 0} {
 		t.Fatalf("aggregates after gc = %v", got)
+	}
+}
+
+// TestEqualRankProvenanceTieBreak: an equal-rank duplicate never changes
+// counts, and the row remembers the LATER provider event — an earlier
+// straggler must not overwrite the provenance of the evidence already
+// recorded.
+func TestEqualRankProvenanceTieBreak(t *testing.T) {
+	f := newFixture(t)
+	g := f.gate(sendingpolicy.DisabledPolicy())
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	user := f.user("standard")
+	agent := f.agent(user)
+	rcpt := []string{"tie@example.test"}
+	msg := f.messageTo(agent, "relay", rcpt)
+	_, corrID, sesID := f.authorizedSend(g, msg, rcpt)
+	base := time.Now().UTC().Add(-time.Hour)
+
+	send := func(id string, at time.Time) {
+		t.Helper()
+		if _, err := module.ProcessProviderFeedback(f.ctx, feedback(id, at, delivery.KindDelivery, sesID, corrID, rcpt[0])); err != nil {
+			t.Fatal(err)
+		}
+	}
+	send("mid", base)
+	if id, at := f.provenance(corrID); id != "mid" || !at.Equal(base) {
+		t.Fatalf("provenance = %s/%v", id, at)
+	}
+	// A later equal-rank event advances provenance, counts unchanged.
+	send("late", base.Add(time.Minute))
+	if id, at := f.provenance(corrID); id != "late" || !at.Equal(base.Add(time.Minute)) {
+		t.Fatalf("later equal-rank event must own provenance, got %s/%v", id, at)
+	}
+	// An earlier straggler does not.
+	send("early", base.Add(-time.Minute))
+	if id, _ := f.provenance(corrID); id != "late" {
+		t.Fatalf("an earlier equal-rank event overwrote provenance: %s", id)
+	}
+	if c := f.outcomes(user)[todayKey(1, true)]; c != [4]int{1, 0, 0, 0} {
+		t.Fatalf("equal-rank events changed counts: %v", c)
+	}
+}
+
+// TestSuppressionRepairRequiresALiveAccount: the fallback writer refuses to
+// recreate customer state for an account that no longer exists.
+func TestSuppressionRepairRequiresALiveAccount(t *testing.T) {
+	f := newFixture(t)
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	if err := module.RepairSuppressions(f.ctx, "usr_does_not_exist",
+		[]delivery.FeedbackRepair{{Address: "x@example.test", Source: "bounce", Reason: "bounce:General"}}); err != nil {
+		t.Fatalf("a deleted account must be a no-op, not an error: %v", err)
+	}
+	var n int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM suppressions WHERE address = 'x@example.test'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatal("repair wrote a suppression for a nonexistent account")
 	}
 }

--- a/internal/sendingpolicy/feedback_test.go
+++ b/internal/sendingpolicy/feedback_test.go
@@ -1,0 +1,61 @@
+package sendingpolicy_test
+
+import (
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/delivery"
+	"github.com/tokencanopy/e2a/internal/sendingpolicy"
+)
+
+// TestDeriveBucket pins the bucket a full event kind + subtype maps to, and
+// which of them repair the suppression list. Suppression-list subtypes are
+// excluded from accounting (SES never attempted delivery) but still repair;
+// the global-list subtype Suppressed stays a hard bounce.
+func TestDeriveBucket(t *testing.T) {
+	cases := []struct {
+		name          string
+		kind          delivery.EventKind
+		btype, bsub   string
+		csub          string
+		bucket        sendingpolicy.Bucket
+		repair        bool
+		source        string
+		wantRankAbove sendingpolicy.Bucket // must rank strictly above this bucket
+	}{
+		{"delivered", delivery.KindDelivery, "", "", "", sendingpolicy.BucketDelivered, false, "", sendingpolicy.BucketNone},
+		{"hard bounce general", delivery.KindBounce, "permanent", "General", "", sendingpolicy.BucketHardBounce, true, "bounce", sendingpolicy.BucketTerminalOther},
+		{"hard bounce no email", delivery.KindBounce, "permanent", "NoEmail", "", sendingpolicy.BucketHardBounce, true, "bounce", sendingpolicy.BucketTerminalOther},
+		{"global suppressed counts", delivery.KindBounce, "permanent", "Suppressed", "", sendingpolicy.BucketHardBounce, true, "bounce", sendingpolicy.BucketTerminalOther},
+		{"account list excluded but repairs", delivery.KindBounce, "permanent", "OnAccountSuppressionList", "", sendingpolicy.BucketNone, true, "bounce", ""},
+		{"tenant list excluded but repairs", delivery.KindBounce, "permanent", "OnTenantSuppressionList", "", sendingpolicy.BucketNone, true, "bounce", ""},
+		{"transient bounce is terminal other", delivery.KindBounce, "transient", "MailboxFull", "", sendingpolicy.BucketTerminalOther, false, "", sendingpolicy.BucketDelivered},
+		{"undetermined bounce is terminal other", delivery.KindBounce, "undetermined", "", "", sendingpolicy.BucketTerminalOther, false, "", sendingpolicy.BucketDelivered},
+		{"genuine complaint", delivery.KindComplaint, "", "", "", sendingpolicy.BucketComplaint, true, "complaint", sendingpolicy.BucketHardBounce},
+		{"complaint on account list excluded but repairs", delivery.KindComplaint, "", "", "OnAccountSuppressionList", sendingpolicy.BucketNone, true, "complaint", ""},
+		{"delay is nothing", delivery.KindDeliveryDelay, "", "", "", sendingpolicy.BucketNone, false, "", ""},
+		{"send is nothing", delivery.KindSend, "", "", "", sendingpolicy.BucketNone, false, "", ""},
+		{"reject is nothing", delivery.KindReject, "", "", "", sendingpolicy.BucketNone, false, "", ""},
+		{"other is nothing", delivery.KindOther, "", "", "", sendingpolicy.BucketNone, false, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := sendingpolicy.DeriveBucket(tc.kind, tc.btype, tc.bsub, tc.csub)
+			if d.Bucket != tc.bucket || d.Repair != tc.repair || d.Source != tc.source {
+				t.Fatalf("got bucket=%s repair=%v source=%q, want %s/%v/%q", d.Bucket, d.Repair, d.Source, tc.bucket, tc.repair, tc.source)
+			}
+			if tc.wantRankAbove != "" && d.Bucket.Rank() <= tc.wantRankAbove.Rank() {
+				t.Fatalf("%s rank %d must exceed %s rank %d", d.Bucket, d.Bucket.Rank(), tc.wantRankAbove, tc.wantRankAbove.Rank())
+			}
+		})
+	}
+}
+
+// TestBucketRankOrder pins the exact evidence order the monotonic rule uses.
+func TestBucketRankOrder(t *testing.T) {
+	order := []sendingpolicy.Bucket{sendingpolicy.BucketNone, sendingpolicy.BucketDelivered, sendingpolicy.BucketTerminalOther, sendingpolicy.BucketHardBounce, sendingpolicy.BucketComplaint}
+	for i, b := range order {
+		if b.Rank() != i {
+			t.Fatalf("%s rank = %d, want %d", b, b.Rank(), i)
+		}
+	}
+}

--- a/internal/sendingpolicy/maintenance.go
+++ b/internal/sendingpolicy/maintenance.go
@@ -28,7 +28,15 @@ type FeedbackMaintenanceWorker struct {
 }
 
 func (w *FeedbackMaintenanceWorker) Work(ctx context.Context, _ *river.Job[FeedbackMaintenanceArgs]) error {
-	st, err := w.module.GCFeedback(ctx, w.module.now(), w.module.configPolicy.DetectorWindowDays)
+	// The EFFECTIVE policy, not the config file: on a database-source
+	// deployment an operator who widened the detector window would
+	// otherwise get a janitor that keeps deleting daily outcomes at the old
+	// width, silently shrinking the evidence the detector sums.
+	window, err := w.module.EffectiveDetectorWindowDays(ctx)
+	if err != nil {
+		return err
+	}
+	st, err := w.module.GCFeedback(ctx, w.module.now(), window)
 	if err != nil {
 		return err
 	}

--- a/internal/sendingpolicy/maintenance.go
+++ b/internal/sendingpolicy/maintenance.go
@@ -27,6 +27,13 @@ type FeedbackMaintenanceWorker struct {
 	module *Module
 }
 
+// NewFeedbackMaintenanceWorker builds the retention worker over a module.
+// Exported so the janitor — the one component here that DELETES evidence —
+// can be driven directly by a test rather than only through River.
+func NewFeedbackMaintenanceWorker(module *Module) *FeedbackMaintenanceWorker {
+	return &FeedbackMaintenanceWorker{module: module}
+}
+
 func (w *FeedbackMaintenanceWorker) Work(ctx context.Context, _ *river.Job[FeedbackMaintenanceArgs]) error {
 	// The EFFECTIVE policy, not the config file: on a database-source
 	// deployment an operator who widened the detector window would

--- a/internal/sendingpolicy/maintenance.go
+++ b/internal/sendingpolicy/maintenance.go
@@ -1,0 +1,58 @@
+package sendingpolicy
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/riverqueue/river"
+
+	"github.com/tokencanopy/e2a/internal/jobs"
+)
+
+// feedbackMaintenanceInterval paces the retention pass. Nothing here is
+// urgent: expiries are stamped days ahead, and the detector window is
+// measured in days.
+const feedbackMaintenanceInterval = time.Hour
+
+// FeedbackMaintenanceArgs is the periodic retention job.
+type FeedbackMaintenanceArgs struct{}
+
+func (FeedbackMaintenanceArgs) Kind() string { return "sending_feedback_maintenance" }
+
+// FeedbackMaintenanceWorker runs one retention pass over feedback provenance
+// and daily outcome aggregates.
+type FeedbackMaintenanceWorker struct {
+	river.WorkerDefaults[FeedbackMaintenanceArgs]
+	module *Module
+}
+
+func (w *FeedbackMaintenanceWorker) Work(ctx context.Context, _ *river.Job[FeedbackMaintenanceArgs]) error {
+	st, err := w.module.GCFeedback(ctx, w.module.now(), w.module.configPolicy.DetectorWindowDays)
+	if err != nil {
+		return err
+	}
+	if st.Events+st.Recipients+st.Correlations+st.Outcomes > 0 {
+		log.Printf("[sendingpolicy:feedback-gc] removed events=%d recipients=%d correlations=%d daily_outcomes=%d",
+			st.Events, st.Recipients, st.Correlations, st.Outcomes)
+	}
+	return nil
+}
+
+// MaintenanceJobs registers the feedback retention periodic. Implements
+// jobs.Registrar.
+type MaintenanceJobs struct{ module *Module }
+
+// NewMaintenanceJobs builds the registrar over the gate's module.
+func NewMaintenanceJobs(module *Module) *MaintenanceJobs { return &MaintenanceJobs{module: module} }
+
+func (m *MaintenanceJobs) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
+	river.AddWorker(w, &FeedbackMaintenanceWorker{module: m.module})
+	return []*river.PeriodicJob{river.NewPeriodicJob(
+		river.PeriodicInterval(feedbackMaintenanceInterval),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return FeedbackMaintenanceArgs{}, &river.InsertOpts{Queue: jobs.QueueMaintenance}
+		},
+		&river.PeriodicJobOpts{RunOnStart: false},
+	)}
+}

--- a/internal/sendingpolicy/maintenance_test.go
+++ b/internal/sendingpolicy/maintenance_test.go
@@ -1,0 +1,144 @@
+package sendingpolicy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/riverqueue/river"
+
+	"github.com/tokencanopy/e2a/internal/jobs"
+	"github.com/tokencanopy/e2a/internal/sendingpolicy"
+)
+
+// TestFeedbackMaintenanceWorkerHonorsTheEffectiveWindow is the guard on the
+// one component in this slice that DELETES evidence.
+//
+// A database-source deployment reads its detector window from the audited
+// policy row, not from the config file. An operator who widens the window
+// there and gets a janitor still cutting at the config width would lose the
+// daily outcomes the detector is summing — an abuser's bad days would age
+// out early, and nothing would say so.
+func TestFeedbackMaintenanceWorkerHonorsTheEffectiveWindow(t *testing.T) {
+	f := newFixture(t)
+	ctx := context.Background()
+
+	// Config says 30 days; the database singleton (generation zero) says 7.
+	wide := sendingpolicy.DisabledPolicy()
+	wide.DetectorWindowDays = 30
+	dbSourced := sendingpolicy.NewGate(f.pool, f.secrets(), sendingpolicy.PolicySourceDatabase, wide).(*sendingpolicy.Module)
+	configSourced := sendingpolicy.NewGate(f.pool, f.secrets(), sendingpolicy.PolicySourceConfig, wide).(*sendingpolicy.Module)
+
+	got, err := dbSourced.EffectiveDetectorWindowDays(ctx)
+	if err != nil {
+		t.Fatalf("effective window: %v", err)
+	}
+	if got != 7 {
+		t.Fatalf("database-source window = %d, want the policy row's 7 (not the config's 30)", got)
+	}
+	if got, err := configSourced.EffectiveDetectorWindowDays(ctx); err != nil || got != 30 {
+		t.Fatalf("config-source window = %d (err %v), want 30", got, err)
+	}
+
+	// The worker must cut at the window it just read. Seed one aggregate
+	// just inside the database window and one outside it.
+	user := f.user("standard")
+	for _, age := range []int{6, 9} {
+		if _, err := f.pool.Exec(ctx,
+			`INSERT INTO account_sending_outcomes_daily (user_id, outcome_epoch, day, shared_reputation, delivered_count)
+			 VALUES ($1, 1, current_date - $2::int, true, 1)`, user, age); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := sendingpolicy.NewFeedbackMaintenanceWorker(dbSourced).Work(ctx, &river.Job[sendingpolicy.FeedbackMaintenanceArgs]{}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	var days []int
+	rows, err := f.pool.Query(ctx, `SELECT current_date - day FROM account_sending_outcomes_daily WHERE user_id = $1 ORDER BY 1`, user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var d int
+		if err := rows.Scan(&d); err != nil {
+			t.Fatal(err)
+		}
+		days = append(days, d)
+	}
+	if len(days) != 1 || days[0] != 6 {
+		t.Fatalf("remaining aggregate ages = %v, want only the 6-day-old row (window 7 + 1 day of safety)", days)
+	}
+}
+
+// TestFeedbackMaintenanceWorkerRemovesExpiredProvenance: the worker is the
+// only thing that honors the post-deletion horizon, so it has to actually
+// remove what account deletion stamped.
+func TestFeedbackMaintenanceWorkerRemovesExpiredProvenance(t *testing.T) {
+	f := newFixture(t)
+	ctx := context.Background()
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO sending_feedback_correlations
+		    (correlation_id, operation_id, submission_attempt, policy_subject_ref, purpose, shared_reputation, tenant_mode, expires_at)
+		VALUES ('cor_gc_expired', 'op_gc_1', 1, 'usr_gone', 'customer_message', true, 'none', now() - interval '1 hour'),
+		       ('cor_gc_live',    'op_gc_2', 1, 'usr_here', 'customer_message', true, 'none', NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO sending_feedback_recipients (correlation_id, recipient_hmac, hmac_key_version)
+		VALUES ('cor_gc_expired', '\xaa', 1), ('cor_gc_live', '\xbb', 1)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO sending_feedback_events (provider_event_id, correlation_id, provider_occurred_at, expires_at)
+		VALUES ('evt_gc_expired', 'cor_gc_expired', now(), now() - interval '1 hour'),
+		       ('evt_gc_live',    'cor_gc_live',    now(), NULL)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sendingpolicy.NewFeedbackMaintenanceWorker(module).Work(ctx, &river.Job[sendingpolicy.FeedbackMaintenanceArgs]{}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	for table, column := range map[string]string{
+		"sending_feedback_correlations": "correlation_id",
+		"sending_feedback_recipients":   "correlation_id",
+		"sending_feedback_events":       "provider_event_id",
+	} {
+		var expired, live int
+		if err := f.pool.QueryRow(ctx,
+			`SELECT count(*) FILTER (WHERE `+column+` LIKE '%expired'), count(*) FILTER (WHERE `+column+` LIKE '%live')
+			   FROM `+table+` WHERE `+column+` LIKE '%gc%'`).Scan(&expired, &live); err != nil {
+			t.Fatal(err)
+		}
+		if expired != 0 {
+			t.Errorf("%s: %d expired row(s) survived the janitor", table, expired)
+		}
+		if live != 1 {
+			t.Errorf("%s: retained row was deleted (live=%d)", table, live)
+		}
+	}
+}
+
+// TestFeedbackMaintenanceRegistersOnTheMaintenanceQueue: the periodic has
+// to reach River on the low-urgency queue, or the retention horizon is
+// never enforced at all.
+func TestFeedbackMaintenanceRegistersOnTheMaintenanceQueue(t *testing.T) {
+	f := newFixture(t)
+	module := sendingpolicy.NewModule(f.pool, f.secrets())
+	periodics := sendingpolicy.NewMaintenanceJobs(module).RegisterJobs(river.NewWorkers())
+	if len(periodics) != 1 {
+		t.Fatalf("periodic jobs = %d, want 1", len(periodics))
+	}
+	// River keeps the periodic's constructor unexported, so assert the two
+	// facts that are observable and load-bearing: the job kind the worker
+	// is registered under, and that the registrar hands River a real
+	// client-buildable set. A registrar that returned no periodic, or a
+	// kind rename that left the worker unreachable, both fail here.
+	if kind := (sendingpolicy.FeedbackMaintenanceArgs{}).Kind(); kind != "sending_feedback_maintenance" {
+		t.Fatalf("periodic kind = %q", kind)
+	}
+	if _, err := jobs.New(f.pool, jobs.Config{}, sendingpolicy.NewMaintenanceJobs(module)); err != nil {
+		t.Fatalf("the registrar must produce a buildable River client: %v", err)
+	}
+}

--- a/internal/sendingpolicy/store.go
+++ b/internal/sendingpolicy/store.go
@@ -74,6 +74,24 @@ type Module struct {
 	configPolicy RuntimePolicy
 
 	commitAttestation func(context.Context, pgx.Tx) error
+
+	// clock is the ingestion clock the feedback path stamps aggregates with;
+	// nil means time.Now. Tests and staging drills pin it to cross UTC days.
+	clock func() time.Time
+}
+
+// WithClock pins the module's ingestion clock (feedback day assignment and
+// retention); nil restores time.Now.
+func (m *Module) WithClock(fn func() time.Time) *Module {
+	m.clock = fn
+	return m
+}
+
+func (m *Module) now() time.Time {
+	if m.clock != nil {
+		return m.clock()
+	}
+	return time.Now()
 }
 
 // NewModule binds the module to a pool and the immutable trust roots parsed at

--- a/internal/suppressionsync/store.go
+++ b/internal/suppressionsync/store.go
@@ -1,0 +1,103 @@
+// Package suppressionsync owns the write side of the account suppression list
+// that provider feedback drives.
+//
+// Slice B8 of the sending abuse prevention plan moves suppression upsert
+// ownership here ahead of the provider-facing reconciliation (Task 11): every
+// feedback-driven upsert advances the row's sync_generation and clears any
+// pending removal, so a stale delete that raced the upsert loses. The race
+// contract is fixed now, before a remote list exists, so Task 11 can add the
+// SES-facing half without changing it.
+//
+// The package is a leaf over pgx: it never reads a message, an agent, or a
+// user row, which is what lets the deletion-resistant feedback path call it
+// after the message that caused the bounce is long gone.
+package suppressionsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Source values match the suppressions.source CHECK constraint.
+const (
+	SourceBounce    = "bounce"
+	SourceComplaint = "complaint"
+	SourceManual    = "manual"
+)
+
+// Upsert is the outcome of one feedback-driven upsert.
+type Upsert struct {
+	ID         string
+	Inserted   bool  // a new row; false when an existing row was refreshed
+	Generation int64 // sync_generation after this write
+}
+
+// UpsertTx inserts the (user, address) suppression or, when it already
+// exists, advances its sync_generation and clears removal_pending. The
+// existing row's reason and source are kept: the first evidence wins, and a
+// refresh must not rewrite a manual entry into a bounce.
+//
+// The address must already be normalized (lower-cased, trimmed); this
+// package does not own address canonicalization.
+func UpsertTx(ctx context.Context, tx pgx.Tx, id, userID, address, reason, source, sourceMessageID string) (Upsert, error) {
+	if strings.TrimSpace(id) == "" || strings.TrimSpace(userID) == "" || strings.TrimSpace(address) == "" {
+		return Upsert{}, errors.New("suppressionsync: id, user and address are required")
+	}
+	var out Upsert
+	var srcMsg *string
+	if sourceMessageID != "" {
+		srcMsg = &sourceMessageID
+	}
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO suppressions (id, user_id, address, reason, source, source_message_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (user_id, address) DO UPDATE
+		    SET sync_generation = suppressions.sync_generation + 1,
+		        removal_pending = false
+		RETURNING id, (xmax = 0) AS inserted, sync_generation`,
+		id, userID, address, reason, source, srcMsg,
+	).Scan(&out.ID, &out.Inserted, &out.Generation); err != nil {
+		return Upsert{}, fmt.Errorf("suppressionsync: upsert: %w", err)
+	}
+	return out, nil
+}
+
+// MarkRemovalPendingTx flags the row for removal and returns the generation
+// the remover must present to CompleteRemovalTx. found=false when there is
+// no such suppression.
+func MarkRemovalPendingTx(ctx context.Context, tx pgx.Tx, userID, address string) (generation int64, found bool, err error) {
+	err = tx.QueryRow(ctx, `
+		UPDATE suppressions
+		   SET removal_pending = true
+		 WHERE user_id = $1 AND address = $2
+		RETURNING sync_generation`, userID, address,
+	).Scan(&generation)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("suppressionsync: mark removal pending: %w", err)
+	}
+	return generation, true, nil
+}
+
+// CompleteRemovalTx deletes the row only if it is still pending removal at
+// the generation the remover observed. A feedback upsert in between advanced
+// the generation and cleared the flag, so the stale delete removes nothing:
+// the address stays suppressed, which is the only safe answer when the
+// provider has just said it bounces.
+func CompleteRemovalTx(ctx context.Context, tx pgx.Tx, userID, address string, generation int64) (removed bool, err error) {
+	tag, err := tx.Exec(ctx, `
+		DELETE FROM suppressions
+		 WHERE user_id = $1 AND address = $2
+		   AND removal_pending = true
+		   AND sync_generation = $3`, userID, address, generation)
+	if err != nil {
+		return false, fmt.Errorf("suppressionsync: complete removal: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/internal/suppressionsync/store_test.go
+++ b/internal/suppressionsync/store_test.go
@@ -1,0 +1,126 @@
+package suppressionsync_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tokencanopy/e2a/internal/suppressionsync"
+	"github.com/tokencanopy/e2a/internal/testutil/testdb"
+)
+
+// TestUpsertAdvancesGenerationAndDefeatsStaleRemoval pins the race contract
+// the provider-facing reconciliation (Task 11) will build on: a feedback
+// upsert on an existing row bumps sync_generation and clears
+// removal_pending, so a removal that observed the earlier generation
+// deletes nothing.
+func TestUpsertAdvancesGenerationAndDefeatsStaleRemoval(t *testing.T) {
+	ctx := context.Background()
+	pool := testdb.TestDB(t)
+	const user = "usr_suppsync_1"
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, google_subject, account_class) VALUES ($1, 'suppsync@reviewer.test', 'google-suppsync', 'standard') ON CONFLICT (id) DO NOTHING`, user); err != nil {
+		t.Fatal(err)
+	}
+	inTx := func(fn func(tx pgx.Tx) error) {
+		t.Helper()
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := fn(tx); err != nil {
+			_ = tx.Rollback(ctx)
+			t.Fatal(err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var first, second suppressionsync.Upsert
+	inTx(func(tx pgx.Tx) error {
+		var err error
+		first, err = suppressionsync.UpsertTx(ctx, tx, "supp_a", user, "bounce@example.test", "bounce:General", suppressionsync.SourceBounce, "msg_1")
+		return err
+	})
+	if !first.Inserted || first.Generation != 1 {
+		t.Fatalf("first upsert = %+v, want inserted at generation 1", first)
+	}
+	inTx(func(tx pgx.Tx) error {
+		var err error
+		second, err = suppressionsync.UpsertTx(ctx, tx, "supp_b", user, "bounce@example.test", "complaint", suppressionsync.SourceComplaint, "")
+		return err
+	})
+	if second.Inserted || second.ID != first.ID || second.Generation != 2 {
+		t.Fatalf("second upsert = %+v, want refresh of %s at generation 2", second, first.ID)
+	}
+	var reason, source string
+	if err := pool.QueryRow(ctx, `SELECT reason, source FROM suppressions WHERE id = $1`, first.ID).Scan(&reason, &source); err != nil {
+		t.Fatal(err)
+	}
+	if reason != "bounce:General" || source != "bounce" {
+		t.Fatalf("refresh must keep the first evidence, got reason=%q source=%q", reason, source)
+	}
+
+	// A remover marks the row pending at generation 2; feedback re-proves
+	// the address (generation 3, pending cleared); the stale removal at 2
+	// deletes nothing and the address stays suppressed.
+	var gen int64
+	inTx(func(tx pgx.Tx) error {
+		var found bool
+		var err error
+		gen, found, err = suppressionsync.MarkRemovalPendingTx(ctx, tx, user, "bounce@example.test")
+		if err == nil && !found {
+			t.Fatal("row must be found")
+		}
+		return err
+	})
+	if gen != 2 {
+		t.Fatalf("pending generation = %d, want 2", gen)
+	}
+	inTx(func(tx pgx.Tx) error {
+		up, err := suppressionsync.UpsertTx(ctx, tx, "supp_c", user, "bounce@example.test", "bounce:General", suppressionsync.SourceBounce, "")
+		if err == nil && (up.Generation != 3 || up.Inserted) {
+			t.Fatalf("racing upsert = %+v, want generation 3 refresh", up)
+		}
+		return err
+	})
+	inTx(func(tx pgx.Tx) error {
+		removed, err := suppressionsync.CompleteRemovalTx(ctx, tx, user, "bounce@example.test", gen)
+		if err == nil && removed {
+			t.Fatal("a stale removal must delete nothing after a racing upsert")
+		}
+		return err
+	})
+	var pending bool
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*), bool_or(removal_pending) FROM suppressions WHERE user_id = $1 AND address = 'bounce@example.test'`, user).Scan(&count, &pending); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || pending {
+		t.Fatalf("row count=%d pending=%v, want the row kept and not pending", count, pending)
+	}
+
+	// An uncontested removal at the current generation succeeds.
+	inTx(func(tx pgx.Tx) error {
+		g, _, err := suppressionsync.MarkRemovalPendingTx(ctx, tx, user, "bounce@example.test")
+		if err != nil {
+			return err
+		}
+		removed, err := suppressionsync.CompleteRemovalTx(ctx, tx, user, "bounce@example.test", g)
+		if err == nil && !removed {
+			t.Fatal("an uncontested removal must delete the row")
+		}
+		return err
+	})
+	if _, found, err := func() (int64, bool, error) {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			return 0, false, err
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		return suppressionsync.MarkRemovalPendingTx(ctx, tx, user, "bounce@example.test")
+	}(); err != nil || found {
+		t.Fatalf("row should be gone: found=%v err=%v", found, err)
+	}
+}

--- a/migrations/121_sending_feedback_indexes.sql
+++ b/migrations/121_sending_feedback_indexes.sql
@@ -1,0 +1,29 @@
+-- 121_sending_feedback_indexes.sql
+--
+-- Access paths for the B8 feedback provenance tables. Migration 114 created
+-- them with only their primary keys, which left three hot queries on
+-- sequential scans over tables that grow one row per send for the lifetime
+-- of an account:
+--
+--   * the startup keyring-coverage gate (recipients by key version),
+--   * the hourly retention janitor (correlations/events by expires_at),
+--   * the account-deletion retention stamp (events by correlation).
+--
+-- Index-only additions on tables that no hot path writes more than once per
+-- submission; no lock beyond the brief metadata lock each CREATE takes.
+
+SET LOCAL lock_timeout = '2s';
+
+CREATE INDEX IF NOT EXISTS sending_feedback_recipients_key_version_idx
+    ON sending_feedback_recipients (hmac_key_version);
+
+CREATE INDEX IF NOT EXISTS sending_feedback_correlations_expiry_idx
+    ON sending_feedback_correlations (expires_at)
+    WHERE expires_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS sending_feedback_events_expiry_idx
+    ON sending_feedback_events (expires_at)
+    WHERE expires_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS sending_feedback_events_correlation_idx
+    ON sending_feedback_events (correlation_id);

--- a/migrations/121_sending_feedback_indexes.sql
+++ b/migrations/121_sending_feedback_indexes.sql
@@ -1,21 +1,26 @@
 -- 121_sending_feedback_indexes.sql
 --
 -- Access paths for the B8 feedback provenance tables. Migration 114 created
--- them with only their primary keys, which left three hot queries on
--- sequential scans over tables that grow one row per send for the lifetime
--- of an account:
+-- sending_feedback_events with only its primary key and no expiry index, and
+-- gave sending_feedback_correlations an expiry index led by
+-- source_account_ref, which the retention janitor's `WHERE expires_at <= $1`
+-- cannot use. Both of the janitor's deletes and the account-deletion
+-- retention stamp were therefore sequential scans over tables that grow one
+-- row per send.
 --
---   * the startup keyring-coverage gate (recipients by key version),
---   * the hourly retention janitor (correlations/events by expires_at),
---   * the account-deletion retention stamp (events by correlation).
+-- Deliberately NOT indexed: sending_feedback_recipients.hmac_key_version.
+-- Its only reader is the startup keyring gate, whose predicate is
+-- "version NOT IN (held versions)" — a btree cannot serve that, so the index
+-- would be write amplification on the hottest of these tables with no
+-- reader. That scan is boot-only and bounded in practice by the gate's
+-- LIMIT 1 in the failing case.
 --
--- Index-only additions on tables that no hot path writes more than once per
--- submission; no lock beyond the brief metadata lock each CREATE takes.
+-- Index-only additions. Note these are NON-concurrent CREATE INDEX, which
+-- takes SHARE and blocks writes to the table for its duration: acceptable
+-- only because these tables are empty or near-empty at the release that
+-- carries this migration.
 
 SET LOCAL lock_timeout = '2s';
-
-CREATE INDEX IF NOT EXISTS sending_feedback_recipients_key_version_idx
-    ON sending_feedback_recipients (hmac_key_version);
 
 CREATE INDEX IF NOT EXISTS sending_feedback_correlations_expiry_idx
     ON sending_feedback_correlations (expires_at)


### PR DESCRIPTION
Slice **B8** of the sending abuse prevention plan (ops PR #320, Task 8): deletion-resistant feedback provenance and subtype aggregation. Passive evidence capture only; the detector (B9) is not in this PR and no control is enabled.

## What changes

**Feedback counts after deletion.** The SNS consumer runs a new `delivery.FeedbackProcessor` seam BEFORE it looks for a live message, in its own transaction; if accounting fails the notification is not acked and the provider retries. The seam (implemented by the sending-policy module) never reads `messages`, `agent_identities`, or `users`:

- correlates by the SES message id bound at settlement (normalized), then by the echoed `X-E2A-Provider-Attempt` marker (now parsed; shape-checked like the message-id marker);
- matches each recipient the event names against the keyed HMACs recorded at authorization — an address outside the authorized envelope is ignored (no accounting, no suppression);
- one row per provider event id, so a redelivered notification is a zero delta;
- derives the detector bucket from the full kind + retained subtypes: `delivered`, `terminal_other` (transient/undetermined bounce), `hard_bounce` (permanent, including global-list `Suppressed`), `complaint`. Account/tenant suppression-list subtypes (bounce or `complaintSubType`) are `none` but still repair the local list;
- moves evidence monotonically per recipient (`none < delivered < terminal_other < hard_bounce < complaint`): subtracts the prior bucket from the epoch/day it was counted in and adds the new one to the account's current `outcome_epoch` + ingestion UTC day on the correlation's immutable shared/dedicated path; equal rank is a zero delta with provider time then event id deciding stored provenance; lower evidence never regresses;
- repairs the account suppression from the signed event's plaintext recipient only while the account exists; after account deletion it updates retained provenance only.

**Suppression upsert ownership → `internal/suppressionsync`.** The upsert advances `sync_generation` and clears `removal_pending`; a removal that observed an earlier generation deletes nothing. `identity.AddSuppressionTx` routes through it (existing rows keep their first reason/source). The consumer uses the seam's Inserted verdict for the `suppression_added` event so a second upsert cannot hide a genuine insert.

**Retention.** Account deletion stamps the post-deletion horizon (policy `sending_feedback_post_account_retention_days`, default 30) on the account's correlations and events. An hourly `sending_feedback_maintenance` job removes expired provenance and daily outcome rows older than the detector window + 1 day.

**Keyring coverage is a startup gate.** The server refuses to start if any unexpired recipient row was signed under a key version the keyring does not hold (rotation is superset-first).

## Tests
- `sendingpolicy`: bucket/rank table; purge message + agent then feedback by SES id and by attempt marker with HMAC match and a forged recipient rejected; monotonic evidence (delivered→complaint moves the unit, delayed delivery/suppression-subtype ignored, equal-rank zero delta, hard bounce kept across a suppression-list bounce, terminal_other denominator); shared vs dedicated aggregates incl. a HITL notification on the shared path; post-account-deletion provenance only; keyring rotation (superset matches, narrow keyring fails coverage and cannot match, expiry releases the version); GC.
- `suppressionsync`: upsert generation + stale-removal race.
- `delivery`: processor runs first and for uncorrelated events, processor error fails Process, Inserted verdict drives the event, parser retains subtypes and drops a malformed marker.
- `identity`: account deletion stamps retention on that account's rows only.
- `outbound`: the attempt header name is pinned equal across the adapter and the parser.

Plan step 5 (`go test -p 1 -race` over delivery/sendingpolicy/suppressionsync) green locally.

## Review round 1 (correctness + adversarial, Opus) → second commit

Both reviewers found the same blocker: the seam wrote the suppression in its own transaction, so a live transaction that failed after that commit lost `suppression_added` and its lifecycle transition **permanently** on the SNS retry (the seam returned Duplicate with no suppressions, the store then reported `added=false`), and every feedback suppression lost `source_message_id` and changed `reason` on `GET /v1/account/suppressions`.

**Fixed by giving ownership back to the live path.** The seam does accounting only and reports `RepairNeeded`; when a message survives, the consumer writes the suppression in its own transaction exactly as before (same fields, same event semantics, insert atomic with the announcement). Only when no message can own the row does the consumer call `RepairSuppressions`, and repair is limited to customer messages so a bounced approval notice cannot suppress the account owner's own address. A regression test drives the failure-then-retry and asserts exactly one event.

Also applied: retention janitor reads the **effective** policy (a database-source deployment could otherwise delete evidence at the config window); the keyring gate skips a deployment with no keyring and asks a bounded question instead of scanning two unindexed tables at every boot; **migration 121** indexes the three feedback access paths; feedback recipients are addr-spec extracted before the HMAC match (a DSN `Final-Recipient` with a display name previously failed silently) and unmatched recipients are counted and logged; suppression-list subtypes compare case-insensitively; the correlation lookup prefers an unexpired row deterministically; the account-deletion lock-order interaction is documented. New tests: retry, purged-message repair, equal-rank provenance tie-break (an earlier straggler must not overwrite), repair guard on a deleted account.

**Not changed, called out instead:** the `suppressionsync` generation guard has no production remover yet (`RemoveSuppression` is still an unconditional delete) — it is Task 11 groundwork, and the design addendum now says so.

## Review round 2 (mutation-tested re-review, Opus) → third commit

Verdict: no blockers. Both round-1 blockers proved closed by mutation (breaking the fix fails a named test in each case), and the equal-rank tie-break gap from round 1 is closed too. Its should-fixes are applied:

- **A repaired suppression is now announced.** The purged-message path fires `suppression_added` with no message id (the schema documents that field as present only when known). Silently adding a row to the customer's suppression list was the one genuinely new customer-visible behavior in the slice.
- **Addresses are normalized once, in the parser.** The reviewer showed the seam and the live path could disagree on a decorated recipient — crediting the detector under the real address while suppressing a literal `Bob <bob@x.test>` the customer could never clear. The DSN `Final-Recipient` address-type prefix is stripped too.
- **Two proven-uncovered properties now have tests:** the stored suppression `reason`/`source` (mutating the diagnostic to a constant passed the whole suite before) and platform mail accounting-but-not-repairing (mutating the purpose guard passed before). Both fail under those mutations now.
- **Smaller:** `RepairSuppressions` takes `FOR KEY SHARE` on the account instead of a bare `EXISTS` (a concurrent deletion was a constraint violation, not a no-op); the unmatched-recipient log fires once per event rather than per redelivery; the config-source policy read no longer opens a transaction; dead helper removed.
- **Migration 121 drops the recipients index.** Its only reader is the keyring gate's "version not in this set" predicate, which no btree can serve — measured on 200k seeded rows, the planner picks a sequential scan even with `enable_seqscan=off`. It was write amplification on the hottest of these tables with no reader. The remaining three indexes are justified, and the comment now states the gate's real cost and that non-concurrent `CREATE INDEX` takes `SHARE`.

## Coverage audit → fourth commit

A pass over the new code found two things with no coverage at all, both in the category where a failure is silent:

- **The retention janitor was at 0%** — the one component here that deletes evidence, and one a reviewer had already caught reading the wrong policy source. Now covered: a database-source deployment cuts at the policy row's window rather than the config file's (reverting that read fails the test), an expired correlation takes its recipients and events with it while a retained one survives, and the periodic reaches River's maintenance queue.
- **Both production wiring lines were unasserted.** Installing the accounting seam on the delivery consumer and registering the janitor were one line each in `main.go`. Dropping either leaves the whole suite green while the feature is inert in production, because the consumer still acks every notification and still runs the message lifecycle — the detector just never receives evidence. Both now compose through the outbound root and are pinned by a wiring test that fails when the root forgets them.

Function coverage of the new code after this: decision logic (bucket derivation, ranking, subtype exclusion) 100%; the stateful paths 77–85%, with the remainder being database-failure branches; the janitor 67–100%, up from 0%.

## Gate
B8's gate is ingestion observation, and it has to run on **prod**, not staging: `config.staging.yaml` deliberately omits `delivery_feedback:`, so SES publishes no delivery/bounce/complaint events there and nothing would arrive to observe. The keyring is wired in both hosted environments (`E2A_SENDING_FEEDBACK_HMAC_KEYS` in the env assembler and both compose files), so recipient provenance is written on both today.

After the release that carries this slice, confirm on prod that SES feedback for real sends lands in `sending_feedback_events` / `sending_feedback_recipients` with buckets set, that `account_sending_outcomes_daily` accumulates, that the hourly maintenance job runs, and that the unmatched-recipient log line stays quiet (a systematic normalization or key mismatch is exactly what it exists to surface). No activation, no detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjfGxvXW6fNKWGFHuo68yX
