### PR TITLE
feat(web): allow the static export's assets to be served from a prefix

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -15,6 +15,16 @@ const withMDX = createMDX({});
 
 const nextConfig: NextConfig = {
   output: isDev ? undefined : "export",
+  // Serve the static export's own assets (/_next/*) from a prefix instead of
+  // the site root. Unset everywhere by default, so the published image, the
+  // dev server and self-hosted builds are byte-identical to before.
+  //
+  // The hosted deployment sets it when it builds the marketing pages
+  // separately from the dashboard: the two builds then have different release
+  // cadences but would otherwise both claim /_next/*, and only one of them can
+  // own that path. A self-hoster serving assets from a CDN subpath can use it
+  // the same way.
+  assetPrefix: process.env.NEXT_ASSET_PREFIX || undefined,
   turbopack: { root: repoRoot },
   pageExtensions: ["ts", "tsx", "md", "mdx"],
   ...(isDev && {


### PR DESCRIPTION
One optional config line: `assetPrefix: process.env.NEXT_ASSET_PREFIX || undefined`.

## Why

A deployment that builds this static export **more than once, at different cadences**, hits a collision: both builds emit `/_next/*` and only one of them can own that path. Concretely — serving the marketing pages (which change with copy) separately from the dashboard (which must match the deployed server version). `assetPrefix` gives one of the builds its own asset namespace.

It's also the standard way to serve a static export's assets from a CDN subpath, so it's useful to self-hosters independently of that.

## Why it's safe

Unset everywhere by default. Verified against real builds (Next 16, `output: "export"`):

- **With `NEXT_ASSET_PREFIX=/_marketing`**: every script, stylesheet and font reference becomes `/_marketing/_next/static/...`, with no bare `/_next` left in the emitted HTML.
- **With it unset**: the export is byte-identical to a build from the unmodified config — all 380 files, hash-compared — modulo two pre-existing sources of build nondeterminism: Next's random per-build ID directory (`_next/static/<id>/_buildManifest.js`) and the `<lastmod>` timestamps `sitemap.ts` stamps at build time.

`|| undefined` rather than `|| ""` is deliberate: Next maps an empty `assetPrefix` onto `basePath`, which is a different behaviour from "no prefix configured".

## No test here, on purpose

`next.config.ts` uses `import.meta`, so jest (CJS) can't load it, and reshaping the config to make it unit-testable would be a worse trade than the guard it buys. The consumer asserts it end-to-end instead: the hosted build's bundle test checks the emitted HTML actually references `/_marketing/_next/`, which fails loudly if this option is ever removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GB8rYQbBBqow6ZmZ7JdyqD