### PR TITLE
test(httpapi): pin dot-segment collapse targets at 404 on trailing slash

### DIFF
--- a/internal/httpapi/router_errors_test.go
+++ b/internal/httpapi/router_errors_test.go
@@ -246,3 +246,36 @@ func TestMagicLinkRoutesAbsentWithoutDeps(t *testing.T) {
 		t.Fatalf("legacy handler called %d times for magic-link paths", legacyCalls)
 	}
 }
+
+// #792: a dot-segment collapse resolves to a destructive route (deleteAccount,
+// deleteAgent) with a trailing slash. Pins the current safe 404 so a future
+// chi upgrade or RedirectSlashes/StripSlashes addition fails this test first.
+func TestDestructiveRouteCollapseTargetsStay404OnTrailingSlash(t *testing.T) {
+	s := New(Deps{})
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "account delete", method: http.MethodDelete, path: "/v1/account/?confirm=DELETE"},
+		{name: "agent delete", method: http.MethodDelete, path: "/v1/agents/foo%40bar.com/?confirm=DELETE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			s.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, nil))
+			if rr.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404 (a collapsed-slash hit on a destructive route); body=%q", rr.Code, rr.Body.String())
+			}
+			var env ErrorEnvelope
+			if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode envelope: %v; body=%q", err, rr.Body.String())
+			}
+			if env.Err.Code != "not_found" {
+				t.Fatalf("error.code = %q, want not_found", env.Err.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A dot-segment path collapse (`DELETE /v1/account/suppressions/..`, `DELETE /v1/agents/{email}/suppressions/..`) resolves to the destructive `deleteAccount` / `deleteAgent` routes with a trailing slash. It's safe today only because chi's root router registers no `RedirectSlashes`/`StripSlashes`/`CleanPath` middleware, so the trailing-slash form 404s: a library default the repo never asserted. This adds a regression test pinning that 404, following `router_errors_test.go`'s existing table-test pattern, so a future chi upgrade or an accidental trailing-slash middleware addition fails CI instead of silently turning the collapse into a live destructive hit.

Priority 1 from #792 (the SDK-side guard) already shipped in #909. This covers priority 2 (the router regression test). Priorities 3 (web `fetch` call-site hardening) and 4 (scaling confirmation to blast radius) are out of scope here.

## Operational risk

None, test-only change, no production code touched.

## Test plan

- [x] `go test ./internal/httpapi/...`: full package suite passes, including both new sub-tests (account, agent).
- [x] Temporarily added `root.Use(middleware.RedirectSlashes)` to confirm the new test goes red (301 instead of 404) before reverting; it catches the regression it's meant to catch.
- [x] `go vet` and `gofmt -l` clean on the changed file; `go test -cover` puts the package at 87.0%, above the 73% floor in `.testcoverage.yml`.

I ran the package suite standalone against a local Postgres container rather than through `make cover`'s full fixture wiring, so I can't speak to the coverage-gate job's exact numbers, only that this package's own floor is comfortably cleared.
