### PR TITLE
test(contract): point shared test domain at agents.localhost

### DIFF
--- a/internal/e2e/agents_create_race_e2e_test.go
+++ b/internal/e2e/agents_create_race_e2e_test.go
@@ -50,9 +50,9 @@ func TestCreateAgentConcurrentRequestsRespectMaxAgentsE2E(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			// A shared-domain address (testutil's default SharedDomain,
-			// agents.e2a.dev) needs no domain ownership/verification, so the
+			// agents.localhost) needs no domain ownership/verification, so the
 			// only thing under test is the max_agents race.
-			body := []byte(fmt.Sprintf(`{"email":"race-agent-%d@agents.e2a.dev","name":"race agent"}`, i))
+			body := []byte(fmt.Sprintf(`{"email":"race-agent-%d@agents.localhost","name":"race agent"}`, i))
 			req, err := http.NewRequest("POST", ts.HTTPServer.URL+"/v1/agents", bytes.NewReader(body))
 			if err != nil {
 				t.Errorf("build request %d: %v", i, err)

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -153,7 +153,7 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 	outboundJobs.SetEnqueuer(jobsClient)
 
 	router := mux.NewRouter()
-	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.localhost", "", false)
 	api.SetProviderSubmitter(providerSubmitter, sendingGate)
 	api.SetIdempotencyStore(idempotencyStore)
 	api.SetEnforcer(enforcer)
@@ -173,7 +173,7 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 	v1 := apiserver.New(apiserver.Params{
 		API: api, Store: store, Enforcer: enforcer, UsageStore: usageStore,
 		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
-		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
+		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.localhost",
 		PublicURL: "http://127.0.0.1", Production: false,
 		EventsEnabled:            true,
 		ManagedUnsubscribeIssuer: managedUnsubscribeIssuer,
@@ -305,7 +305,7 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 		return nil, err
 	}
 	for i := 1; i <= 3; i++ {
-		agentEmail := fmt.Sprintf("overcap-bot-%d@agents.e2a.dev", i)
+		agentEmail := fmt.Sprintf("overcap-bot-%d@agents.localhost", i)
 		if _, err := store.CreateAgentWithLimit(ctx, agentEmail, "overcap-1.test.dev", "OverCap Bot", overCapUser.ID, 0); err != nil {
 			_ = smtpServer.Close()
 			_ = httpServer.Shutdown(context.Background())

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -108,7 +108,7 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 	// Mirrors production's boot-time call (cmd/e2a/main.go): the FK on
 	// agent_identities.registered_domain needs a domains row for the shared
 	// domain before any scenario can create a slug-based agent on it. The
-	// migration seed only covers the hardcoded agents.e2a.dev row (see
+	// migration seed only covers the hardcoded customer shared domain (see
 	// EnsureSharedDomain's own doc comment), which no longer matches this
 	// harness's "agents.localhost" SharedDomain.
 	if err := store.EnsureSharedDomain(ctx, "agents.localhost"); err != nil {

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -105,6 +105,16 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 	}
 
 	store := identity.NewStore(pool)
+	// Mirrors production's boot-time call (cmd/e2a/main.go): the FK on
+	// agent_identities.registered_domain needs a domains row for the shared
+	// domain before any scenario can create a slug-based agent on it. The
+	// migration seed only covers the hardcoded agents.e2a.dev row (see
+	// EnsureSharedDomain's own doc comment), which no longer matches this
+	// harness's "agents.localhost" SharedDomain.
+	if err := store.EnsureSharedDomain(ctx, "agents.localhost"); err != nil {
+		pool.Close()
+		return nil, err
+	}
 	managedUnsubscribeIssuer, err := unsubscribe.NewIssuer(TestHMACSecret, "http://127.0.0.1", false, store)
 	if err != nil {
 		pool.Close()

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -247,7 +247,7 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 		MaxMessagesMonth: 100000, MaxStorageBytes: 1 << 40,
 	}, time.Minute)
 	idempotencyStore := idempotency.NewStore(pool)
-	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.localhost", "", false)
 	api.SetProviderSubmitter(providerSubmitter, sendingGate)
 	api.SetIdempotencyStore(idempotencyStore)
 	api.SetSubscriberStore(subscriberStore)
@@ -269,7 +269,7 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 	v1 := apiserver.New(apiserver.Params{
 		API: api, Store: store, Enforcer: enforcer, UsageStore: usageStore,
 		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
-		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
+		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.localhost",
 		PublicURL: "http://127.0.0.1", Production: false,
 		EventsEnabled: true,
 		Legacy:        router, WSHandle: wsHandler.ServeWithEmail,

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -184,7 +184,7 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 	// Mirrors production's boot-time call (cmd/e2a/main.go): the FK on
 	// agent_identities.registered_domain needs a domains row for the shared
 	// domain before any test can create a slug-based agent on it. The
-	// migration seed only covers the hardcoded agents.e2a.dev row (see
+	// migration seed only covers the hardcoded customer shared domain (see
 	// EnsureSharedDomain's own doc comment), which no longer matches this
 	// harness's "agents.localhost" SharedDomain.
 	if err := store.EnsureSharedDomain(context.Background(), "agents.localhost"); err != nil {

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -181,6 +181,15 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 	}
 
 	store := identity.NewStore(pool)
+	// Mirrors production's boot-time call (cmd/e2a/main.go): the FK on
+	// agent_identities.registered_domain needs a domains row for the shared
+	// domain before any test can create a slug-based agent on it. The
+	// migration seed only covers the hardcoded agents.e2a.dev row (see
+	// EnsureSharedDomain's own doc comment), which no longer matches this
+	// harness's "agents.localhost" SharedDomain.
+	if err := store.EnsureSharedDomain(context.Background(), "agents.localhost"); err != nil {
+		t.Fatalf("ensure shared domain: %v", err)
+	}
 	outboundCfg := &config.OutboundSMTPConfig{
 		Host:            o.outboundSMTPHost,
 		Port:            o.outboundSMTPPort,

--- a/internal/testutil/shared_domain_boundary_test.go
+++ b/internal/testutil/shared_domain_boundary_test.go
@@ -1,0 +1,50 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sharedDomainBoundaryGuardedFiles configure the contract harness's shared
+// domain (#829). AGENTS.md: an agents.e2a.dev address is a customer
+// identifier, not a safe example value; agents.localhost is approved.
+var sharedDomainBoundaryGuardedFiles = []string{
+	"internal/testutil/contract_server.go",
+	"internal/testutil/server.go",
+	"tests/contract/scenarios.yaml",
+}
+
+func TestContractHarnessDoesNotUseCustomerSharedDomain(t *testing.T) {
+	root := moduleRoot(t)
+	for _, rel := range sharedDomainBoundaryGuardedFiles {
+		raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if strings.Contains(string(raw), "agents.e2a.dev") {
+			t.Errorf("%s references agents.e2a.dev, the customer shared domain AGENTS.md forbids in test infrastructure; use agents.localhost instead", rel)
+		}
+	}
+}
+
+// moduleRoot walks up from the test's working directory to the directory
+// holding go.mod.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above the test directory")
+		}
+		dir = parent
+	}
+}

--- a/sdks/python/tests/test_contract.py
+++ b/sdks/python/tests/test_contract.py
@@ -1094,7 +1094,7 @@ def test_scheduled_send_scenario_is_self_cleaning_and_projection_complete():
     steps = {step["id"]: step for step in scenario["steps"]}
 
     assert scenario["setup"][0]["register_agent"]["email"] == (
-        "scheduled-contract-{scenario_token}@agents.e2a.dev"
+        "scheduled-contract-{scenario_token}@agents.localhost"
     )
     assert steps["schedule_send"]["body"]["send_at"] == "{future_rfc3339}"
     assert steps["schedule_send"]["expect"]["body_match"] == {
@@ -1233,7 +1233,7 @@ def _slug(prefix: str) -> str:
 @requires_contract_server
 def test_client_send_wait_sent_returns_terminal_loopback_result():
     with E2AClient(API_KEY, base_url=BASE_URL) as client:
-        email = f"{_slug('sdkc-wait')}@agents.e2a.dev"
+        email = f"{_slug('sdkc-wait')}@agents.localhost"
         client.agents.create({"email": email})
         try:
             res = client.messages.send(
@@ -1257,7 +1257,7 @@ def test_client_send_managed_unsubscribe_is_accepted_and_held():
     # deterministic accepted shape is the review hold, mirroring the
     # managed_unsubscribe_send_held step of the Go/TS scenario runner.
     with E2AClient(API_KEY, base_url=BASE_URL) as client:
-        email = f"{_slug('sdkc-unsub')}@agents.e2a.dev"
+        email = f"{_slug('sdkc-unsub')}@agents.localhost"
         client.agents.create({"email": email})
         try:
             client.agents.replace_protection(

--- a/sdks/typescript/test/v1/contract-client.test.ts
+++ b/sdks/typescript/test/v1/contract-client.test.ts
@@ -36,7 +36,7 @@ describe.skipIf(!baseUrl || !apiKey)("E2AClient contract (high-level)", () => {
   const client = new E2AClient({ apiKey: apiKey!, baseUrl: baseUrl! });
 
   it("messages.send with wait: \"sent\" returns the terminal loopback result", async () => {
-    const email = `${slug("sdkc-wait")}@agents.e2a.dev`;
+    const email = `${slug("sdkc-wait")}@agents.localhost`;
     await client.agents.create({ email });
     try {
       const res = await client.messages.send(
@@ -53,7 +53,7 @@ describe.skipIf(!baseUrl || !apiKey)("E2AClient contract (high-level)", () => {
   });
 
   it("messages.getMetrics keeps rates null without outward traffic and numeric with it", async () => {
-    const email = `${slug("sdkc-metrics")}@agents.e2a.dev`;
+    const email = `${slug("sdkc-metrics")}@agents.localhost`;
     await client.agents.create({ email });
     try {
       // A brand-new agent has no traffic. Every rate must come back null, not
@@ -114,7 +114,7 @@ describe.skipIf(!baseUrl || !apiKey)("E2AClient contract (high-level)", () => {
   });
 
   it("account.metrics rolls up every agent and can break down by agent", async () => {
-    const email = `${slug("sdkc-acct")}@agents.e2a.dev`;
+    const email = `${slug("sdkc-acct")}@agents.localhost`;
     await client.agents.create({ email });
     try {
       await client.messages.send(
@@ -144,7 +144,7 @@ describe.skipIf(!baseUrl || !apiKey)("E2AClient contract (high-level)", () => {
   });
 
   it("agents.delete with permanent: true removes the agent immediately", async () => {
-    const email = `${slug("sdkc-del")}@agents.e2a.dev`;
+    const email = `${slug("sdkc-del")}@agents.localhost`;
     await client.agents.create({ email });
 
     const receipt = await client.agents.delete(email, { permanent: true });
@@ -179,7 +179,7 @@ describe.skipIf(!baseUrl || !apiKey)("E2AClient contract (high-level)", () => {
     // on update the stored validator never matches "undefined", and a
     // conditional request never creates a first enrolment. Only a live server
     // can prove the header truly stays off the wire end to end.
-    const email = `${slug("sdkc-ifm")}@agents.e2a.dev`;
+    const email = `${slug("sdkc-ifm")}@agents.localhost`;
     const address = `${slug("sdkc-ifm-c")}@fund.vc`;
     await client.agents.create({ email });
     try {

--- a/sdks/typescript/test/v1/contract.test.ts
+++ b/sdks/typescript/test/v1/contract.test.ts
@@ -208,7 +208,7 @@ it("keeps the scheduled-send scenario self-cleaning and projection-complete", ()
   );
   expect(scenario).toBeDefined();
   expect(scenario!.setup?.[0]?.register_agent?.email).toBe(
-    "scheduled-contract-{scenario_token}@agents.e2a.dev",
+    "scheduled-contract-{scenario_token}@agents.localhost",
   );
 
   const steps = new Map(scenario!.steps.map((step) => [step.id, step]));

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -995,7 +995,7 @@ scenarios:
       immediately rather than waiting for the future instant.
     setup:
       - register_agent:
-          email: scheduled-contract-{scenario_token}@agents.e2a.dev
+          email: scheduled-contract-{scenario_token}@agents.localhost
     steps:
       - id: schedule_send
         action: request
@@ -1084,7 +1084,7 @@ scenarios:
       through with delivery_status=accepted.
     setup:
       - register_agent:
-          email: sched-hold-{scenario_token}@agents.e2a.dev
+          email: sched-hold-{scenario_token}@agents.localhost
     steps:
       - id: enable_outbound_review
         # Empty-allowlist outbound review gate → every recipient is held for review.
@@ -1176,7 +1176,7 @@ scenarios:
       API alone cannot seed one; runners without store access skip this).
     setup:
       - register_agent:
-          email: scheduled-reply-{scenario_token}@agents.e2a.dev
+          email: scheduled-reply-{scenario_token}@agents.localhost
       - inject_message:
           agent_email: "{agent_email}"
           from: alice@example.net
@@ -1263,7 +1263,7 @@ scenarios:
       runners without store access skip this).
     setup:
       - register_agent:
-          email: scheduled-forward-{scenario_token}@agents.e2a.dev
+          email: scheduled-forward-{scenario_token}@agents.localhost
       - inject_message:
           agent_email: "{agent_email}"
           from: alice@example.net
@@ -1353,7 +1353,7 @@ scenarios:
       scheduled_reply_fields; runners without store access skip this).
     setup:
       - register_agent:
-          email: scheduled-validation-{scenario_token}@agents.e2a.dev
+          email: scheduled-validation-{scenario_token}@agents.localhost
       - inject_message:
           agent_email: "{agent_email}"
           from: alice@example.net
@@ -1453,7 +1453,7 @@ scenarios:
       runners alike instead of being store-seeded and skipped in TS/Python.
     setup:
       - register_agent:
-          email: bot-reply-to-{scenario_token}@agents.e2a.dev
+          email: bot-reply-to-{scenario_token}@agents.localhost
     steps:
       - id: send_reply_to_array
         action: request
@@ -2279,11 +2279,11 @@ scenarios:
         path: /v1/agents
         auth_override: "Bearer {capped_api_key}"
         body:
-          email: capped-bot-{scenario_token}@agents.e2a.dev
+          email: capped-bot-{scenario_token}@agents.localhost
         expect:
           status: 201
           body_match:
-            email: capped-bot-{scenario_token}@agents.e2a.dev
+            email: capped-bot-{scenario_token}@agents.localhost
 
       - id: second_agent_fits_the_cap
         action: request
@@ -2291,7 +2291,7 @@ scenarios:
         path: /v1/agents
         auth_override: "Bearer {capped_api_key}"
         body:
-          email: capped-bot-2-{scenario_token}@agents.e2a.dev
+          email: capped-bot-2-{scenario_token}@agents.localhost
         expect:
           status: 201
 
@@ -2301,7 +2301,7 @@ scenarios:
         path: /v1/agents
         auth_override: "Bearer {capped_api_key}"
         body:
-          email: capped-bot-3-{scenario_token}@agents.e2a.dev
+          email: capped-bot-3-{scenario_token}@agents.localhost
         expect:
           status: 402
           body_match:
@@ -2317,7 +2317,7 @@ scenarios:
       - id: agent_slot_frees_on_delete
         action: request
         method: DELETE
-        path: /v1/agents/capped-bot-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        path: /v1/agents/capped-bot-{scenario_token}@agents.localhost?confirm=DELETE&permanent=true
         auth_override: "Bearer {capped_api_key}"
         expect:
           status: 200
@@ -2330,7 +2330,7 @@ scenarios:
         path: /v1/agents
         auth_override: "Bearer {capped_api_key}"
         body:
-          email: capped-bot-3-{scenario_token}@agents.e2a.dev
+          email: capped-bot-3-{scenario_token}@agents.localhost
         expect:
           status: 201
 
@@ -2349,19 +2349,19 @@ scenarios:
       - id: delete_agent_1
         action: request
         method: DELETE
-        path: /v1/agents/capped-bot-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        path: /v1/agents/capped-bot-{scenario_token}@agents.localhost?confirm=DELETE&permanent=true
         auth_override: "Bearer {capped_api_key}"
 
       - id: delete_agent_2
         action: request
         method: DELETE
-        path: /v1/agents/capped-bot-2-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        path: /v1/agents/capped-bot-2-{scenario_token}@agents.localhost?confirm=DELETE&permanent=true
         auth_override: "Bearer {capped_api_key}"
 
       - id: delete_agent_3
         action: request
         method: DELETE
-        path: /v1/agents/capped-bot-3-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        path: /v1/agents/capped-bot-3-{scenario_token}@agents.localhost?confirm=DELETE&permanent=true
         auth_override: "Bearer {capped_api_key}"
 
       - id: delete_domain
@@ -2407,7 +2407,7 @@ scenarios:
         path: /v1/agents
         auth_override: "Bearer {overcap_api_key}"
         body:
-          email: overcap-blocked-bot-{scenario_token}@agents.e2a.dev
+          email: overcap-blocked-bot-{scenario_token}@agents.localhost
         expect:
           status: 402
           body_match:
@@ -2878,7 +2878,7 @@ scenarios:
       scenarios).
     setup:
       - register_agent:
-          email: quote-history-{scenario_token}@agents.e2a.dev
+          email: quote-history-{scenario_token}@agents.localhost
       - inject_message:
           agent_email: "{agent_email}"
           from: alice@example.net


### PR DESCRIPTION
Swapped `agents.e2a.dev` for `agents.localhost` as the contract harness's SharedDomain in `contract_server.go` and `server.go`, and updated the 17 scenario addresses in `scenarios.yaml` that depend on it. Also caught one more literal in `contract_server.go`'s over-cap fixture (`overcap-bot-%d@agents.e2a.dev`) that uses the same domain outside the SharedDomain wiring.

Checked `server.go` and the prober seed like the issue asked. `server.go` only had the same two SharedDomain lines, already covered above. The prober's agent email comes from `E2A_PROBE_AGENT_EMAIL` with no hardcoded domain, so nothing there needed a change.

Added a test that reads the three files and fails if `agents.e2a.dev` shows up again. It fails without the change.

Fixes #829
